### PR TITLE
DEX-330 Timeout after an order book deletion

### DIFF
--- a/dex/dex-devnet.conf
+++ b/dex/dex-devnet.conf
@@ -1,18 +1,23 @@
-waves.dex {
-  # Matcher's account address
-  # account = ""
+waves{
+  extensions = ["com.wavesplatform.dex.Matcher"]
 
-  # Matcher REST API bind address
-  bind-address = "0.0.0.0"
+  dex {
+    # Matcher's account address
+    # account = ""
 
-  # Matcher REST API port
-  port = 6886
+    # Matcher REST API bind address
+    bind-address = "0.0.0.0"
 
-  price-assets = [
-    "WAVES",
-    "AaFXAN1WTM39XjECHW7DsVFixhq9yMGWHdM2ghr83Gmf",
-    "A2fMWXoSMVCTYi9pmwt5QhHGYM68d4NHTsg94RS3cBWo",
-    "2iiam1a8PwxerAET8Vp57MdnH4kNARXmxUPY4kPV3miE",
-    "DuQ76zE9VziyEizHK8bRMpzWkET2k2pGjkJJuUXaZgcX"
-  ]
+    # Matcher REST API port
+    port = 6886
+
+    price-assets = [
+      "WAVES",
+      "AaFXAN1WTM39XjECHW7DsVFixhq9yMGWHdM2ghr83Gmf",
+      "A2fMWXoSMVCTYi9pmwt5QhHGYM68d4NHTsg94RS3cBWo",
+      "2iiam1a8PwxerAET8Vp57MdnH4kNARXmxUPY4kPV3miE",
+      "DuQ76zE9VziyEizHK8bRMpzWkET2k2pGjkJJuUXaZgcX"
+    ]
+  }
+
 }

--- a/dex/dex-mainnet.conf
+++ b/dex/dex-mainnet.conf
@@ -1,10 +1,14 @@
-waves.dex {
-  # Matcher's account address
-  # account = ""
+waves{
+  extensions = ["com.wavesplatform.dex.Matcher"]
 
-  # Matcher REST API bind address
-  bind-address = "127.0.0.1"
+  dex {
+    # Matcher's account address
+    # account = ""
 
-  # Matcher REST API port
-  port = 6886
+    # Matcher REST API bind address
+    bind-address = "127.0.0.1"
+
+    # Matcher REST API port
+    port = 6886
+  }
 }

--- a/dex/dex-testnet.conf
+++ b/dex/dex-testnet.conf
@@ -1,18 +1,22 @@
-waves.dex {
-  # Matcher's account address
-  # account = ""
+waves {
+  extensions = ["com.wavesplatform.dex.Matcher"]
 
-  # Matcher REST API bind address
-  bind-address = "127.0.0.1"
+  dex {
+    # Matcher's account address
+    # account = ""
 
-  # Matcher REST API port
-  port = 6886
+    # Matcher REST API bind address
+    bind-address = "127.0.0.1"
 
-  price-assets = [
-    "WAVES",
-    "Fmg13HEHJHuZYbtJq8Da8wifJENq8uBxDuWoP9pVe2Qe",
-    "HyFJ3rrq5m7FxdkWtQXkZrDat1F7LjVVGfpSkUuEXQHj",
-    "2xnE3EdpqXtFgCP156qt1AbyjpqdZ5jGjWo3CwTawcux",
-    "6pmDivReTLikwYqQtJTv6dTcE59knriaodB3AK8T9cF8"
-  ]
+    # Matcher REST API port
+    port = 6886
+
+    price-assets = [
+      "WAVES",
+      "Fmg13HEHJHuZYbtJq8Da8wifJENq8uBxDuWoP9pVe2Qe",
+      "HyFJ3rrq5m7FxdkWtQXkZrDat1F7LjVVGfpSkUuEXQHj",
+      "2xnE3EdpqXtFgCP156qt1AbyjpqdZ5jGjWo3CwTawcux",
+      "6pmDivReTLikwYqQtJTv6dTcE59knriaodB3AK8T9cF8"
+    ]
+  }
 }

--- a/dex/src/main/resources/application.conf
+++ b/dex/src/main/resources/application.conf
@@ -283,6 +283,9 @@ waves.dex {
   # Timeout for REST API responses from actors.
   # To change a timeout for all REST API responses, change this option and akka.http.server.request-timeout
   actor-response-timeout = ${akka.http.server.request-timeout}
+
+  # Timeout to process consumed messages. Used in a back pressure.
+  process-consumed-timeout = 10 seconds
 }
 
 akka {

--- a/dex/src/main/scala/com/wavesplatform/dex/WatchDistributedCompletionActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/WatchDistributedCompletionActor.scala
@@ -1,32 +1,57 @@
 package com.wavesplatform.dex
 
-import akka.actor.{Actor, ActorRef, Props, Terminated}
+import akka.actor.{Actor, ActorRef, Cancellable, Props, Terminated}
+import com.wavesplatform.dex.WatchDistributedCompletionActor.TimedOut
+import com.wavesplatform.utils.ScorexLogging
 
-class WatchDistributedCompletionActor(workers: Set[ActorRef], completionReceiver: ActorRef, startWorkCommand: Any, workCompleted: Any) extends Actor {
-  workers.foreach { x =>
-    context.watch(x)
-    x ! startWorkCommand
-  }
+import scala.concurrent.duration.FiniteDuration
 
-  override def receive: Receive = state(workers)
+class WatchDistributedCompletionActor(workers: Set[ActorRef],
+                                      completionReceiver: ActorRef,
+                                      startWorkCommand: Any,
+                                      workCompleted: Any,
+                                      timeout: FiniteDuration)
+    extends Actor
+    with ScorexLogging {
 
-  private def state(rest: Set[ActorRef]): Receive = {
+  import context.dispatcher
+
+  if (workers.isEmpty) stop(Cancellable.alreadyCancelled)
+  else
+    workers.foreach { x =>
+      context.watch(x)
+      x ! startWorkCommand
+    }
+
+  override def receive: Receive = state(workers, context.system.scheduler.scheduleOnce(timeout, self, TimedOut))
+
+  private def state(rest: Set[ActorRef], timer: Cancellable): Receive = {
     case `workCompleted` =>
-      switchTo(rest - sender())
+      switchTo(rest - sender(), timer)
       context.unwatch(sender())
 
     case Terminated(ref) =>
-      switchTo(rest - ref)
+      switchTo(rest - ref, timer)
+
+    case TimedOut =>
+      val workerPairs = workers.iterator.map(_.path.name).mkString(", ")
+      log.error(s"PingAll is timed out! Pairs those didn't respond: $workerPairs")
+      stop(timer)
   }
 
-  private def switchTo(updatedRest: Set[ActorRef]): Unit =
-    if (updatedRest.isEmpty) {
-      completionReceiver ! workCompleted
-      context.stop(self)
-    } else context.become(state(updatedRest))
+  private def switchTo(updatedRest: Set[ActorRef], timer: Cancellable): Unit =
+    if (updatedRest.isEmpty) stop(timer) else context.become(state(updatedRest, timer))
+
+  private def stop(timer: Cancellable): Unit = {
+    timer.cancel()
+    completionReceiver ! workCompleted
+    context.stop(self)
+  }
 }
 
 object WatchDistributedCompletionActor {
-  def props(workers: Set[ActorRef], completionReceiver: ActorRef, startWorkCommand: Any, workCompleted: Any): Props =
-    Props(new WatchDistributedCompletionActor(workers, completionReceiver, startWorkCommand, workCompleted))
+  def props(workers: Set[ActorRef], completionReceiver: ActorRef, startWorkCommand: Any, workCompleted: Any, timeout: FiniteDuration): Props =
+    Props(new WatchDistributedCompletionActor(workers, completionReceiver, startWorkCommand, workCompleted, timeout))
+
+  private object TimedOut
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/settings/MatcherSettings.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/settings/MatcherSettings.scala
@@ -47,6 +47,7 @@ case class MatcherSettings(account: String,
                            orderBookSnapshotHttpCache: OrderBookSnapshotHttpCache.Settings,
                            balanceWatchingBufferInterval: FiniteDuration,
                            eventsQueue: EventsQueueSettings,
+                           processConsumedTimeout: FiniteDuration,
                            orderFee: OrderFeeSettings,
                            deviation: DeviationsSettings,
                            orderRestrictions: Map[AssetPair, OrderRestrictionsSettings],
@@ -95,8 +96,9 @@ object MatcherSettings {
 
     val balanceWatchingBufferInterval = config.as[FiniteDuration]("balance-watching-buffer-interval")
 
-    val eventsQueue         = config.as[EventsQueueSettings](s"events-queue")
-    val recoverOrderHistory = !new File(dataDirectory).exists()
+    val eventsQueue            = config.as[EventsQueueSettings]("events-queue")
+    val processConsumedTimeout = config.as[FiniteDuration]("process-consumed-timeout")
+    val recoverOrderHistory    = !new File(dataDirectory).exists()
 
     val limitEventsDuringRecovery = config.getAs[Int]("limit-events-during-recovery")
     require(limitEventsDuringRecovery.forall(_ >= snapshotsInterval), "limit-events-during-recovery should be >= snapshotsInterval")
@@ -137,6 +139,7 @@ object MatcherSettings {
       orderBookSnapshotHttpCache,
       balanceWatchingBufferInterval,
       eventsQueue,
+      processConsumedTimeout,
       orderFee,
       deviation,
       orderRestrictions,

--- a/dex/src/main/scala/com/wavesplatform/dex/util/ActorNameParser.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/util/ActorNameParser.scala
@@ -1,0 +1,14 @@
+package com.wavesplatform.dex.util
+
+import com.wavesplatform.transaction.assets.exchange.AssetPair
+
+import scala.util.{Failure, Try}
+
+object ActorNameParser {
+  def orderBookPair(orderBookActorName: String): Try[AssetPair] = {
+    val name = orderBookActorName
+    val xs   = name.split('-')
+    if (xs.length == 2) AssetPair.createAssetPair(xs.head, xs(1))
+    else Failure(new IllegalArgumentException(s"Can't extract a pair from the order book name: '$orderBookActorName'"))
+  }
+}

--- a/dex/src/test/scala/com/wavesplatform/dex/WatchDistributedCompletionActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/WatchDistributedCompletionActorSpecification.scala
@@ -1,0 +1,104 @@
+package com.wavesplatform.dex
+
+import akka.actor.{Actor, ActorRef, ActorSystem, PoisonPill, Props}
+import akka.testkit.{ImplicitSender, TestKit, TestProbe}
+import com.wavesplatform.NTPTime
+import com.wavesplatform.dex.WatchDistributedCompletionActorSpecification._
+import org.scalacheck.Gen
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatestplus.scalacheck.{ScalaCheckDrivenPropertyChecks => DrivenPropertyChecks}
+
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.util.Random
+
+class WatchDistributedCompletionActorSpecification
+    extends TestKit(ActorSystem("WatchDistributedCompletionActorSpecification"))
+    with WordSpecLike
+    with DrivenPropertyChecks
+    with Matchers
+    with BeforeAndAfterAll
+    with ImplicitSender
+    with NTPTime {
+
+  "WatchDistributedCompletionActorSpecification" should {
+    "respond" when {
+      "no workers" in watcher(Set.empty).expectMsg('pong)
+
+      "all work is done" in {
+        val workers = (-1 to Random.nextInt(10)).map(_ => system.actorOf(Props(new PongActor))).toSet
+        watcher(workers).expectMsg('pong)
+      }
+
+      val dyingTestGen = for {
+        workingNumber <- Gen.choose(0, 5)
+        dyingNumber   <- Gen.choose(if (workingNumber == 0) 1 else 0, 5)
+        dieDelays     <- Gen.listOfN(dyingNumber, Gen.choose(0.millis, 50.millis))
+      } yield {
+        val working = (1 to workingNumber).map(_ => system.actorOf(Props(new PongActor)))
+        val dying = (1 to dyingNumber).zip(dieDelays).map {
+          case (_, dieDelay) => system.actorOf(Props(new DyingActor(dieDelay)))
+        }
+        (working ++ dying).toSet
+      }
+
+      "even several of workers is dead" in forAll(dyingTestGen) { workers =>
+        watcher(workers).expectMsg('pong)
+      }
+
+      "even all workers are dead" in {
+        val workers = (-1 to Random.nextInt(10)).map(_ => system.actorOf(Props(new DyingActor(0.seconds)))).toSet
+        watcher(workers).expectMsg('pong)
+      }
+
+      "when a worker respond and die" in {
+        val workers = (-1 to Random.nextInt(10)).map(_ => system.actorOf(Props(new PongAndDieActor))).toSet
+        watcher(workers).expectMsg('pong)
+      }
+
+      "requests are timed out" in {
+        val workers = (-1 to Random.nextInt(10)).map(_ => system.actorOf(Props(new IgnoringActor))).toSet
+        watcher(workers, 50.millis).expectMsg('pong)
+      }
+    }
+  }
+
+  override protected def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+    super.afterAll()
+  }
+}
+
+object WatchDistributedCompletionActorSpecification {
+  def watcher(workers: Set[ActorRef], timeout: FiniteDuration = 1.minute)(implicit system: ActorSystem): TestProbe = {
+    val p = TestProbe()
+    system.actorOf(Props(new WatchDistributedCompletionActor(workers, p.ref, 'ping, 'pong, timeout)))
+    p
+  }
+
+  class IgnoringActor extends Actor {
+    override def receive: Receive = Actor.ignoringBehavior
+  }
+
+  class PongActor extends Actor {
+    override def receive: Receive = {
+      case 'ping => sender() ! 'pong
+    }
+  }
+
+  class PongAndDieActor extends Actor {
+    override def receive: Receive = {
+      case 'ping =>
+        sender() ! 'pong
+        context.stop(self)
+    }
+  }
+
+  class DyingActor(delay: FiniteDuration) extends Actor {
+    import context.dispatcher
+
+    if (delay.length == 0) context.stop(self)
+    else context.system.scheduler.scheduleOnce(delay, self, PoisonPill)
+
+    override def receive: Receive = Actor.ignoringBehavior
+  }
+}

--- a/dex/src/test/scala/com/wavesplatform/dex/settings/MatcherSettingsSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/settings/MatcherSettingsSpecification.scala
@@ -128,6 +128,7 @@ class MatcherSettingsSpecification extends FlatSpec with Matchers {
       |        }
       |      }
       |    }
+      |    process-consumed-timeout = 663s
       |    $orderFeeStr
       |    $deviationsStr
       |    $allowedAssetPairsStr
@@ -178,6 +179,7 @@ class MatcherSettingsSpecification extends FlatSpec with Matchers {
         KafkaMatcherQueue.ProducerSettings(enable = false, 200)
       )
     )
+    settings.processConsumedTimeout shouldBe 663.seconds
 
     settings.orderFee match {
       case DynamicSettings(baseFee) =>


### PR DESCRIPTION
* Added internal MatcherSettings.process-consumed-timeout;
* WatchDistributedCompletionActor schedules a timeout, also it works correctly if there is no worker. Added unit tests;
* Examples of configurations contains a line to enable DEX;