### PR TITLE
DEX-352 The matcher fee in REST API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -135,3 +135,6 @@ def checkPR: Command = Command.command("checkPR") { state =>
 }
 
 commands += checkPR
+
+// IDE settings
+ideExcludedDirectories := Seq((root / baseDirectory).value / "_local")

--- a/dex/src/main/scala/com/wavesplatform/dex/AddressActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/AddressActor.scala
@@ -180,8 +180,7 @@ class AddressActor(
           lo <- activeOrders.values
           if maybePair.forall(_ == lo.order.assetPair)
         } yield
-          lo.order.id() -> OrderInfo(
-            2,
+          lo.order.id() -> OrderInfo.v2(
             lo.order.orderType,
             lo.order.amount,
             lo.order.price,
@@ -261,8 +260,7 @@ class AddressActor(
     orderDB.saveOrderInfo(
       lo.order.id(),
       owner,
-      OrderInfo(
-        2,
+      OrderInfo.v2(
         lo.order.orderType,
         lo.order.amount,
         lo.order.price,

--- a/dex/src/main/scala/com/wavesplatform/dex/MatcherTool.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/MatcherTool.scala
@@ -15,21 +15,25 @@ import com.google.common.primitives.Shorts
 import com.typesafe.config.ConfigFactory
 import com.wavesplatform.account.{Address, AddressScheme}
 import com.wavesplatform.common.state.ByteStr
-import com.wavesplatform.common.utils.Base58
+import com.wavesplatform.common.utils.{Base58, EitherExt2}
 import com.wavesplatform.database._
 import com.wavesplatform.db.openDB
 import com.wavesplatform.dex.db.{AssetPairsDB, OrderBookSnapshotDB}
 import com.wavesplatform.dex.doc.MatcherErrorDoc
 import com.wavesplatform.dex.market.{MatcherActor, OrderBookActor}
-import com.wavesplatform.dex.model.{LimitOrder, OrderBook}
+import com.wavesplatform.dex.model.OrderInfo.FinalOrderInfo
+import com.wavesplatform.dex.model.{LimitOrder, OrderBook, OrderInfo, OrderStatus}
 import com.wavesplatform.dex.settings.MatcherSettings
 import com.wavesplatform.settings.loadConfig
-import com.wavesplatform.transaction.assets.exchange.AssetPair
+import com.wavesplatform.transaction.Asset
+import com.wavesplatform.transaction.Asset.Waves
+import com.wavesplatform.transaction.assets.exchange.{AssetPair, Order}
 import com.wavesplatform.utils.ScorexLogging
 import net.ceedubs.ficus.Ficus._
-import org.iq80.leveldb.DB
+import org.iq80.leveldb.{DB, ReadOptions}
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
@@ -83,6 +87,112 @@ object MatcherTool extends ScorexLogging {
     db.readWrite(rw => keysToDelete.result().foreach(rw.delete(_, "matcher-legacy-entries")))
   }
 
+  private def migrateOrderInfo(readOnlyBlockchainDb: ReadOnlyDB, db: DB, matcherAccount: String, useFast: Boolean, from: Int): Unit = {
+    log.info(s"Starting OrderInfo migration from $from, algorithm: ${if (useFast) "fast" else "correct"}")
+    val readOnlyDB = new ReadOnlyDB(db, new ReadOptions())
+
+    val scriptedMemo = mutable.Map.empty[Asset, Boolean]
+    def isAssetScripted(asset: Asset): Boolean =
+      scriptedMemo.getOrElseUpdate(
+        asset,
+        asset.fold(false) { assetId =>
+          readOnlyBlockchainDb.get(Keys.assetScriptHistory(assetId)).headOption.exists { height =>
+            readOnlyBlockchainDb.get(Keys.assetScriptPresent(assetId)(height)).isDefined
+          }
+        }
+      )
+
+    val matcherAccountAddress = Address.fromString(matcherAccount).explicitGet()
+    val isMatcherScripted = {
+      for {
+        id     <- readOnlyBlockchainDb.get(Keys.addressId(matcherAccountAddress))
+        height <- readOnlyBlockchainDb.get(Keys.addressScriptHistory(id)).headOption
+      } yield readOnlyBlockchainDb.get(Keys.addressScript(id)(height)).isDefined
+    }.getOrElse(false)
+
+    val defaultFee   = 300000L
+    val scriptRunFee = 400000L
+    val baseFee      = defaultFee + (if (isMatcherScripted) scriptRunFee else 0L)
+
+    def getBlockchainTotalFee(assetPair: AssetPair): (Asset, Long) = {
+      val a = if (isAssetScripted(assetPair.amountAsset)) scriptRunFee else 0L
+      val p = if (isAssetScripted(assetPair.priceAsset)) scriptRunFee else 0L
+      (Waves, baseFee + a + p)
+    }
+
+    def getDexTotalFee(orderId: Order.Id): Option[(Asset, Long)] =
+      readOnlyDB.get(MatcherKeys.order(orderId)).map(x => (x.matcherFeeAssetId, x.matcherFee))
+
+    val getTotalFee: (AssetPair, Order.Id) => (Asset, Long) =
+      if (useFast) { (assetPair, _) =>
+        getBlockchainTotalFee(assetPair)
+      } else { (assetPair, orderId) =>
+        getDexTotalFee(orderId).getOrElse(getBlockchainTotalFee(assetPair))
+      }
+
+    val iter = readOnlyDB.iterateOverStream(Shorts.toByteArray(2))
+    val orderInfos =
+      iter.zipWithIndex
+        .drop(from)
+        .map { case (entry, idx) => (parseOrderInfo(entry), idx) }
+        .filterNot { case ((_, finalInfo), _) => finalInfo.version > 1 }
+
+    val batchSize = 2000
+    val batch     = new mutable.ArrayBuffer[(Order.Id, FinalOrderInfo)](batchSize)
+
+    def forceWrite(): Unit = {
+      val wb = db.createWriteBatch()
+      batch.foreach {
+        case (id, orderInfo) =>
+          val key = MatcherKeys.orderInfo(id)
+          wb.put(key.keyBytes, key.encode(Some(orderInfo)))
+      }
+      db.write(wb)
+      batch.clear()
+    }
+
+    def update(id: Order.Id, orderInfo: FinalOrderInfo): Unit = {
+      batch.append((id, orderInfo))
+      if (batch.size >= batchSize) forceWrite()
+    }
+
+    orderInfos.foreach {
+      case ((id, finalInfo), idx) =>
+        val (feeAssetId, totalFee) = getTotalFee(finalInfo.assetPair, id)
+        if (totalFee != defaultFee) {
+          val filledFee = (BigInt(finalInfo.status.filledAmount) * totalFee / finalInfo.amount).toLong
+          val updatedStatus = finalInfo.status match {
+            case x: OrderStatus.Cancelled => OrderStatus.Cancelled(x.filledAmount, filledFee)
+            case x: OrderStatus.Filled    => OrderStatus.Filled(x.filledAmount, filledFee)
+            case OrderStatus.NotFound     => finalInfo.status // Impossible
+          }
+
+          val updatedOrderInfo = OrderInfo.v2(
+            side = finalInfo.side,
+            amount = finalInfo.amount,
+            price = finalInfo.price,
+            matcherFee = totalFee,
+            matcherFeeAssetId = feeAssetId,
+            timestamp = finalInfo.timestamp,
+            status = updatedStatus,
+            assetPair = finalInfo.assetPair
+          )
+
+          update(id, updatedOrderInfo)
+        }
+
+        if (idx % 100000 == 0) log.info(s"Current index: $idx")
+    }
+
+    iter.close()
+  }
+
+  private def parseOrderInfo(entry: DBEntry): (Order.Id, OrderInfo.FinalOrderInfo) = {
+    val orderId = ByteStr(entry.getKey.drop(2))
+    val oi      = MatcherKeys.orderInfo(orderId).parse(entry.getValue)
+    orderId -> oi.getOrElse(throw new RuntimeException(s"Can't parse order info for $orderId, bytes: ${entry.getValue.mkString(",")}"))
+  }
+
   def main(args: Array[String]): Unit = {
     log.info(s"OK, engine start")
 
@@ -90,6 +200,7 @@ object MatcherTool extends ScorexLogging {
     val actualConfig              = loadConfig(userConfig)
     val settings: MatcherSettings = actualConfig.as[MatcherSettings]("waves.dex")
     val db                        = openDB(settings.dataDir)
+    val blockchainDb              = openDB(actualConfig.getString("waves.db.directory"))
 
     AddressScheme.current = new AddressScheme {
       override val chainId: Byte = Base58.tryDecodeWithLimit(settings.account).get(1)
@@ -181,6 +292,10 @@ object MatcherTool extends ScorexLogging {
         orderInfoKey.parse(db.get(orderInfoKey.keyBytes)).foreach { oi =>
           log.info(s"Order info: $oi")
         }
+      case "oi-migrate" =>
+        val useFast = if (args.length < 3) false else args(2).toBoolean
+        val offset  = if (args.length < 4) 0 else args(3).toInt
+        migrateOrderInfo(new ReadOnlyDB(blockchainDb, new ReadOptions()), db, settings.account, useFast, offset)
       case "ddd" =>
         log.warn("DELETING LEGACY ENTRIES")
         deleteLegacyEntries(db)
@@ -345,6 +460,7 @@ object MatcherTool extends ScorexLogging {
 
     log.info(s"Completed in ${(System.currentTimeMillis() - start) / 1000}s")
     db.close()
+    blockchainDb.close()
   }
 
   case class Stats(entryCount: Long, totalKeySize: Long, totalValueSize: Long)

--- a/dex/src/main/scala/com/wavesplatform/dex/api/MatcherApiRoute.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/MatcherApiRoute.scala
@@ -436,14 +436,12 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
             "id"        -> id.toString,
             "type"      -> oi.side.toString,
             "amount"    -> oi.amount,
+            "fee"       -> oi.matcherFee,
             "price"     -> oi.price,
             "timestamp" -> oi.timestamp,
-            "filled" -> (oi.status match {
-              case OrderStatus.Filled(f)          => f
-              case OrderStatus.PartiallyFilled(f) => f
-              case OrderStatus.Cancelled(f)       => f
-              case _                              => 0L
-            }),
+            "filled"    -> oi.status.filledAmount,
+            "filledFee" -> oi.status.filledFee,
+            "feeAsset"  -> oi.matcherFeeAssetId,
             "status"    -> oi.status.name,
             "assetPair" -> oi.assetPair.json
           )

--- a/dex/src/main/scala/com/wavesplatform/dex/model/OrderInfo.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/OrderInfo.scala
@@ -3,29 +3,99 @@ package com.wavesplatform.dex.model
 import java.nio.ByteBuffer
 
 import com.wavesplatform.dex.util.Codecs.ByteBufferExt
+import com.wavesplatform.transaction.Asset
+import com.wavesplatform.transaction.Asset.Waves
 import com.wavesplatform.transaction.assets.exchange.{AssetPair, OrderType}
 
-case class OrderInfo[+S <: OrderStatus](side: OrderType, amount: Long, price: Long, timestamp: Long, status: S, assetPair: AssetPair)
+case class OrderInfo[+S <: OrderStatus](version: Byte,
+                                        side: OrderType,
+                                        amount: Long,
+                                        price: Long,
+                                        matcherFee: Long,
+                                        matcherFeeAssetId: Asset,
+                                        timestamp: Long,
+                                        status: S,
+                                        assetPair: AssetPair)
 
 object OrderInfo {
   type FinalOrderInfo = OrderInfo[OrderStatus.Final]
 
-  def encode(oi: FinalOrderInfo): Array[Byte] = {
+  def encode(oi: FinalOrderInfo): Array[Byte] = if (oi.version <= 1) encodeV1(oi) else encodeV2(oi)
+
+  def decode(bytes: Array[Byte]): FinalOrderInfo = {
+    val buf = ByteBuffer.wrap(bytes)
+    buf.get match {
+      case side @ (0 | 1) => decodeV1(side, buf)
+      case 2              => decodeV2(buf)
+      case x              => throw new IllegalStateException(s"An unknown version of order info: $x")
+    }
+  }
+
+  private def encodeV1(oi: FinalOrderInfo): Array[Byte] = {
     val assetPairBytes = oi.assetPair.bytes
     ByteBuffer
-      .allocate(34 + assetPairBytes.length)
+      .allocate(42 + assetPairBytes.length)
       .put(oi.side.bytes)
       .putLong(oi.amount)
       .putLong(oi.price)
       .putLong(oi.timestamp)
-      .putFinalOrderStatus(oi.status)
+      .putFinalOrderStatus(1, oi.status)
       .putAssetId(oi.assetPair.amountAsset)
       .putAssetId(oi.assetPair.priceAsset)
       .array()
   }
 
-  def decode(bytes: Array[Byte]): FinalOrderInfo = {
-    val buf = ByteBuffer.wrap(bytes)
-    OrderInfo(OrderType(buf.get()), buf.getLong, buf.getLong, buf.getLong, buf.getFinalOrderStatus, AssetPair(buf.getAssetId, buf.getAssetId))
+  private def decodeV1(side: Byte, buf: ByteBuffer): FinalOrderInfo = {
+    val version: Byte = 1
+    val totalAmount   = buf.getLong()
+    val totalFee      = 300000L
+
+    OrderInfo(
+      version = version,
+      side = OrderType(side),
+      amount = totalAmount,
+      price = buf.getLong,
+      matcherFee = totalFee,
+      matcherFeeAssetId = Waves,
+      timestamp = buf.getLong,
+      status = buf.getFinalOrderStatus(version, totalAmount, totalFee),
+      assetPair = AssetPair(buf.getAssetId, buf.getAssetId)
+    )
+  }
+
+  private def encodeV2(oi: FinalOrderInfo): Array[Byte] =
+    // DON'T WRITE BYTES "oi.matcherFeeAssetId.byteRepr" to the buffer. It works another way :(
+    ByteBuffer
+      .allocate(51 + oi.matcherFeeAssetId.byteRepr.length + oi.assetPair.bytes.length)
+      .put(oi.version)
+      .put(oi.side.bytes)
+      .putLong(oi.amount)
+      .putLong(oi.price)
+      .putLong(oi.matcherFee)
+      .putAssetId(oi.matcherFeeAssetId)
+      .putLong(oi.timestamp)
+      .putFinalOrderStatus(2, oi.status)
+      .putAssetId(oi.assetPair.amountAsset)
+      .putAssetId(oi.assetPair.priceAsset)
+      .array()
+
+  private def decodeV2(buf: ByteBuffer): FinalOrderInfo = {
+    val version: Byte = 2
+    val side          = OrderType(buf.get)
+    val totalAmount   = buf.getLong
+    val price         = buf.getLong
+    val totalFee      = buf.getLong
+
+    OrderInfo(
+      version = version,
+      side = side,
+      amount = totalAmount,
+      price = price,
+      matcherFee = totalFee,
+      matcherFeeAssetId = buf.getAssetId,
+      timestamp = buf.getLong,
+      status = buf.getFinalOrderStatus(version, totalAmount, totalFee),
+      assetPair = AssetPair(buf.getAssetId, buf.getAssetId)
+    )
   }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/util/Codecs.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/util/Codecs.scala
@@ -26,13 +26,28 @@ object Codecs {
         IssuedAsset(ByteStr(arr))
     }
 
-    def putFinalOrderStatus(st: OrderStatus): ByteBuffer = st match {
-      case OrderStatus.Filled(filled)    => b.put(0.toByte).putLong(filled)
-      case OrderStatus.Cancelled(filled) => b.put(1.toByte).putLong(filled)
-      case other                         => throw new IllegalArgumentException(s"Can't encode order status $other")
+    def putFinalOrderStatus(orderInfoVersion: Byte, st: OrderStatus): ByteBuffer = {
+      val tpe: Byte = st match {
+        case _: OrderStatus.Filled    => 0
+        case _: OrderStatus.Cancelled => 1
+        case x                        => throw new IllegalArgumentException(s"Can't encode order status $x")
+      }
+      val r = b.put(tpe).putLong(st.filledAmount)
+      if (orderInfoVersion <= 1) r else r.putLong(st.filledFee)
     }
 
-    def getFinalOrderStatus: OrderStatus.Final =
-      if (b.get() == 1) OrderStatus.Cancelled(b.getLong) else OrderStatus.Filled(b.getLong)
+    def getFinalOrderStatus(orderInfoVersion: Byte, totalAmount: Long, totalFee: Long): OrderStatus.Final = {
+      def fee(filledAmount: Long) = if (orderInfoVersion <= 1) (BigDecimal(filledAmount) / totalAmount * totalFee).toLongExact else b.getLong
+
+      b.get match {
+        case 0 =>
+          val filledAmount = b.getLong
+          OrderStatus.Filled(filledAmount, fee(filledAmount))
+        case 1 =>
+          val filledAmount = b.getLong
+          OrderStatus.Cancelled(filledAmount, fee(filledAmount))
+        case x => throw new IllegalArgumentException(s"Can't parse order status: $x")
+      }
+    }
   }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/util/Codecs.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/util/Codecs.scala
@@ -37,7 +37,7 @@ object Codecs {
     }
 
     def getFinalOrderStatus(orderInfoVersion: Byte, totalAmount: Long, totalFee: Long): OrderStatus.Final = {
-      def fee(filledAmount: Long) = if (orderInfoVersion <= 1) (BigDecimal(filledAmount) / totalAmount * totalFee).toLongExact else b.getLong
+      def fee(filledAmount: Long) = if (orderInfoVersion <= 1) (BigInt(filledAmount) * totalFee / totalAmount).toLong else b.getLong
 
       b.get match {
         case 0 =>

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderDBSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderDBSpec.scala
@@ -62,8 +62,8 @@ class OrderDBSpec extends FreeSpec with Matchers with WithDB with MatcherTestDat
       } yield
         (
           o,
-          OrderInfo(2, o.orderType, o.amount, o.price, o.matcherFee, o.matcherFeeAssetId, o.timestamp, s1, o.assetPair),
-          OrderInfo(2, o.orderType, o.amount, o.price, o.matcherFee, o.matcherFeeAssetId, o.timestamp, s2, o.assetPair),
+          OrderInfo.v2(o.orderType, o.amount, o.price, o.matcherFee, o.matcherFeeAssetId, o.timestamp, s1, o.assetPair),
+          OrderInfo.v2(o.orderType, o.amount, o.price, o.matcherFee, o.matcherFeeAssetId, o.timestamp, s2, o.assetPair),
         )
 
       forAll(dualFinalizedOrderInfoGen) {
@@ -114,6 +114,6 @@ class OrderDBSpec extends FreeSpec with Matchers with WithDB with MatcherTestDat
 object OrderDBSpec {
   private implicit class OrderExt(val o: Order) extends AnyVal {
     def toInfo[A <: OrderStatus](status: A) =
-      OrderInfo[A](2, o.orderType, o.amount, o.price, o.matcherFee, o.matcherFeeAssetId, o.timestamp, status, o.assetPair)
+      OrderInfo.v2[A](o.orderType, o.amount, o.price, o.matcherFee, o.matcherFeeAssetId, o.timestamp, status, o.assetPair)
   }
 }

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderHistoryBalanceSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderHistoryBalanceSpecification.scala
@@ -186,8 +186,8 @@ class OrderHistoryBalanceSpecification
 
     withClue("executed exactly") {
       exec.executedAmount shouldBe counter.amount
-      orderStatus(counter.id()) shouldBe OrderStatus.Filled(exec.executedAmount)
-      orderStatus(submitted.id()) shouldBe OrderStatus.Filled(exec.executedAmount)
+      orderStatus(counter.id()) shouldBe OrderStatus.Filled(exec.executedAmount, exec.counterExecutedFee)
+      orderStatus(submitted.id()) shouldBe OrderStatus.Filled(exec.executedAmount, exec.submittedExecutedFee)
     }
 
     withClue(s"has no reserved assets, counter.senderPublicKey: ${counter.senderPublicKey}, counter.order.id=${counter.idStr()}") {
@@ -239,7 +239,7 @@ class OrderHistoryBalanceSpecification
 
       exec.counterRemainingFee shouldBe 150001L
 
-      orderStatus(counter.id()) shouldBe OrderStatus.PartiallyFilled(exec.executedAmount)
+      orderStatus(counter.id()) shouldBe OrderStatus.PartiallyFilled(exec.executedAmount, exec.counterExecutedFee)
     }
 
     withClue(s"submitted.order.id=${counter.idStr()}") {
@@ -247,7 +247,7 @@ class OrderHistoryBalanceSpecification
       exec.submittedRemainingAmount shouldBe submitted.amount - exec.executedAmount
 
       exec.submittedRemainingFee shouldBe 3781L
-      orderStatus(submitted.id()) shouldBe OrderStatus.Filled(exec.executedAmount)
+      orderStatus(submitted.id()) shouldBe OrderStatus.Filled(exec.executedAmount, exec.submittedExecutedFee)
     }
 
     withClue(s"account checks, counter.senderPublicKey: ${counter.senderPublicKey}, counter.order.id=${counter.idStr()}") {
@@ -290,14 +290,14 @@ class OrderHistoryBalanceSpecification
       exec.counterRemainingAmount shouldBe 0L
       exec.counterRemainingFee shouldBe 0L
 
-      orderStatus(counter.id()) shouldBe OrderStatus.Filled(100000000)
+      orderStatus(counter.id()) shouldBe OrderStatus.Filled(100000000, 2000)
     }
 
     withClue(s"submitted: ${submitted.idStr()}") {
       exec.submittedRemainingAmount shouldBe 20000000L
       exec.submittedRemainingFee shouldBe 167L
 
-      orderStatus(submitted.id()) shouldBe OrderStatus.PartiallyFilled(100000000)
+      orderStatus(submitted.id()) shouldBe OrderStatus.PartiallyFilled(100000000, 833)
     }
 
     withClue(s"account checks, submitted.senderPublicKey: ${submitted.senderPublicKey}, submitted.order.id=${submitted.idStr()}") {
@@ -335,18 +335,18 @@ class OrderHistoryBalanceSpecification
     val exec1 = OrderExecuted(LimitOrder(submitted1), LimitOrder(counter))
     oh.process(exec1)
 
-    orderStatus(counter.id()) shouldBe OrderStatus.PartiallyFilled(50000000)
-    orderStatus(submitted1.id()) shouldBe OrderStatus.Filled(50000000)
+    orderStatus(counter.id()) shouldBe OrderStatus.PartiallyFilled(50000000, 150000)
+    orderStatus(submitted1.id()) shouldBe OrderStatus.Filled(50000000, 300001)
 
     val exec2 = OrderExecuted(LimitOrder(submitted2), exec1.counterRemaining)
     oh.processAll(exec2, OrderAdded(exec2.submittedRemaining, ntpTime.getTimestamp()))
 
     withClue(s"counter: ${counter.idStr()}") {
-      orderStatus(counter.id()) shouldBe OrderStatus.Filled(100000000)
+      orderStatus(counter.id()) shouldBe OrderStatus.Filled(100000000, 300000)
     }
 
-    orderStatus(submitted1.id()) shouldBe OrderStatus.Filled(50000000)
-    orderStatus(submitted2.id()) shouldBe OrderStatus.PartiallyFilled(50000000)
+    orderStatus(submitted1.id()) shouldBe OrderStatus.Filled(50000000, 300001)
+    orderStatus(submitted2.id()) shouldBe OrderStatus.PartiallyFilled(50000000, 187500)
 
     openVolume(counter.senderPublicKey, WavesBtc.priceAsset) shouldBe 0L
     openVolume(counter.senderPublicKey, WavesBtc.amountAsset) shouldBe 0L
@@ -454,7 +454,7 @@ class OrderHistoryBalanceSpecification
     val exec1 = OrderExecuted(LimitOrder(submitted), LimitOrder(counter1))
     oh.processAll(exec1, OrderAdded(exec1.submittedRemaining, ntpTime.getTimestamp()), OrderExecuted(exec1.submittedRemaining, LimitOrder(counter2)))
 
-    orderStatus(submitted.id()) shouldBe OrderStatus.Filled(350)
+    orderStatus(submitted.id()) shouldBe OrderStatus.Filled(350, 299999)
   }
 
   property("Partially with own order") {
@@ -469,7 +469,7 @@ class OrderHistoryBalanceSpecification
     withClue(s"counter: ${counter.idStr()}") {
       exec.counterRemainingAmount shouldBe 0L
       exec.counterRemainingFee shouldBe 0L
-      orderStatus(counter.id()) shouldBe OrderStatus.Filled(100000000)
+      orderStatus(counter.id()) shouldBe OrderStatus.Filled(100000000, 300000)
     }
 
     withClue(s"submitted: ${submitted.idStr()}") {
@@ -493,7 +493,7 @@ class OrderHistoryBalanceSpecification
 
     oh.processAll(OrderAdded(LimitOrder(ord1), ntpTime.getTimestamp()), OrderCanceled(LimitOrder(ord1), unmatchable = false, ntpTime.getTimestamp()))
 
-    orderStatus(ord1.id()) shouldBe OrderStatus.Cancelled(0)
+    orderStatus(ord1.id()) shouldBe OrderStatus.Cancelled(0, 0)
 
     openVolume(ord1.senderPublicKey, WctBtc.amountAsset) shouldBe 0L
     openVolume(ord1.senderPublicKey, WctBtc.priceAsset) shouldBe 0L
@@ -515,7 +515,7 @@ class OrderHistoryBalanceSpecification
     oh.process(OrderAdded(LimitOrder(ord1), ntpTime.getTimestamp()))
     oh.process(OrderCanceled(LimitOrder(ord1), unmatchable = false, ntpTime.getTimestamp()))
 
-    orderStatus(ord1.id()) shouldBe OrderStatus.Cancelled(0)
+    orderStatus(ord1.id()) shouldBe OrderStatus.Cancelled(0, 0)
 
     openVolume(ord1.senderPublicKey, WctBtc.amountAsset) shouldBe 0L
     openVolume(ord1.senderPublicKey, WctBtc.priceAsset) shouldBe 0L
@@ -532,8 +532,8 @@ class OrderHistoryBalanceSpecification
       exec1,
       OrderCanceled(exec1.counter.partial(exec1.counterRemainingAmount, exec1.counterRemainingFee), unmatchable = false, ntpTime.getTimestamp()))
 
-    orderStatus(counter.id()) shouldBe OrderStatus.Cancelled(1000000000)
-    orderStatus(submitted.id()) shouldBe OrderStatus.Filled(1000000000)
+    orderStatus(counter.id()) shouldBe OrderStatus.Cancelled(1000000000, 142857)
+    orderStatus(submitted.id()) shouldBe OrderStatus.Filled(1000000000, 300000)
 
     openVolume(counter.senderPublicKey, WavesBtc.amountAsset) shouldBe 0L
     openVolume(counter.senderPublicKey, WavesBtc.priceAsset) shouldBe 0L
@@ -827,8 +827,8 @@ class OrderHistoryBalanceSpecification
 
     withClue("executed exactly") {
       exec.executedAmount shouldBe counter.amount
-      orderStatus(counter.id()) shouldBe OrderStatus.Filled(exec.executedAmount)
-      orderStatus(submitted.id()) shouldBe OrderStatus.Filled(exec.executedAmount)
+      orderStatus(counter.id()) shouldBe OrderStatus.Filled(exec.executedAmount, exec.counterExecutedFee)
+      orderStatus(submitted.id()) shouldBe OrderStatus.Filled(exec.executedAmount, exec.submittedExecutedFee)
     }
 
     withClue(s"has no reserved assets, counter.senderPublicKey: ${counter.senderPublicKey}, counter.order.id=${counter.idStr()}") {
@@ -863,7 +863,7 @@ class OrderHistoryBalanceSpecification
     val cancel = OrderCanceled(LimitOrder(ord1), unmatchable = false, ntpTime.getTimestamp())
     oh.processAll(OrderAdded(LimitOrder(ord1), ntpTime.getTimestamp()), cancel, cancel)
 
-    orderStatus(ord1.id()) shouldBe OrderStatus.Cancelled(0)
+    orderStatus(ord1.id()) shouldBe OrderStatus.Cancelled(0, 0)
 
     openVolume(ord1.senderPublicKey, WctBtc.amountAsset) shouldBe 0L
     openVolume(ord1.senderPublicKey, WctBtc.priceAsset) shouldBe 0L

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderInfoSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderInfoSpec.scala
@@ -1,0 +1,39 @@
+package com.wavesplatform.dex.model
+
+import com.wavesplatform.NoShrink
+import com.wavesplatform.dex.MatcherTestData
+import com.wavesplatform.dex.model.OrderInfoSpec.OrderExt
+import com.wavesplatform.transaction.assets.exchange.Order
+import org.scalacheck.Gen
+import org.scalatest.{FreeSpec, Matchers}
+import org.scalatestplus.scalacheck.{ScalaCheckPropertyChecks => PropertyChecks}
+
+class OrderInfoSpec extends FreeSpec with Matchers with MatcherTestData with PropertyChecks with NoShrink {
+  private def finalizedOrderInfoGen(o: Order, orderInfoVersion: Byte): Gen[OrderInfo[OrderStatus.Final]] =
+    for {
+      filledAmount <- Gen.choose(0, o.amount)
+      filledFee    <- if (orderInfoVersion == 1) Gen.const((BigInt(filledAmount) * 300000 / o.amount).toLong) else Gen.choose(0, o.matcherFee)
+      status       <- Gen.oneOf(OrderStatus.Filled(filledAmount, filledFee), OrderStatus.Cancelled(filledAmount, filledFee))
+    } yield o.toInfo(orderInfoVersion, status)
+
+  private val finalizedOrderInfoGen: Gen[OrderInfo[OrderStatus.Final]] = for {
+    (o, _) <- orderGenerator
+    v      <- Gen.choose[Byte](1, 2)
+    result <- finalizedOrderInfoGen(o, v)
+  } yield result
+
+  "OrderInfo" - {
+    "x == decode(encode(x))" in forAll(finalizedOrderInfoGen) { oi =>
+      OrderInfo.decode(OrderInfo.encode(oi)) == oi
+    }
+  }
+}
+
+object OrderInfoSpec {
+  implicit class OrderExt(val o: Order) extends AnyVal {
+    def toInfo[A <: OrderStatus](version: Byte, status: A) = version match {
+      case 1 => OrderInfo.v1[A](o.orderType, o.amount, o.price, o.timestamp, status, o.assetPair)
+      case 2 => OrderInfo.v2[A](o.orderType, o.amount, o.price, o.matcherFee, o.matcherFeeAssetId, o.timestamp, status, o.assetPair)
+    }
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,13 +6,14 @@ resolvers ++= Seq(
 )
 
 Seq(
-  "com.eed3si9n"       % "sbt-assembly"             % "0.14.5",
-  "com.typesafe.sbt"   % "sbt-native-packager"      % "1.3.2",
-  "org.scalastyle"     %% "scalastyle-sbt-plugin"   % "1.0.0",
-  "org.scoverage"      % "sbt-scoverage"            % "1.5.1",
-  "se.marcuslonnberg"  % "sbt-docker"               % "1.4.1",
-  "com.typesafe.sbt"   % "sbt-git"                  % "0.9.3",
-  "com.lucidchart"     % "sbt-scalafmt"             % "1.15"
+  "com.eed3si9n"      % "sbt-assembly"           % "0.14.5",
+  "com.typesafe.sbt"  % "sbt-native-packager"    % "1.3.2",
+  "org.scalastyle"    %% "scalastyle-sbt-plugin" % "1.0.0",
+  "org.scoverage"     % "sbt-scoverage"          % "1.5.1",
+  "se.marcuslonnberg" % "sbt-docker"             % "1.4.1",
+  "com.typesafe.sbt"  % "sbt-git"                % "0.9.3",
+  "com.lucidchart"    % "sbt-scalafmt"           % "1.15",
+  "org.jetbrains"     % "sbt-ide-settings"       % "1.0.0"
 ).map(addSbtPlugin)
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
Migration:
This migration is idempotent and leaves the DB in the correct state even it ran multiple times.

Example of command for Mainnet with specified arguments: "sudo -u waves -main com.wavesplatform.dex.MatcherTool /path/to/config oi-migrate <useFast> <from>"

Arguments:
* They are optional, but you must to specify both if want to specify "from" without "useFast";
* "useFast" can be "true", if your DEX accepts only the base coin (for Waves network it is WAVES) and works in the "dynamic" mode. If you are not sure, use "false".
  The fast migration works 3-4 times faster than the correct one and processes 100 millions of orders in ≈5 minutes;
* "from" if you ran migration previously and want to skip processed orders. Note, that skipping is not a fast operation (but it does less work). If you are not sure, use "0";

REST API:
* GET /orderbook/{amountAsset}/{priceAsset}/publicKey/{publicKey}, GET /orderbook/{publicKey}, GET /orders/{address}: added "fee", "filledFee" and "feeAsset" fields in JSON;
* GET /orderbook/{amountAsset}/{priceAsset}/{orderId} - added "filledFee" in JSON;

Internals:
* OrderInfo - added version, matcherFee and matcherFeeAssetId. Updated serde and added fallback calculations for them;
* OrderInfo can't be created directly, only through v1 and v2. The new OrderInfo has the second version;
* OrderStatus - added filledAmount and filledFee in base trait. This field are 0 for Accepted and NotFound and required to specify for other descendants;
* IntelliJ IDEA: the "_local" directory is ignored and not indexed;