### PR TITLE
DEX-343 Matching Rules API

### DIFF
--- a/dex/src/main/resources/application.conf
+++ b/dex/src/main/resources/application.conf
@@ -272,7 +272,7 @@ waves.dex {
     # When broadcast-until-confirmed = yes
     # Not sended transaction:
     # * Will be removed from queue after this timeout;
-    # * A warning will be loggeg.
+    # * A warning will be logged.
     max-pending-time = 15 minutes
   }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/error/MatcherError.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/error/MatcherError.scala
@@ -2,10 +2,10 @@ package com.wavesplatform.dex.error
 
 import com.wavesplatform.account.{Address, PublicKey}
 import com.wavesplatform.common.utils.Base58
-import com.wavesplatform.features.{BlockchainFeature, BlockchainFeatures}
 import com.wavesplatform.dex.error.MatcherError._
 import com.wavesplatform.dex.model.MatcherModel.Denormalization
-import com.wavesplatform.dex.settings.{DeviationsSettings, OrderRestrictionsSettings}
+import com.wavesplatform.dex.settings.{DeviationsSettings, OrderRestrictionsSettings, formatValue}
+import com.wavesplatform.features.{BlockchainFeature, BlockchainFeatures}
 import com.wavesplatform.transaction.Asset
 import com.wavesplatform.transaction.Asset.IssuedAsset
 import com.wavesplatform.transaction.assets.exchange.AssetPair.assetIdStr
@@ -99,7 +99,8 @@ object MatcherError {
         e"Required ${'required -> required} ${'assetId -> assetIdStr(theAsset)} as fee for this order, but given ${'given -> given} ${'assetId -> assetIdStr(theAsset)}"
       )
 
-  case class AssetNotFound(theAsset: IssuedAsset) extends MatcherError(asset, commonEntity, notFound, e"The asset ${'assetId -> assetIdStr(theAsset)} not found")
+  case class AssetNotFound(theAsset: IssuedAsset)
+      extends MatcherError(asset, commonEntity, notFound, e"The asset ${'assetId -> assetIdStr(theAsset)} not found")
 
   case class CanNotCreateExchangeTransaction(details: String)
       extends MatcherError(exchangeTx, order, commonClass, e"Can't verify the order by an exchange transaction: ${'details -> details}")
