### PR TITLE
DEX-351 Show the DEX's version in Swagger

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import sbt.internal.inc.ReflectUtilities
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 
-def nodeVersionTag: String = "5468da2b49078a82d1208fadd1523deed251feb1"
+def nodeVersionTag: String = "v1.0.1"
 
 lazy val node = ProjectRef(uri(s"git://github.com/wavesplatform/Waves.git#$nodeVersionTag"), "node")
 

--- a/dex/src/main/scala/com/wavesplatform/dex/Matcher.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/Matcher.scala
@@ -12,10 +12,11 @@ import akka.stream.ActorMaterializer
 import akka.util.Timeout
 import cats.data.NonEmptyList
 import com.wavesplatform.account.{Address, PublicKey}
-import com.wavesplatform.api.http.{ApiRoute, CompositeHttpService}
+import com.wavesplatform.api.http.{ApiRoute, CompositeHttpService => _}
 import com.wavesplatform.common.utils.{Base58, EitherExt2}
 import com.wavesplatform.db._
 import com.wavesplatform.dex.Matcher.Status
+import com.wavesplatform.dex.api.http.CompositeHttpService
 import com.wavesplatform.dex.api.{MatcherApiRoute, MatcherApiRouteV1, OrderBookSnapshotHttpCache}
 import com.wavesplatform.dex.db.{AssetPairsDB, OrderBookSnapshotDB, OrderDB}
 import com.wavesplatform.dex.error.MatcherError
@@ -330,7 +331,7 @@ class Matcher(context: Context) extends Extension with ScorexLogging {
 
     log.info(s"Starting matcher on: ${settings.bindAddress}:${settings.port} ...")
 
-    val combinedRoute = CompositeHttpService(matcherApiTypes, matcherApiRoutes, context.settings.restAPISettings).compositeRoute
+    val combinedRoute = new CompositeHttpService(matcherApiTypes, matcherApiRoutes, context.settings.restAPISettings).compositeRoute
     matcherServerBinding = Await.result(Http().bindAndHandle(combinedRoute, settings.bindAddress, settings.port), 5.seconds)
 
     log.info(s"Matcher bound to ${matcherServerBinding.localAddress}")

--- a/dex/src/main/scala/com/wavesplatform/dex/api/http/CompositeHttpService.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/http/CompositeHttpService.scala
@@ -1,0 +1,54 @@
+package com.wavesplatform.dex.api.http
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.HttpMethods._
+import akka.http.scaladsl.model.headers._
+import akka.http.scaladsl.model.{HttpRequest, StatusCodes}
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.RouteResult.Complete
+import akka.http.scaladsl.server.directives.{DebuggingDirectives, LoggingMagnet}
+import akka.http.scaladsl.server.{Route, RouteResult}
+import akka.stream.ActorMaterializer
+import com.wavesplatform.api.http.ApiRoute
+import com.wavesplatform.settings.RestAPISettings
+import com.wavesplatform.utils.ScorexLogging
+
+class CompositeHttpService(apiTypes: Set[Class[_]], routes: Seq[ApiRoute], settings: RestAPISettings)(implicit system: ActorSystem)
+    extends ScorexLogging {
+
+  private val swaggerService    = new SwaggerDocService(system, ActorMaterializer()(system), apiTypes, settings)
+  private val redirectToSwagger = redirect("/api-docs/index.html", StatusCodes.PermanentRedirect)
+  private val swaggerRoute: Route = swaggerService.routes ~
+    (pathEndOrSingleSlash | path("swagger"))(redirectToSwagger) ~
+    pathPrefix("api-docs") {
+      pathEndOrSingleSlash(redirectToSwagger) ~ getFromResourceDirectory("swagger-ui")
+    }
+
+  val compositeRoute: Route        = extendRoute(routes.map(_.route).reduce(_ ~ _)) ~ swaggerRoute ~ complete(StatusCodes.NotFound)
+  val loggingCompositeRoute: Route = DebuggingDirectives.logRequestResult(LoggingMagnet(_ => logRequestResponse))(compositeRoute)
+
+  private def logRequestResponse(req: HttpRequest)(res: RouteResult): Unit = res match {
+    case Complete(resp) =>
+      val msg = s"HTTP ${resp.status.value} from ${req.method.value} ${req.uri}"
+      if (resp.status == StatusCodes.OK) log.info(msg) else log.warn(msg)
+    case _ =>
+  }
+
+  private val corsAllowedHeaders = (if (settings.apiKeyDifferentHost) List("api_key", "X-API-Key") else List.empty[String]) ++
+    Seq("Authorization", "Content-Type", "X-Requested-With", "Timestamp", "Signature")
+
+  private def corsAllowAll = if (settings.cors) respondWithHeader(`Access-Control-Allow-Origin`.*) else pass
+
+  private def extendRoute(base: Route): Route =
+    if (settings.cors) { ctx =>
+      val extendedRoute = corsAllowAll(base) ~ options {
+        respondWithDefaultHeaders(
+          `Access-Control-Allow-Credentials`(true),
+          `Access-Control-Allow-Headers`(corsAllowedHeaders),
+          `Access-Control-Allow-Methods`(OPTIONS, POST, PUT, GET, DELETE)
+        )(corsAllowAll(complete(StatusCodes.OK)))
+      }
+
+      extendedRoute(ctx)
+    } else base
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/api/http/SwaggerDocService.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/http/SwaggerDocService.scala
@@ -1,0 +1,30 @@
+package com.wavesplatform.dex.api.http
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import com.github.swagger.akka.SwaggerHttpService
+import com.github.swagger.akka.model.{Info, License}
+import com.wavesplatform.dex.Version
+import com.wavesplatform.settings.RestAPISettings
+import io.swagger.models.{Scheme, Swagger}
+
+class SwaggerDocService(val actorSystem: ActorSystem, val materializer: ActorMaterializer, val apiClasses: Set[Class[_]], settings: RestAPISettings)
+    extends SwaggerHttpService {
+
+  override val host: String = settings.bindAddress + ":" + settings.port
+  override val info: Info = Info(
+    "The Web Interface to the Waves DEX API",
+    Version.VersionString,
+    "Waves DEX",
+    "License: MIT License",
+    None,
+    Some(License("MIT License", "https://github.com/wavesplatform/dex/blob/master/LICENSE"))
+  )
+
+  //Let swagger-ui determine the host and port
+  override val swaggerConfig: Swagger = new Swagger()
+    .basePath(SwaggerHttpService.prependSlashIfNecessary(basePath))
+    .info(info)
+    .scheme(Scheme.HTTP)
+    .scheme(Scheme.HTTPS)
+}

--- a/dex/src/test/scala/com/wavesplatform/state/diffs/package.scala
+++ b/dex/src/test/scala/com/wavesplatform/state/diffs/package.scala
@@ -53,7 +53,7 @@ package object diffs extends WithState with Matchers {
     }
 
     val BlockDiffer.Result(diff, fees, totalFee, _) = differ(state, preconditions.lastOption, block).explicitGet()
-    val cb              = CompositeBlockchain.composite(state, Some(diff))
+    val cb              = CompositeBlockchain(state, Some(diff))
     assertion(diff, cb)
 
     state.append(diff, fees, totalFee, block)


### PR DESCRIPTION
* Updated the NODE dependency to 1.0.1. Fixed upgrade issues;
* Added own CompositeHttpService and SwaggerDocService, because the NODE ones contain an incorrect for DEX information;
* Version.scala is generated for DEX.