@@ -116,10 +117,10 @@ object MatcherError {
       extends MatcherError(order, commonEntity, commonClass, e"The order is invalid: ${'details -> details}")
 
   case class InvalidAsset(theAsset: String)
-    extends MatcherError(asset, commonEntity, broken, e"The asset '${'assetId -> theAsset}' is wrong. It should be 'WAVES' or a Base58 string")
+      extends MatcherError(asset, commonEntity, broken, e"The asset '${'assetId -> theAsset}' is wrong. It should be 'WAVES' or a Base58 string")
 
   case class AssetBlacklisted(theAsset: IssuedAsset)
-    extends MatcherError(asset, commonEntity, blacklisted, e"The asset ${'assetId -> assetIdStr(theAsset)} is blacklisted")
+      extends MatcherError(asset, commonEntity, blacklisted, e"The asset ${'assetId -> assetIdStr(theAsset)} is blacklisted")
 
   case class AmountAssetBlacklisted(theAsset: IssuedAsset)
       extends MatcherError(asset, amount, blacklisted, e"The amount asset ${'assetId -> assetIdStr(theAsset)} is blacklisted")
@@ -127,7 +128,8 @@ object MatcherError {
   case class PriceAssetBlacklisted(theAsset: IssuedAsset)
       extends MatcherError(asset, price, blacklisted, e"The price asset ${'assetId -> assetIdStr(theAsset)} is blacklisted")
 
-  case class FeeAssetBlacklisted(theAsset: IssuedAsset) extends MatcherError(asset, fee, blacklisted, e"The fee asset ${'assetId -> assetIdStr(theAsset)} is blacklisted")
+  case class FeeAssetBlacklisted(theAsset: IssuedAsset)
+      extends MatcherError(asset, fee, blacklisted, e"The fee asset ${'assetId -> assetIdStr(theAsset)} is blacklisted")
 
   case class AddressIsBlacklisted(address: Address)
       extends MatcherError(account, commonEntity, blacklisted, e"The account ${'address -> address} is blacklisted")
@@ -248,12 +250,12 @@ object MatcherError {
       )
 
   case class AssetPairSameAssets(theAsset: Asset)
-    extends MatcherError(
-      order,
-      assetPair,
-      duplicate,
-      e"The amount and price assets must be different, but they are: ${'assetId -> assetIdStr(theAsset)}"
-    )
+      extends MatcherError(
+        order,
+        assetPair,
+        duplicate,
+        e"The amount and price assets must be different, but they are: ${'assetId -> assetIdStr(theAsset)}"
+      )
 
   case class AssetPairIsNotAllowed(orderAssetPair: AssetPair)
       extends MatcherError(
@@ -282,8 +284,6 @@ object MatcherError {
         denied,
         e"Unknown order version: ${'version -> version}. Allowed order versions can be obtained via /matcher/settings GET method"
       )
-
-  import OrderRestrictionsSettings.formatValue
 
   case class OrderInvalidAmount(ord: Order, amtSettings: OrderRestrictionsSettings, amountAssetDecimals: Int)
       extends MatcherError(

--- a/dex/src/main/scala/com/wavesplatform/dex/history/HistoryRouter.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/history/HistoryRouter.scala
@@ -104,8 +104,8 @@ object HistoryRouter {
 
 class HistoryRouter(blockchain: Blockchain, postgresConnection: PostgresConnection, orderHistorySettings: OrderHistorySettings) extends Actor {
 
-  private def denormalizeAmountAndFee(value: Long, pair: AssetPair): Double = Denormalization.denormalizeAmountAndFee(value, blockchain, pair)
-  private def denormalizePrice(value: Long, pair: AssetPair): Double        = Denormalization.denormalizePrice(value, blockchain, pair)
+  private def denormalizeAmountAndFee(value: Long, pair: AssetPair): Double = Denormalization.denormalizeAmountAndFee(value, pair, blockchain)
+  private def denormalizePrice(value: Long, pair: AssetPair): Double        = Denormalization.denormalizePrice(value, pair, blockchain)
 
   private val ctx = new PostgresJdbcContext(SnakeCase, postgresConnection.getConfig); import ctx._
 

--- a/dex/src/main/scala/com/wavesplatform/dex/market/ExchangeTransactionBroadcastActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/market/ExchangeTransactionBroadcastActor.scala
@@ -41,8 +41,8 @@ class ExchangeTransactionBroadcastActor(settings: ExchangeTransactionBroadcastSe
       val (expired, ready)         = unconfirmed.partition(_.timestamp <= expireMs)
 
       broadcast(ready)
-      log.debug(
-        s"Stats: ${confirmed.size} confirmed, ${ready.size} sent, ${expired.size} failed to send: ${expired.map(_.id().toString).mkString(", ")}")
+      log.debug(s"Stats: ${confirmed.size} confirmed, ${ready.size} sent")
+      if (expired.nonEmpty) log.warn(s"${expired.size} failed to send: ${expired.map(_.id().toString).mkString(", ")}")
 
       scheduleSend()
       context.become(watching(next ++ ready, Vector.empty))

--- a/dex/src/main/scala/com/wavesplatform/dex/market/OrderBookActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/market/OrderBookActor.scala
@@ -122,6 +122,9 @@ class OrderBookActor(owner: ActorRef,
   }
 
   private def processEvents(events: Iterable[Event]): Unit = {
+    updateMarketStatus(MarketStatus(orderBook))
+    updateSnapshot(orderBook.aggregatedSnapshot)
+
     events.foreach { e =>
       e match {
         case Events.OrderAdded(order, _) =>
@@ -141,9 +144,6 @@ class OrderBookActor(owner: ActorRef,
 
       addressActor ! e
     }
-
-    updateMarketStatus(MarketStatus(orderBook))
-    updateSnapshot(orderBook.aggregatedSnapshot)
   }
 
   private def onCancelOrder(event: QueueEventWithMeta, orderIdToCancel: ByteStr): Unit =

--- a/dex/src/main/scala/com/wavesplatform/dex/settings/MatchingRules.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/settings/MatchingRules.scala
@@ -1,9 +1,7 @@
 package com.wavesplatform.dex.settings
 
 import cats.data.NonEmptyList
-import cats.data.Validated.Valid
 import cats.implicits._
-import com.wavesplatform.dex.model.OrderBook.TickSize
 import com.wavesplatform.dex.queue.QueueEventWithMeta
 import future.com.wavesplatform.settings.nonEmptyListReader
 import future.com.wavesplatform.settings.utils.ConfigSettingsValidator
@@ -11,11 +9,11 @@ import future.com.wavesplatform.settings.utils.ConfigSettingsValidator.ErrorList
 import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ValueReader
 
-case class MatchingRules(startOffset: QueueEventWithMeta.Offset, tickSize: TickSize)
+case class MatchingRules(startOffset: QueueEventWithMeta.Offset, normalizedTickSize: Long)
 
 object MatchingRules {
 
-  val Default                                 = MatchingRules(0L, TickSize.Disabled)
+  val Default                                 = MatchingRules(0L, 1)
   val DefaultNel: NonEmptyList[MatchingRules] = NonEmptyList.one(Default)
 
   def skipOutdated(currOffset: QueueEventWithMeta.Offset, rules: NonEmptyList[MatchingRules]): NonEmptyList[MatchingRules] =
@@ -29,24 +27,18 @@ object MatchingRules {
       } else rules
 }
 
-case class RawMatchingRules(startOffset: Long, mergePrices: Boolean, tickSize: Double = 0)
+case class RawMatchingRules(startOffset: Long, tickSize: Double)
 
 object RawMatchingRules {
 
   private implicit val rawMatchingRulesReader: ValueReader[RawMatchingRules] = { (cfg, path) =>
     val cfgValidator = ConfigSettingsValidator(cfg)
 
-    val offsetValidated      = cfgValidator.validateByPredicate[Long](s"$path.start-offset")(_ >= 0, "required 0 <= start offset")
-    val mergePricesValidated = cfgValidator.validate[Boolean](s"$path.merge-prices")
-
-    val tickSizeValidated = mergePricesValidated match {
-      case Valid(true) => cfgValidator.validateByPredicate[Double](s"$path.tick-size")(_ > 0, "required 0 < tick size")
-      case _           => Valid(0d)
-    }
+    val offsetValidated   = cfgValidator.validateByPredicate[Long](s"$path.start-offset")(_ >= 0, "required 0 <= start offset")
+    val tickSizeValidated = cfgValidator.validateByPredicate[Double](s"$path.tick-size")(_ > 0, "required 0 < tick size")
 
     (
       offsetValidated,
-      mergePricesValidated,
       tickSizeValidated
     ) mapN RawMatchingRules.apply getValueOrThrowErrors
   }
@@ -54,7 +46,7 @@ object RawMatchingRules {
   implicit val rawMatchingRulesNelReader: ValueReader[NonEmptyList[RawMatchingRules]] =
     nonEmptyListReader[RawMatchingRules].map { xs =>
       val isStrictOrder = xs.tail.zip(xs.toList).forall { case (next, prev) => next.startOffset > prev.startOffset }
-      if (isStrictOrder) { if (xs.head.startOffset != 0) RawMatchingRules(0, false) :: xs else xs } else
-        throw new IllegalArgumentException(s"Rules should be ordered by offset, but they are: ${xs.map(_.startOffset).toList.mkString(", ")}")
+      if (isStrictOrder) xs
+      else throw new IllegalArgumentException(s"Rules should be ordered by offset, but they are: ${xs.map(_.startOffset).toList.mkString(", ")}")
     }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/settings/MatchingRules.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/settings/MatchingRules.scala
@@ -16,7 +16,13 @@ object MatchingRules {
   val Default                                 = MatchingRules(0L, 1)
   val DefaultNel: NonEmptyList[MatchingRules] = NonEmptyList.one(Default)
 
-  def skipOutdated(currOffset: QueueEventWithMeta.Offset, rules: NonEmptyList[MatchingRules]): NonEmptyList[MatchingRules] =
+}
+
+case class RawMatchingRules(startOffset: Long, tickSize: Double)
+
+object RawMatchingRules {
+
+  def skipOutdated(currOffset: QueueEventWithMeta.Offset, rules: NonEmptyList[RawMatchingRules]): NonEmptyList[RawMatchingRules] =
     if (currOffset > rules.head.startOffset)
       rules.tail match {
         case x :: xs =>
@@ -25,11 +31,6 @@ object MatchingRules {
           else rules
         case _ => rules
       } else rules
-}
-
-case class RawMatchingRules(startOffset: Long, tickSize: Double)
-
-object RawMatchingRules {
 
   private implicit val rawMatchingRulesReader: ValueReader[RawMatchingRules] = { (cfg, path) =>
     val cfgValidator = ConfigSettingsValidator(cfg)

--- a/dex/src/main/scala/com/wavesplatform/dex/settings/OrderRestrictionsSettings.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/settings/OrderRestrictionsSettings.scala
@@ -32,9 +32,14 @@ case class OrderRestrictionsSettings(stepAmount: Double,
 
 object OrderRestrictionsSettings {
 
-  val stepAmountDefault, stepPriceDefault, minAmountDefault, minPriceDefault = 0.00000001
-  val maxAmountDefault                                                       = 1000000000
-  val maxPriceDefault                                                        = 1000000
+  val Default = OrderRestrictionsSettings(
+    stepAmount = 0.00000001,
+    minAmount = 0.00000001,
+    maxAmount = 1000000000,
+    stepPrice = 0.00000001,
+    minPrice = 0.00000001,
+    maxPrice = 1000000
+  )
 
   def formatValue(value: Double): String = new java.text.DecimalFormat("#.########").format(value)
 
@@ -60,8 +65,8 @@ object OrderRestrictionsSettings {
     }
 
     (
-      validateSizeMinMax(s"$path.step-amount", s"$path.min-amount", s"$path.max-amount", stepAmountDefault, minAmountDefault, maxAmountDefault),
-      validateSizeMinMax(s"$path.step-price", s"$path.min-price", s"$path.max-price", stepPriceDefault, minPriceDefault, maxPriceDefault),
+      validateSizeMinMax(s"$path.step-amount", s"$path.min-amount", s"$path.max-amount", Default.stepAmount, Default.minAmount, Default.maxAmount),
+      validateSizeMinMax(s"$path.step-price", s"$path.min-price", s"$path.max-price", Default.stepPrice, Default.minPrice, Default.maxPrice),
     ) mapN {
       case ((stepAmount, minAmount, maxAmount), (stepPrice, minPrice, maxPrice)) =>
         OrderRestrictionsSettings(stepAmount, minAmount, maxAmount, stepPrice, minPrice, maxPrice)

--- a/dex/src/main/scala/com/wavesplatform/dex/settings/OrderRestrictionsSettings.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/settings/OrderRestrictionsSettings.scala
@@ -16,8 +16,6 @@ case class OrderRestrictionsSettings(stepAmount: Double,
                                      minPrice: Double,
                                      maxPrice: Double) {
 
-  import OrderRestrictionsSettings._
-
   def getJson: Coeval[JsObject] = Coeval.evalOnce {
     Json.obj(
       "stepAmount" -> formatValue(stepAmount),
@@ -40,8 +38,6 @@ object OrderRestrictionsSettings {
     minPrice = 0.00000001,
     maxPrice = 1000000
   )
-
-  def formatValue(value: Double): String = new java.text.DecimalFormat("#.########").format(value)
 
   implicit val orderRestrictionsSettingsReader: ValueReader[OrderRestrictionsSettings] = { (cfg, path) =>
     val cfgValidator = ConfigSettingsValidator(cfg)

--- a/dex/src/main/scala/com/wavesplatform/dex/settings/package.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/settings/package.scala
@@ -1,0 +1,10 @@
+package com.wavesplatform.dex
+
+package object settings {
+  private val format = new java.text.DecimalFormat("#.########")
+
+  /**
+    * Formats amount or price
+    */
+  def formatValue(value: Double): String = format.format(value)
+}

--- a/dex/src/test/scala/com/wavesplatform/dex/api/MatcherApiRouteSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/api/MatcherApiRouteSpec.scala
@@ -83,6 +83,7 @@ class MatcherApiRouteSpec extends RouteSpec("/matcher") with RequestGen with Pat
       storeEvent = _ => Future.failed(new NotImplementedError("Storing is not implemented")),
       orderBook = _ => None,
       getMarketStatus = _ => None,
+      tickSize = _ => 0.1,
       orderValidator = _ => Left(MatcherError.FeatureNotImplemented),
       orderBookSnapshot = new OrderBookSnapshotHttpCache(settings.orderBookSnapshotHttpCache, ntpTime, getAssetDecimals, _ => None),
       matcherSettings = settings,

--- a/dex/src/test/scala/com/wavesplatform/dex/market/MatcherActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/market/MatcherActorSpecification.scala
@@ -436,10 +436,21 @@ class MatcherActorSpecification
     TestActorRef(
       new MatcherActor(
         matcherSettings,
-        apdb,  doNothingOnRecovery,
-          ob,
-          (assetPair, matcher) =>
-            OrderBookActor.props(matcher, addressActor, snapshotStoreActor, assetPair, _ => {}, _ => {}, matcherSettings, txFactory, ntpTime, MatchingRules.DefaultNel),
+        apdb,
+        doNothingOnRecovery,
+        ob,
+        (assetPair, matcher) =>
+          OrderBookActor.props(matcher,
+                               addressActor,
+                               snapshotStoreActor,
+                               assetPair,
+                               _ => {},
+                               _ => {},
+                               _ => {},
+                               matcherSettings,
+                               txFactory,
+                               ntpTime,
+                               MatchingRules.DefaultNel),
         blockchain.assetDescription
       )
     )

--- a/dex/src/test/scala/com/wavesplatform/dex/market/MatcherActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/market/MatcherActorSpecification.scala
@@ -4,6 +4,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 import akka.actor.{Actor, ActorRef, ActorSystem, Kill, Props, Terminated}
 import akka.testkit.{ImplicitSender, TestActor, TestActorRef, TestProbe}
+import cats.data.NonEmptyList
 import com.wavesplatform.account.KeyPair
 import com.wavesplatform.common.state.ByteStr
 import com.wavesplatform.dex.MatcherTestData
@@ -12,10 +13,8 @@ import com.wavesplatform.dex.market.MatcherActor.{ForceStartOrderBook, GetMarket
 import com.wavesplatform.dex.market.MatcherActorSpecification.{DeletingActor, FailAtStartActor, NothingDoActor, RecoveringActor, _}
 import com.wavesplatform.dex.market.OrderBookActor.{OrderBookRecovered, OrderBookSnapshotUpdateCompleted}
 import com.wavesplatform.dex.model.{Events, ExchangeTransactionCreator, OrderBook}
-import com.wavesplatform.dex.queue.QueueEventWithMeta
-import com.wavesplatform.dex.settings.MatchingRules
-import com.wavesplatform.dex.MatcherTestData
 import com.wavesplatform.dex.queue.{QueueEvent, QueueEventWithMeta}
+import com.wavesplatform.dex.settings.{MatchingRules, RawMatchingRules}
 import com.wavesplatform.state.{AssetDescription, Blockchain}
 import com.wavesplatform.transaction.Asset
 import com.wavesplatform.transaction.Asset.IssuedAsset
@@ -440,17 +439,20 @@ class MatcherActorSpecification
         doNothingOnRecovery,
         ob,
         (assetPair, matcher) =>
-          OrderBookActor.props(matcher,
-                               addressActor,
-                               snapshotStoreActor,
-                               assetPair,
-                               _ => {},
-                               _ => {},
-                               _ => {},
-                               matcherSettings,
-                               txFactory,
-                               ntpTime,
-                               MatchingRules.DefaultNel),
+          OrderBookActor.props(
+            matcher,
+            addressActor,
+            snapshotStoreActor,
+            assetPair,
+            _ => {},
+            _ => {},
+            _ => {},
+            _ => MatchingRules.Default,
+            matcherSettings,
+            txFactory,
+            ntpTime,
+            NonEmptyList.one(RawMatchingRules(0, 0.00000001))
+        ),
         blockchain.assetDescription
       )
     )

--- a/dex/src/test/scala/com/wavesplatform/dex/market/OrderBookActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/market/OrderBookActorSpecification.scala
@@ -17,7 +17,7 @@ import com.wavesplatform.dex.market.OrderBookActor._
 import com.wavesplatform.dex.model.Events.{OrderAdded, OrderCanceled}
 import com.wavesplatform.dex.model._
 import com.wavesplatform.dex.queue.QueueEvent.Canceled
-import com.wavesplatform.dex.settings.MatchingRules
+import com.wavesplatform.dex.settings.{MatchingRules, RawMatchingRules}
 import com.wavesplatform.transaction.Asset.{IssuedAsset, Waves}
 import com.wavesplatform.transaction.assets.exchange.OrderOps._
 import com.wavesplatform.transaction.assets.exchange.{AssetPair, Order}
@@ -48,20 +48,20 @@ class OrderBookActorSpecification
       f(pair, actor, probe)
     }
 
-  private def obcTestWithTickSize(normalizedTickSize: Long)(f: (AssetPair, ActorRef, TestProbe) => Unit): Unit =
-    obcTestWithPrepare((_, _) => (), NonEmptyList(MatchingRules(0L, normalizedTickSize), List.empty)) { (pair, actor, probe) =>
+  private def obcTestWithTickSize(tickSize: Double)(f: (AssetPair, ActorRef, TestProbe) => Unit): Unit =
+    obcTestWithPrepare((_, _) => (), NonEmptyList(RawMatchingRules(0L, tickSize), List.empty)) { (pair, actor, probe) =>
       probe.expectMsg(OrderBookRecovered(pair, None))
       f(pair, actor, probe)
     }
 
-  private def obcTestWithMatchingRules(matchingRules: NonEmptyList[MatchingRules])(f: (AssetPair, ActorRef, TestProbe) => Unit): Unit =
+  private def obcTestWithMatchingRules(matchingRules: NonEmptyList[RawMatchingRules])(f: (AssetPair, ActorRef, TestProbe) => Unit): Unit =
     obcTestWithPrepare((_, _) => (), matchingRules) { (pair, actor, probe) =>
       probe.expectMsg(OrderBookRecovered(pair, None))
       f(pair, actor, probe)
     }
 
   private def obcTestWithPrepare(prepare: (OrderBookSnapshotDB, AssetPair) => Unit,
-                                 matchingRules: NonEmptyList[MatchingRules] = MatchingRules.DefaultNel)(
+                                 matchingRules: NonEmptyList[RawMatchingRules] = NonEmptyList.one(RawMatchingRules(0, 0.00000001)))(
       f: (AssetPair, TestActorRef[OrderBookActor with RestartableActor], TestProbe) => Unit): Unit = {
     obc.clear()
     md.clear()
@@ -81,6 +81,7 @@ class OrderBookActorSpecification
         update(pair),
         p => Option(md.get(p)),
         _ => (),
+        raw => MatchingRules(raw.startOffset, (BigDecimal(raw.tickSize) * BigDecimal(10).pow(8)).toLongExact),
         txFactory,
         ntpTime,
         matchingRules
@@ -293,10 +294,10 @@ class OrderBookActorSpecification
     }
 
     val switchRulesTest = NonEmptyList(
-      MatchingRules.Default,
+      RawMatchingRules(0, 0.00000001),
       List(
-        MatchingRules(4, 100),
-        MatchingRules(10, 300)
+        RawMatchingRules(4, 0.000001),
+        RawMatchingRules(10, 0.000003)
       )
     )
 
@@ -326,9 +327,9 @@ class OrderBookActorSpecification
     }
 
     val disableRulesTest = NonEmptyList(
-      MatchingRules(0, 100),
+      RawMatchingRules(0, 0.000001),
       List(
-        MatchingRules(3, MatchingRules.Default.normalizedTickSize)
+        RawMatchingRules(3, 0.00000001)
       )
     )
 
@@ -354,10 +355,10 @@ class OrderBookActorSpecification
     }
 
     val matchingRulesForCancelTest = NonEmptyList(
-      MatchingRules.Default,
+      RawMatchingRules(0, 0.00000001),
       List(
-        MatchingRules.Default,
-        MatchingRules(1, 100)
+        RawMatchingRules(0, 0.00000001),
+        RawMatchingRules(0, 0.000001)
       )
     )
 

--- a/dex/src/test/scala/com/wavesplatform/dex/model/MatchingRulesSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/MatchingRulesSpecification.scala
@@ -3,9 +3,8 @@ package com.wavesplatform.dex.model
 import cats.data.NonEmptyList
 import com.wavesplatform.NoShrink
 import com.wavesplatform.dex.MatcherTestData
-import com.wavesplatform.dex.model.OrderBook.TickSize
 import com.wavesplatform.dex.settings.MatchingRules
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Gen
 import org.scalatest.{Matchers, PropSpec}
 import org.scalatestplus.scalacheck.{ScalaCheckPropertyChecks => PropertyChecks}
 
@@ -42,15 +41,11 @@ class MatchingRulesSpecification extends PropSpec with PropertyChecks with Match
     if (prevRules.startOffset == Long.MaxValue) Gen.const(None)
     else
       for {
-        startOffset <- Gen.choose(prevRules.startOffset + 1, Long.MaxValue)
-        disabled    <- Arbitrary.arbBool.arbitrary
-        tickSize    <- if (disabled) Gen.const(TickSize.Disabled) else Gen.choose(1, Long.MaxValue).map(TickSize.Enabled)
-      } yield Some(MatchingRules(startOffset, tickSize))
+        startOffset        <- Gen.choose(prevRules.startOffset + 1, Long.MaxValue)
+        normalizedTickSize <- Gen.choose(1, Long.MaxValue)
+      } yield Some(MatchingRules(startOffset, normalizedTickSize))
 
-  private val firstRuleGen: Gen[MatchingRules] = for {
-    disabled <- Arbitrary.arbBool.arbitrary
-    tickSize <- if (disabled) Gen.const(TickSize.Disabled) else Gen.choose(1, Long.MaxValue).map(TickSize.Enabled)
-  } yield MatchingRules(0L, tickSize)
+  private val firstRuleGen: Gen[MatchingRules] = Gen.choose(1, Long.MaxValue).map(MatchingRules(0L, _))
 
   private def rulesChainGen(maxNumber: Int): Gen[NonEmptyList[MatchingRules]] = {
     def loop(rest: Int, acc: Gen[NonEmptyList[MatchingRules]]): Gen[NonEmptyList[MatchingRules]] =

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderBookSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderBookSpec.scala
@@ -5,8 +5,8 @@ import java.nio.ByteBuffer
 import com.wavesplatform.common.state.ByteStr
 import com.wavesplatform.dex.MatcherTestData
 import com.wavesplatform.dex.model.MatcherModel.Price
-import com.wavesplatform.dex.model.OrderBook.{Level, TickSize}
 import com.wavesplatform.dex.model.OrderBook.{LastTrade, Level, SideSnapshot, Snapshot}
+import com.wavesplatform.dex.settings.MatchingRules
 import com.wavesplatform.settings.Constants
 import com.wavesplatform.transaction.Asset.{IssuedAsset, Waves}
 import com.wavesplatform.transaction.assets.exchange.{AssetPair, Order}
@@ -36,8 +36,8 @@ class OrderBookSpec extends FreeSpec with PropertyChecks with Matchers with Matc
   "place several buy orders at the same price" in {}
 
   "place buy and sell orders with prices different from each other less than tick size in one level" in {
-    val ob       = OrderBook.empty
-    val tickSize = TickSize.Enabled(toNormalized(100L))
+    val ob                 = OrderBook.empty
+    val normalizedTickSize = toNormalized(100L)
 
     val buyOrd1 = buy(pair, 1583290045643L, 34100)
     val buyOrd2 = buy(pair, 170484969L, 34120)
@@ -53,19 +53,19 @@ class OrderBookSpec extends FreeSpec with PropertyChecks with Matchers with Matc
     val sellOrd5 = sell(pair, 54521418494L, 44357)
     val sellOrd6 = sell(pair, 54521418493L, 44389)
 
-    ob.add(buyOrd1, ntpNow, tickSize)
-    ob.add(buyOrd2, ntpNow, tickSize)
-    ob.add(buyOrd3, ntpNow, tickSize)
-    ob.add(buyOrd4, ntpNow, tickSize)
-    ob.add(buyOrd5, ntpNow, tickSize)
-    ob.add(buyOrd6, ntpNow, tickSize)
+    ob.add(buyOrd1, ntpNow, normalizedTickSize)
+    ob.add(buyOrd2, ntpNow, normalizedTickSize)
+    ob.add(buyOrd3, ntpNow, normalizedTickSize)
+    ob.add(buyOrd4, ntpNow, normalizedTickSize)
+    ob.add(buyOrd5, ntpNow, normalizedTickSize)
+    ob.add(buyOrd6, ntpNow, normalizedTickSize)
 
-    ob.add(sellOrd1, ntpNow, tickSize)
-    ob.add(sellOrd2, ntpNow, tickSize)
-    ob.add(sellOrd3, ntpNow, tickSize)
-    ob.add(sellOrd4, ntpNow, tickSize)
-    ob.add(sellOrd5, ntpNow, tickSize)
-    ob.add(sellOrd6, ntpNow, tickSize)
+    ob.add(sellOrd1, ntpNow, normalizedTickSize)
+    ob.add(sellOrd2, ntpNow, normalizedTickSize)
+    ob.add(sellOrd3, ntpNow, normalizedTickSize)
+    ob.add(sellOrd4, ntpNow, normalizedTickSize)
+    ob.add(sellOrd5, ntpNow, normalizedTickSize)
+    ob.add(sellOrd6, ntpNow, normalizedTickSize)
 
     ob.getBids.keySet shouldBe SortedSet[Long](34300, 34200, 34100).map(toNormalized)
     ob.getAsks.keySet shouldBe SortedSet[Long](44100, 44200, 44300, 44400).map(toNormalized)
@@ -99,12 +99,12 @@ class OrderBookSpec extends FreeSpec with PropertyChecks with Matchers with Matc
   "place several sell orders at the same price" - {
     "with same level" - {
       "TickSize.Enabled" in {
-        val tickSize = TickSize.Enabled(toNormalized(100L))
-        val ob       = OrderBook.empty
+        val normalizedTickSize = toNormalized(100L)
+        val ob                 = OrderBook.empty
 
         val sellOrder = sell(pair, 54521418493L, 44389)
-        ob.add(sellOrder, ntpNow, tickSize)
-        ob.add(sellOrder, ntpNow, tickSize)
+        ob.add(sellOrder, ntpNow, normalizedTickSize)
+        ob.add(sellOrder, ntpNow, normalizedTickSize)
 
         ob.getAsks.size shouldBe 1
 
@@ -112,12 +112,12 @@ class OrderBookSpec extends FreeSpec with PropertyChecks with Matchers with Matc
         ob.getAsks.head._2.toList shouldBe List(sellLimitOrder, sellLimitOrder)
       }
 
-      "TickSize.Disabled" in {
+      "MatchingRules.Default.normalizedTickSize" in {
         val ob = OrderBook.empty
 
         val sellOrder = sell(pair, 54521418493L, 44389)
-        ob.add(sellOrder, ntpNow, TickSize.Disabled)
-        ob.add(sellOrder, ntpNow, TickSize.Disabled)
+        ob.add(sellOrder, ntpNow, MatchingRules.Default.normalizedTickSize)
+        ob.add(sellOrder, ntpNow, MatchingRules.Default.normalizedTickSize)
 
         ob.getAsks.size shouldBe 1
 
@@ -130,8 +130,8 @@ class OrderBookSpec extends FreeSpec with PropertyChecks with Matchers with Matc
       val ob = OrderBook.empty
 
       val sellOrder = sell(pair, 54521418493L, 44389)
-      ob.add(sellOrder, ntpNow, TickSize.Enabled(toNormalized(100L)))
-      ob.add(sellOrder, ntpNow, TickSize.Disabled)
+      ob.add(sellOrder, ntpNow, toNormalized(100L))
+      ob.add(sellOrder, ntpNow, MatchingRules.Default.normalizedTickSize)
 
       ob.getAsks.size shouldBe 2
 

--- a/dex/src/test/scala/com/wavesplatform/dex/model/RawMatchingRulesSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/RawMatchingRulesSpecification.scala
@@ -3,12 +3,12 @@ package com.wavesplatform.dex.model
 import cats.data.NonEmptyList
 import com.wavesplatform.NoShrink
 import com.wavesplatform.dex.MatcherTestData
-import com.wavesplatform.dex.settings.MatchingRules
+import com.wavesplatform.dex.settings.RawMatchingRules
 import org.scalacheck.Gen
 import org.scalatest.{Matchers, PropSpec}
 import org.scalatestplus.scalacheck.{ScalaCheckPropertyChecks => PropertyChecks}
 
-class MatchingRulesSpecification extends PropSpec with PropertyChecks with Matchers with MatcherTestData with NoShrink {
+class RawMatchingRulesSpecification extends PropSpec with PropertyChecks with Matchers with MatcherTestData with NoShrink {
   property("skipOutdated: rules.head.startOffset <= currentOffset < rules(1).startOffset") {
     val g = for {
       currOffset <- currOffsetGen
@@ -17,7 +17,7 @@ class MatchingRulesSpecification extends PropSpec with PropertyChecks with Match
 
     forAll(g) {
       case (currOffset, rules) =>
-        val updatedRules = MatchingRules.skipOutdated(currOffset, rules)
+        val updatedRules = RawMatchingRules.skipOutdated(currOffset, rules)
         updatedRules.toList match {
           case first :: Nil =>
             withClue(s"first.startOffset=${first.startOffset}, currOffset=$currOffset") {
@@ -37,18 +37,18 @@ class MatchingRulesSpecification extends PropSpec with PropertyChecks with Match
 
   private val currOffsetGen = Gen.choose(0L, Long.MaxValue)
 
-  private def nextRulesGen(prevRules: MatchingRules): Gen[Option[MatchingRules]] =
+  private def nextRulesGen(prevRules: RawMatchingRules): Gen[Option[RawMatchingRules]] =
     if (prevRules.startOffset == Long.MaxValue) Gen.const(None)
     else
       for {
-        startOffset        <- Gen.choose(prevRules.startOffset + 1, Long.MaxValue)
-        normalizedTickSize <- Gen.choose(1, Long.MaxValue)
-      } yield Some(MatchingRules(startOffset, normalizedTickSize))
+        startOffset <- Gen.choose(prevRules.startOffset + 1, Long.MaxValue)
+        tickSize    <- Gen.choose(1, Double.MaxValue)
+      } yield Some(RawMatchingRules(startOffset, tickSize))
 
-  private val firstRuleGen: Gen[MatchingRules] = Gen.choose(1, Long.MaxValue).map(MatchingRules(0L, _))
+  private val firstRuleGen: Gen[RawMatchingRules] = Gen.choose(1, Double.MaxValue).map(RawMatchingRules(0L, _))
 
-  private def rulesChainGen(maxNumber: Int): Gen[NonEmptyList[MatchingRules]] = {
-    def loop(rest: Int, acc: Gen[NonEmptyList[MatchingRules]]): Gen[NonEmptyList[MatchingRules]] =
+  private def rulesChainGen(maxNumber: Int): Gen[NonEmptyList[RawMatchingRules]] = {
+    def loop(rest: Int, acc: Gen[NonEmptyList[RawMatchingRules]]): Gen[NonEmptyList[RawMatchingRules]] =
       if (rest == 0) acc
       else
         for {

--- a/dex/src/test/scala/com/wavesplatform/dex/settings/MatcherSettingsSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/settings/MatcherSettingsSpecification.scala
@@ -463,18 +463,18 @@ class MatcherSettingsSpecification extends FlatSpec with Matchers {
               stepAmount = 0.001,
               minAmount = 0.001,
               maxAmount = 1000000,
-              stepPrice = OrderRestrictionsSettings.stepPriceDefault,
-              minPrice = OrderRestrictionsSettings.minPriceDefault,
-              maxPrice = OrderRestrictionsSettings.maxPriceDefault
+              stepPrice = OrderRestrictionsSettings.Default.stepPrice,
+              minPrice = OrderRestrictionsSettings.Default.minPrice,
+              maxPrice = OrderRestrictionsSettings.Default.maxPrice
             ),
           AssetPair.createAssetPair("ETH", "USD").get ->
             OrderRestrictionsSettings(
               stepAmount = 0.01,
               minAmount = 0.05,
               maxAmount = 20000,
-              stepPrice = OrderRestrictionsSettings.stepPriceDefault,
-              minPrice = OrderRestrictionsSettings.minPriceDefault,
-              maxPrice = OrderRestrictionsSettings.maxPriceDefault
+              stepPrice = OrderRestrictionsSettings.Default.stepPrice,
+              minPrice = OrderRestrictionsSettings.Default.minPrice,
+              maxPrice = OrderRestrictionsSettings.Default.maxPrice
             )
         )
     }
@@ -500,12 +500,11 @@ class MatcherSettingsSpecification extends FlatSpec with Matchers {
         |  "WAVES-8LQW8f7P5d5PZM7GtZEBgaqRPGSzS3DfPuiXrURJ4AJS": [
         |    {
         |      start-offset = 100
-        |      merge-prices = yes
         |      tick-size    = 0.002
         |    },
         |    {
         |      start-offset = 500
-        |      merge-prices = no
+        |      tick-size    = 0.001
         |    }
         |  ]
         |}
@@ -516,12 +515,11 @@ class MatcherSettingsSpecification extends FlatSpec with Matchers {
         |  "WAVES-8LQW8f7P5d5PZM7GtZEBgaqRPGSzS3DfPuiXrURJ4AJS": [
         |    {
         |      start-offset = $firstRuleOffset
-        |      merge-prices = yes
         |      tick-size    = 0.002
         |    },
         |    {
         |      start-offset = $secondRuleOffset
-        |      merge-prices = no
+        |      tick-size    = 0.001
         |    }
         |  ]
         |}
@@ -535,10 +533,9 @@ class MatcherSettingsSpecification extends FlatSpec with Matchers {
       getSettingByConfig(configStr(nonEmptyCorrect)).explicitGet().matchingRules shouldBe Map(
         AssetPair.fromString("WAVES-8LQW8f7P5d5PZM7GtZEBgaqRPGSzS3DfPuiXrURJ4AJS").get ->
           NonEmptyList[RawMatchingRules](
-            RawMatchingRules(0, false),
+            RawMatchingRules(100L, 0.002),
             List(
-              RawMatchingRules(100L, mergePrices = true, 0.002),
-              RawMatchingRules(500L, mergePrices = false)
+              RawMatchingRules(500L, 0.001)
             )
           )
       )


### PR DESCRIPTION
REST API:
* GET /orderbook/{amountAsset}/{priceAsset}/info returns "restrictions" (an old fields) and "matchingRules.tickSize";
* GET /orderbook returns matchingRules;

Internal:
* OrderBookActor updates the current matching rules during the rules switch;
* Removed RawMatchingRules.mergePrices, because "disabled" option means the most minimal tick size for this order book;
* RawMatchingRules.rawMatchingRulesNelReader doesn't prepend the default rules, because we don't know asset's decimals during config parsing. They are prepended in the Matcher;
* Added OrderRestrictionsSettings.Default;
* TickSize is removed;
* OrderBook works with normalizedTickSize: Long instead of tickSize: TickSize;
* ExchangeTransactionBroadcastActor logs failed to send transactions as it is noticed in the documentation;
* OrderBookActor works with raw matching rules to not to do conversion RawMatchingRules <-> MatchingRules twice;
* MatchingRules.skipOutdated now in RawMatchingRules;

Tests:
* Fixed MatcherTestSuite ("1 vs 0" issue);