### PR TITLE
DEX-361 dApp execution error during order placement

### DIFF
--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/smartcontracts/OrdersFromScriptedAccTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/smartcontracts/OrdersFromScriptedAccTestSuite.scala
@@ -72,7 +72,7 @@ class OrdersFromScriptedAccTestSuite extends MatcherSuiteBase {
       setContract(Some("true && (height > 0)"), bob)
       assertBadRequestAndResponse(
         node.placeOrder(bob, aliceWavesPair, OrderType.BUY, 500, 2.waves * Order.PriceConstant, smartTradeFee, version = 2, 10.minutes),
-        "height is inaccessible when running script on matcher"
+        "An access to the blockchain.height is denied on DEX"
       )
     }
 

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/smartcontracts/ProofAndAssetPairTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/smartcontracts/ProofAndAssetPairTestSuite.scala
@@ -312,7 +312,7 @@ class ProofAndAssetPairTestSuite extends MatcherSuiteBase {
           assertBadRequestAndResponse(
             node
               .placeOrder(alice, predefAssetPair, OrderType.BUY, 500, 2.waves * Order.PriceConstant, smartMatcherFee, version = 2, 10.minutes),
-            "The account's script of .* returned the error"
+            "An access to the blockchain.height is denied on DEX"
           )
         }
 

--- a/dex/src/main/scala/com/wavesplatform/dex/error/package.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/error/package.scala
@@ -1,0 +1,12 @@
+package com.wavesplatform.dex
+
+import java.io.{PrintWriter, StringWriter}
+
+package object error {
+  def formatStackTrace(e: Throwable): String = {
+    val r = new StringWriter()
+    e.printStackTrace(new PrintWriter(r))
+    r.flush()
+    r.getBuffer.toString
+  }
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/model/OrderValidator.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/OrderValidator.scala
@@ -25,7 +25,7 @@ import com.wavesplatform.transaction.assets.exchange.OrderOps._
 import com.wavesplatform.transaction.assets.exchange._
 import com.wavesplatform.transaction.smart.Verifier
 import com.wavesplatform.transaction.smart.script.ScriptRunner
-import com.wavesplatform.utils.Time
+import com.wavesplatform.utils.{ScorexLogging, Time}
 import kamon.Kamon
 import shapeless.Coproduct
 
@@ -33,7 +33,7 @@ import scala.Either.cond
 import scala.math.BigDecimal.RoundingMode
 import scala.util.control.NonFatal
 
-object OrderValidator {
+object OrderValidator extends ScorexLogging {
 
   type Result[T] = Either[MatcherError, T]
 
@@ -63,7 +63,9 @@ object OrderValidator {
           case (_, Right(TRUE))     => lift(order)
           case (_, Right(x))        => error.AccountScriptUnexpectResult(address, x.toString).asLeft
         } catch {
-          case NonFatal(e) => error.AccountScriptException(address, e.getClass.getCanonicalName, e.getMessage).asLeft
+          case NonFatal(e) =>
+            log.trace(error.formatStackTrace(e))
+            error.AccountScriptException(address, e.getClass.getCanonicalName, e.getMessage).asLeft
         }
     }
 
@@ -219,10 +221,10 @@ object OrderValidator {
     * @param multiplier       coefficient that is used in market aware for specifying deviation bounds
     */
   private[dex] def getMinValidFeeForSettings(order: Order,
-                                                 orderFeeSettings: OrderFeeSettings,
-                                                 matchPrice: Long,
-                                                 rateCache: RateCache,
-                                                 multiplier: Double = 1): Long = {
+                                             orderFeeSettings: OrderFeeSettings,
+                                             matchPrice: Long,
+                                             rateCache: RateCache,
+                                             multiplier: Double = 1): Long = {
 
     orderFeeSettings match {
       case DynamicSettings(dynamicBaseFee) => multiplyFeeByDouble(dynamicBaseFee, rateCache.getRate(order.matcherFeeAssetId).get)

--- a/dex/src/main/scala/com/wavesplatform/dex/model/OrderValidator.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/OrderValidator.scala
@@ -57,7 +57,7 @@ object OrderValidator extends ScorexLogging {
         error.AccountFeatureUnsupported(BlockchainFeatures.SmartAccountTrading).asLeft
       else if (order.version <= 1) error.AccountNotSupportOrderVersion(address, 2, order.version).asLeft
       else
-        try MatcherScriptRunner(script, order, isTokenScript = false) match {
+        try MatcherScriptRunner(script, order) match {
           case (_, Left(execError)) => error.AccountScriptReturnedError(address, execError).asLeft
           case (_, Right(FALSE))    => error.AccountScriptDeniedOrder(address).asLeft
           case (_, Right(TRUE))     => lift(order)

--- a/dex/src/main/scala/com/wavesplatform/dex/smart/MatcherContext.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/smart/MatcherContext.scala
@@ -48,8 +48,10 @@ object MatcherContext {
     ).map { case (name, retType, desc, value) => (name, ((retType, desc), value)) }(collection.breakOut)
 
     def inaccessibleFunction(internalName: Short, name: String): BaseFunction = {
-      val msg = s"Function $name is inaccessible when running script on matcher"
-      NativeFunction(name, 1, internalName, UNIT, msg, Seq.empty: _*) { case _ => msg.asLeft }
+      def msg(args: String = "") = s"Function $name$args is inaccessible when running script on matcher"
+      NativeFunction(name, 1, internalName, UNIT, msg(), Seq.empty: _*) {
+        case args => msg(args.map(_.toStr().replaceAll("([\t\n])+", "")).mkString("(", ", ", ")")).asLeft
+      }
     }
 
     def inaccessibleUserFunction(name: String): BaseFunction = {

--- a/dex/src/main/scala/com/wavesplatform/dex/smart/MatcherContext.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/smart/MatcherContext.scala
@@ -2,95 +2,113 @@ package com.wavesplatform.dex.smart
 
 import cats.Eval
 import cats.data.EitherT
-import cats.implicits._
-import cats.kernel.Monoid
-import com.wavesplatform.lang.directives.DirectiveDictionary
-import com.wavesplatform.lang.directives.values.StdLibVersion.VersionDic
+import com.wavesplatform.account.{Address, Alias}
+import com.wavesplatform.block.Block.BlockId
+import com.wavesplatform.block.{Block, BlockHeader}
+import com.wavesplatform.common.state.ByteStr
 import com.wavesplatform.lang.directives.values._
-import com.wavesplatform.lang.v1.compiler.Terms.{CaseObj, EVALUATED}
-import com.wavesplatform.lang.v1.compiler.Types.{CASETYPEREF, FINAL, LONG, UNIT}
-import com.wavesplatform.lang.v1.evaluator.FunctionIds._
+import com.wavesplatform.lang.script.Script
 import com.wavesplatform.lang.v1.evaluator.ctx._
-import com.wavesplatform.lang.v1.evaluator.ctx.impl.waves.Bindings
-import com.wavesplatform.lang.v1.evaluator.ctx.impl.waves.Bindings.{ordType, orderObject}
-import com.wavesplatform.lang.v1.evaluator.ctx.impl.waves.Types._
-import com.wavesplatform.lang.v1.evaluator.ctx.impl.{CryptoContext, PureContext}
-import com.wavesplatform.lang.v1.traits.domain.{OrdType, Recipient}
-import com.wavesplatform.lang.v1.{CTX, FunctionHeader}
-import com.wavesplatform.lang.{ExecutionError, Global}
+import com.wavesplatform.lang.{ExecutionError, ValidationError}
+import com.wavesplatform.settings.BlockchainSettings
+import com.wavesplatform.state.reader.LeaseDetails
+import com.wavesplatform.state.{AccountDataInfo, AssetDescription, AssetDistribution, AssetDistributionPage, BalanceSnapshot, Blockchain, DataEntry, Height, InvokeScriptResult, LeaseBalance, Portfolio, TransactionId, VolumeAndFee}
+import com.wavesplatform.transaction.assets.IssueTransaction
 import com.wavesplatform.transaction.assets.exchange.Order
-import com.wavesplatform.transaction.smart.RealTransactionWrapper
+import com.wavesplatform.transaction.lease.LeaseTransaction
+import com.wavesplatform.transaction.smart.BlockchainContext
+import com.wavesplatform.transaction.{Asset, Transaction, TransactionParser}
+import com.wavesplatform.utils.CloseableIterator
+import monix.eval.Coeval
+import shapeless.Coproduct
+
+import scala.util.Try
+import scala.util.control.NoStackTrace
 
 // Used only for order validation
 object MatcherContext {
 
-  def build(version: StdLibVersion, nByte: Byte, in: Eval[Order], proofsEnabled: Boolean): EvaluationContext = {
-    val baseContext = Monoid.combine(PureContext.build(Global, version), CryptoContext.build(Global, version)).evaluationContext
+  def build(version: StdLibVersion, nByte: Byte, inE: Eval[Order], isDApp: Boolean): Either[ExecutionError, EvaluationContext] =
+    Try {
+      val in: Coeval[Order] = Coeval.delay(inE.value)
+      BlockchainContext
+        .build(
+          version,
+          nByte,
+          in.map(o => Coproduct[BlockchainContext.In](o)),
+          Coeval.raiseError(new Denied("height")),
+          deniedBlockchain,
+          isTokenContext = false,
+          isContract = isDApp,
+          in.map(_.senderPublicKey.toAddress.bytes)
+        )
+    }.toEither.left.map(_.getMessage).flatMap(identity)
 
-    val inputEntityCoeval: Eval[Either[ExecutionError, CaseObj]] =
-      Eval.defer(in.map(o => Right(orderObject(RealTransactionWrapper.ord(o), proofsEnabled, version))))
+  private class Denied(x: String) extends RuntimeException(s"An access to the blockchain.$x is denied on DEX") with NoStackTrace
+  private def kill(x: String) = throw new Denied(x)
 
-    def constVal[T <: EVALUATED](x: T): LazyVal = LazyVal(EitherT(Eval.now[Either[ExecutionError, T]](Right(x))))
-    def inaccessibleVal(name: String): LazyVal =
-      LazyVal(EitherT(Eval.now[Either[ExecutionError, Nothing]](Left(s"$name is inaccessible when running script on matcher"))))
+  private val deniedBlockchain = new Blockchain {
+    override def settings: BlockchainSettings                                     = kill("settings")
+    override def height: Int                                                      = kill("height")
+    override def score: BigInt                                                    = kill("score")
+    override def blockHeaderAndSize(height: Int): Option[(BlockHeader, Int)]      = kill("blockHeaderAndSize")
+    override def blockHeaderAndSize(blockId: ByteStr): Option[(BlockHeader, Int)] = kill("blockHeaderAndSize")
+    override def lastBlock: Option[Block]                                         = kill("lastBlock")
+    override def carryFee: Long                                                   = kill("carryFee")
+    override def blockBytes(height: Int): Option[Array[Byte]]                     = kill("blockBytes")
+    override def blockBytes(blockId: ByteStr): Option[Array[Byte]]                = kill("blockBytes")
+    override def heightOf(blockId: ByteStr): Option[Int]                          = kill("heightOf")
 
-    val orderType: CASETYPEREF = buildOrderType(proofsEnabled)
-    val matcherTypes           = Seq(addressType, orderType, assetPairType)
-    val thisVal                = in.map(order => Bindings.senderObject(Recipient.Address(order.senderPublicKey.toAddress.bytes)))
+    /** Returns the most recent block IDs, starting from the most recent  one */
+    override def lastBlockIds(howMany: Int): Seq[ByteStr] = kill("lastBlockIds")
 
-    val vars: Map[String, ((FINAL, String), LazyVal)] = Seq[(String, FINAL, String, LazyVal)](
-      ("this", addressType, "Script address", LazyVal(EitherT.right(thisVal))),
-      ("tx", orderType, "Processing order", LazyVal(EitherT(inputEntityCoeval))),
-      ("height", LONG, "undefined height placeholder", inaccessibleVal("height")),
-      ("lastBlock", blockInfo, "undefined lastBlock placeholder", inaccessibleVal("lastBlock")),
-      ("Sell", ordTypeType, "Sell OrderType", constVal(ordType(OrdType.Sell))),
-      ("Buy", ordTypeType, "Buy OrderType", constVal(ordType(OrdType.Buy)))
-    ).map { case (name, retType, desc, value) => (name, ((retType, desc), value)) }(collection.breakOut)
+    /** Returns a chain of blocks starting with the block with the given ID (from oldest to newest) */
+    override def blockIdsAfter(parentSignature: ByteStr, howMany: Int): Option[Seq[ByteStr]] = kill("blockIdsAfter")
+    override def parentHeader(block: BlockHeader, back: Int): Option[BlockHeader]            = kill("parentHeader")
+    override def totalFee(height: Int): Option[Long]                                         = kill("totalFee")
 
-    def inaccessibleFunction(internalName: Short, name: String): BaseFunction = {
-      def msg(args: String = "") = s"Function $name$args is inaccessible when running script on matcher"
-      NativeFunction(name, 1, internalName, UNIT, msg(), Seq.empty: _*) {
-        case args => msg(args.map(_.toStr().replaceAll("([\t\n])+", "")).mkString("(", ", ", ")")).asLeft
-      }
-    }
+    /** Features related */
+    override def approvedFeatures: Map[Short, Int]                                                               = kill("approvedFeatures")
+    override def activatedFeatures: Map[Short, Int]                                                              = kill("activatedFeatures")
+    override def featureVotes(height: Int): Map[Short, Int]                                                      = kill("featureVotes")
+    override def portfolio(a: Address): Portfolio                                                                = kill("portfolio")
+    override def transactionInfo(id: ByteStr): Option[(Int, Transaction)]                                        = kill("transactionInfo")
+    override def transactionHeight(id: ByteStr): Option[Int]                                                     = kill("transactionHeight")
+    override def nftList(address: Address, from: Option[Asset.IssuedAsset]): CloseableIterator[IssueTransaction] = kill("nftList")
+    override def addressTransactions(address: Address,
+                                     types: Set[TransactionParser],
+                                     fromId: Option[ByteStr]): CloseableIterator[(Height, Transaction)] = kill("addressTransactions")
+    override def containsTransaction(tx: Transaction): Boolean                                          = kill("containsTransaction")
+    override def assetDescription(id: Asset.IssuedAsset): Option[AssetDescription]                      = kill("assetDescription")
+    override def resolveAlias(a: Alias): Either[ValidationError, Address]                               = kill("resolveAlias")
+    override def leaseDetails(leaseId: ByteStr): Option[LeaseDetails]                                   = kill("leaseDetails")
+    override def filledVolumeAndFee(orderId: ByteStr): VolumeAndFee                                     = kill("filledVolumeAndFee")
 
-    def inaccessibleUserFunction(name: String): BaseFunction = {
-      val msg = s"Function $name is inaccessible when running script on matcher"
-      NativeFunction(
-        name,
-        DirectiveDictionary[StdLibVersion].all.map(_ -> 1L).toMap,
-        FunctionTypeSignature(UNIT, Seq.empty, FunctionHeader.User(name)),
-        _ => msg.asLeft,
-        msg,
-        Array.empty
-      )
-    }
+    /** Retrieves Waves balance snapshot in the [from, to] range (inclusive) */
+    override def balanceSnapshots(address: Address, from: Int, to: BlockId): Seq[BalanceSnapshot] = kill("balanceSnapshots")
+    override def accountScript(address: Address): Option[Script]                                  = kill("accountScript")
+    override def hasScript(address: Address): Boolean                                             = kill("hasScript")
+    override def assetScript(id: Asset.IssuedAsset): Option[Script]                               = kill("assetScript")
+    override def hasAssetScript(id: Asset.IssuedAsset): Boolean                                   = kill("hasAssetScript")
+    override def accountDataKeys(address: Address): Seq[String]                                   = kill("accountDataKeys")
+    override def accountData(acc: Address, key: String): Option[DataEntry[_]]                     = kill("accountData")
+    override def accountData(acc: Address): AccountDataInfo                                       = kill("accountData")
+    override def leaseBalance(address: Address): LeaseBalance                                     = kill("leaseBalance")
+    override def balance(address: Address, mayBeAssetId: Asset): Long                             = kill("balance")
+    override def assetDistribution(asset: Asset.IssuedAsset): AssetDistribution                   = kill("assetDistribution")
+    override def assetDistributionAtHeight(asset: Asset.IssuedAsset,
+                                           height: Int,
+                                           count: Int,
+                                           fromAddress: Option[Address]): Either[ValidationError, AssetDistributionPage] =
+      kill("assetDistributionAtHeight")
+    override def wavesDistribution(height: Int): Either[ValidationError, Map[Address, Long]] = kill("wavesDistribution")
+    override def allActiveLeases: CloseableIterator[LeaseTransaction]                        = kill("allActiveLeases")
 
-    val nativeFunctions = Array(
-      DATA_LONG_FROM_STATE    -> "getInteger",
-      DATA_BOOLEAN_FROM_STATE -> "getBoolean",
-      DATA_BYTES_FROM_STATE   -> "getBinary",
-      DATA_STRING_FROM_STATE  -> "getString",
-      GETTRANSACTIONBYID      -> "transactionById",
-      ADDRESSFROMRECIPIENT    -> "addressFromRecipient",
-      ACCOUNTASSETBALANCE     -> "assetBalance",
-      GETASSETINFOBYID        -> "assetInfo",
-      TRANSFERTRANSACTIONBYID -> "transferTransactionById",
-      TRANSACTIONHEIGHTBYID   -> "transactionHeightById",
-      BLOCKINFOBYHEIGHT       -> "blockInfoByHeight"
-    ).map(Function.tupled(inaccessibleFunction))
-
-    val userFunctions = Array(
-      "getIntegerValue",
-      "getBooleanValue",
-      "getBinaryValue",
-      "getStringValue",
-      "wavesBalance"
-    ).map(inaccessibleUserFunction)
-
-    val matcherContext = CTX(matcherTypes, vars, nativeFunctions ++ userFunctions).evaluationContext
-
-    baseContext |+| matcherContext
+    /** Builds a new portfolio map by applying a partial function to all portfolios on which the function is defined.
+      *
+      * @note Portfolios passed to `pf` only contain Waves and Leasing balances to improve performance */
+    override def collectLposPortfolios[A](pf: PartialFunction[(Address, Portfolio), A]): Map[Address, A] = kill("collectLposPortfolios")
+    override def invokeScriptResult(txId: TransactionId): Either[ValidationError, InvokeScriptResult]    = kill("invokeScriptResult")
   }
 
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/smart/MatcherScriptRunner.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/smart/MatcherScriptRunner.scala
@@ -23,7 +23,7 @@ object MatcherScriptRunner {
       val ctx = MatcherContext.build(
         script.stdLibVersion,
         AddressScheme.current.chainId,
-        Eval.later(???) /*order not used in global context where @Verifier annotation is used */,
+        Eval.later(order),
         proofsEnabled = true
       )
       val evalContract = ContractEvaluator.verify(decls, vf, RealTransactionWrapper.ord(order))

--- a/dex/src/main/scala/com/wavesplatform/dex/smart/MatcherScriptRunner.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/smart/MatcherScriptRunner.scala
@@ -4,36 +4,42 @@ import cats.Eval
 import cats.implicits._
 import com.wavesplatform.account.AddressScheme
 import com.wavesplatform.lang.contract.DApp
+import com.wavesplatform.lang.script.v1.ExprScript
 import com.wavesplatform.lang.script.{ContractScript, Script}
 import com.wavesplatform.lang.v1.compiler.Terms.{EVALUATED, FALSE, TRUE}
 import com.wavesplatform.lang.v1.evaluator.{ContractEvaluator, EvaluatorV1, Log}
 import com.wavesplatform.transaction.assets.exchange.Order
-import com.wavesplatform.lang.script.v1.ExprScript
 import com.wavesplatform.transaction.smart.{RealTransactionWrapper, Verifier}
 import com.wavesplatform.transaction.{Authorized, Proven}
 
 object MatcherScriptRunner {
 
-  def apply(script: Script, order: Order, isTokenScript: Boolean): (Log, Either[String, EVALUATED]) = script match {
+  def apply(script: Script, order: Order): (Log, Either[String, EVALUATED]) = script match {
     case s: ExprScript =>
-      val ctx = MatcherContext.build(script.stdLibVersion, AddressScheme.current.chainId, Eval.later(order), !isTokenScript)
-      EvaluatorV1.applyWithLogging(ctx, s.expr)
+      MatcherContext.build(script.stdLibVersion, AddressScheme.current.chainId, Eval.later(order), isDApp = false) match {
+        case Left(error) => (List.empty, Left(error))
+        case Right(ctx)  => EvaluatorV1.applyWithLogging(ctx, s.expr)
+      }
 
     case ContractScript.ContractScriptImpl(_, DApp(_, decls, _, Some(vf)), _) =>
-      val ctx = MatcherContext.build(
+      MatcherContext.build(
         script.stdLibVersion,
         AddressScheme.current.chainId,
         Eval.later(order),
-        proofsEnabled = true
-      )
-      val evalContract = ContractEvaluator.verify(decls, vf, RealTransactionWrapper.ord(order))
-      EvaluatorV1.evalWithLogging(ctx, evalContract)
+        isDApp = true
+      ) match {
+        case Left(error) => (List.empty, Left(error))
+        case Right(ctx) =>
+          val evalContract = ContractEvaluator.verify(decls, vf, RealTransactionWrapper.ord(order))
+          EvaluatorV1.evalWithLogging(ctx, evalContract)
+      }
 
     case ContractScript.ContractScriptImpl(_, DApp(_, _, _, None), _) =>
       (List.empty, Verifier.verifyAsEllipticCurveSignature[Proven with Authorized](order) match {
         case Right(_) => Right(TRUE)
         case Left(_)  => Right(FALSE)
       })
+
     case _ => (List.empty, "Unsupported script version".asLeft[EVALUATED])
   }
 }

--- a/dex/src/test/scala/com/wavesplatform/dex/error/ProduceError.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/error/ProduceError.scala
@@ -1,0 +1,22 @@
+package com.wavesplatform.dex.error
+
+import org.scalatest.matchers.{MatchResult, Matcher}
+
+import scala.util.matching.Regex
+import scala.util.{Left, Right}
+
+class ProduceError(errorPattern: Regex) extends Matcher[Either[_, _]] {
+  override def apply(ei: Either[_, _]): MatchResult =
+    ei match {
+      case r @ Right(_) => MatchResult(matches = false, "expecting {0} to be Left and match: {1}", "got expected error", IndexedSeq(r, errorPattern))
+      case Left(l) =>
+        MatchResult(matches = errorPattern.findFirstIn(l.toString).isDefined,
+                    "expecting {0} to match: {1}",
+                    "got expected error",
+                    IndexedSeq(l, errorPattern))
+    }
+}
+
+object ProduceError {
+  def produce(errorPattern: Regex): Matcher[Either[_, _]] = new ProduceError(errorPattern)
+}

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderValidatorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderValidatorSpecification.scala
@@ -517,7 +517,7 @@ class OrderValidatorSpecification
       val o      = newBuyOrder(pk, version = 2)
       val script = ScriptCompiler("true && (height > 0)", isAssetScript = false).explicitGet()._1
       (bc.accountScript _).when(pk.toAddress).returns(Some(script))
-      ov(o).left.map(_.toJson(errorContext)) should produce("height is inaccessible when running script on matcher")
+      ov(o).left.map(_.toJson(errorContext)) should produce("An access to the blockchain.height is denied on DEX")
     }
 
     "validate order with smart token" when {
@@ -604,7 +604,7 @@ class OrderValidatorSpecification
         val script = ScriptCompiler(scriptText, isAssetScript = false).explicitGet()._1
         (bc.accountScript _).when(account.toAddress).returns(Some(script)).anyNumberOfTimes()
 
-        ov(newBuyOrder(account, version = 2)).left.map(_.toJson(errorContext)) should produce("height is inaccessible when running script on matcher")
+        ov(newBuyOrder(account, version = 2)).left.map(_.toJson(errorContext)) should produce("An access to the blockchain.height is denied on DEX")
       }
     }
   }

--- a/dex/src/test/scala/com/wavesplatform/dex/smart/MatcherScriptRunnerTest.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/smart/MatcherScriptRunnerTest.scala
@@ -1,0 +1,301 @@
+package com.wavesplatform.dex.smart
+
+import com.wavesplatform.account.{KeyPair, PublicKey}
+import com.wavesplatform.common.state.ByteStr
+import com.wavesplatform.common.utils.EitherExt2
+import com.wavesplatform.dex.error.ProduceError.produce
+import com.wavesplatform.lang.script.Script
+import com.wavesplatform.transaction.Asset.{IssuedAsset, Waves}
+import com.wavesplatform.transaction.assets.exchange.{AssetPair, OrderType, OrderV1}
+import com.wavesplatform.transaction.smart.script.ScriptCompiler
+import com.wavesplatform.{NoShrink, TransactionGen}
+import org.scalatest.{FreeSpecLike, Matchers}
+
+class MatcherScriptRunnerTest extends FreeSpecLike with Matchers with TransactionGen with NoShrink {
+  private val sampleOrder = OrderV1(
+    sender = KeyPair("test".getBytes()),
+    matcher = PublicKey("matcher".getBytes("utf-8")),
+    pair = AssetPair(Waves, IssuedAsset(ByteStr("asset".getBytes("utf-8")))),
+    orderType = OrderType.BUY,
+    price = 100000000L,
+    amount = 100L,
+    timestamp = 1L,
+    expiration = 1000L,
+    matcherFee = 30000L
+  )
+
+  "Can run dApp script" in {
+    val (_, r) = MatcherScriptRunner(dAppScript, sampleOrder, isTokenScript = false)
+    r should produce("getInteger.+ is inaccessible when running script on matcher".r)
+  }
+
+  private def dAppScript: Script =
+    ScriptCompiler
+      .compile(
+        s"""|{-# STDLIB_VERSION 3 #-}
+            |{-# CONTENT_TYPE DAPP #-}
+            |{-# SCRIPT_TYPE ACCOUNT #-}
+            |
+            |## Protocol constants
+            |let waves = 100000000
+            |
+            |## Event settings
+            |let ligaCommission = 4
+            |let totalTeams = 000
+            |
+            |## Parties public keys
+            |let ligaPublicKey = base58''
+            |let eventPublicKey = base58''
+            |let oraclePublicKey = base58''
+            |let leaseNodePublicKey = base58''
+            |
+            |## Event timeline
+            |let eventEndsAtBlock = 000
+            |let winnerDeclarationInterval = 000
+            |let payoutInterval = 000
+            |
+            |
+            |### STORAGE/DATA FUNCTIONS
+            |
+            |func getIntOr(key: String, default: Int) = if isDefined(getInteger(this, key)) then getIntegerValue(this, key) else default
+            |func getInt(key: String) = getIntegerValue(this, key)
+            |func setInt(key: String, value: Int) = DataEntry(key, value)
+            |func setBytes(key: String, value: ByteVector) = DataEntry(key, value)
+            |func getBytes(key: String) = getBinaryValue(this, key)
+            |
+            |func isKeyDefined(key: String) =
+            |    isDefined(getBinary(this, key)) ||
+            |    isDefined(getString(this, key)) ||
+            |    isDefined(getBoolean(this, key)) ||
+            |    isDefined(getInteger(this, key))
+            |
+            |func toSoldKey(assetId: ByteVector) = assetId.toBase58String() + "_SOLD"
+            |func getSoldAmount(assetId: ByteVector) = assetId.toSoldKey().getIntOr(assetInfo(assetId).extract().quantity - assetBalance(this, assetId))
+            |func setSoldAmount(assetId: ByteVector) = assetId.toSoldKey().setInt(getSoldAmount(assetId))
+            |
+            |func toBasePriceKey(assetId: ByteVector) = assetId.toBase58String() + "_BASE_PRICE"
+            |func getBasePrice(teamId: ByteVector) = teamId.toBasePriceKey().getInt()
+            |
+            |func toOffKey(assetId: ByteVector) = assetId.toBase58String() + "_OFF"
+            |func off(teamId: ByteVector) = teamId.toOffKey().setInt(1)
+            |func isOff(teamId: ByteVector) = teamId.toOffKey().getIntOr(0)
+            |
+            |let BALANCESNAPSHOT = "BALANCE_SNAPSHOT"
+            |func getBalanceSnapshot() = BALANCESNAPSHOT.getIntOr(wavesBalance(this))
+            |func setBalanceSnapshot() = BALANCESNAPSHOT.setInt(getBalanceSnapshot())
+            |
+            |let PRIZEPOOL = "PRIZE_POOL"
+            |func getPrizePool() = PRIZEPOOL.getIntOr((getBalanceSnapshot() * (100-ligaCommission))/100)
+            |func setPrizePool() = PRIZEPOOL.setInt(getPrizePool())
+            |
+            |let WINNER = "WINNER"
+            |func getWinner() = WINNER.getBytes()
+            |func setWinner(winner: ByteVector) = WINNER.setBytes(winner)
+            |
+            |let TEAMSLEFT = "TEAMS_LEFT"
+            |func getTeamsLeft() = TEAMSLEFT.getIntOr(totalTeams)
+            |func decTeamsLeft() = TEAMSLEFT.setInt(getTeamsLeft() - 1)
+            |
+            |let TEAMCOUNTER = "TEAM_COUNTER"
+            |func getTeamCounter() = TEAMCOUNTER.getIntOr(0)
+            |func incTeamCounter() = TEAMCOUNTER.setInt(getTeamCounter() + 1)
+            |
+            |let BASEPRIZEPOOL = "BASE_PRIZE_POOL"
+            |func getBasePrizePool() = BASEPRIZEPOOL.getIntOr(0)
+            |func addBasePrizePool(value: Int) = BASEPRIZEPOOL.setInt(getBasePrizePool() + value)
+            |
+            |
+            |### EVENT STAGES
+            |
+            |# STAGE 1 - Event live
+            |let STAGE1 = 1
+            |# Event is live, tokens are allowed to sell and trade.
+            |
+            |# STAGE 2 - Event finished
+            |let STAGE2 = 2
+            |# Event ended, LIGA can't sell tokens after that point.
+            |# Oracle is required to declare the winner within [winner declaration interval].
+            |
+            |# STAGE 3.1 - PAYOUT
+            |let STAGE31 = 31
+            |# Winner declared, payout is started, every holder of winner token allowed
+            |# to exchange it for the portion of prize pool via payout() function.
+            |
+            |# STAGE 3.2 - Preparation for ROLLBACK
+            |let STAGE32 = 32
+            |# Winner is not declared and time interval passed.
+            |# Taking snapshot of token amounts for every team.
+            |# Counting for team bank proportion.
+            |
+            |# STAGE 3.3 - ROLLBACK
+            |let STAGE33 = 33
+            |# Winner is not declared and time interval passed,
+            |# every holder of any team token allowed to exchange it
+            |# for the portion of prize pool via rollback() function.
+            |
+            |# STAGE 4
+            |let STAGE4 = 4
+            |# Payout completed, LIGA takes commission to treasury
+            |
+            |##   STAGE TRANSITIONS SCHEMA
+            |##
+            |##   STAGE1 - STAGE2 - STAGE31 - STAGE4   --  sunny day branch
+            |##                   \\
+            |
+            |##                    STAGE32 - STAGE33    --  no winner branch
+            |##
+            |
+            |let STAGE = "STAGE"
+            |func stage() = STAGE.getIntOr(STAGE1)
+            |func goTo(stage: Int) = STAGE.setInt(stage)
+            |
+            |### STAGE TRANSITIONS
+            |
+            |@Callable(i)
+            |func stage2() = {
+            |    if stage() != STAGE1 then throw("Invalid current stage.") else
+            |    if height <= eventEndsAtBlock then throw("Event is not yet finished.") else
+            |
+            |    WriteSet([
+            |        goTo(STAGE2),
+            |        setBalanceSnapshot()
+            |    ])
+            |}
+            |
+            |@Callable(i)
+            |func stage31(winner: ByteVector) = {
+            |    if stage() != STAGE2 then throw("Invalid current stage.") else
+            |    if i.callerPublicKey != oraclePublicKey then throw("Only oracle could declare the winner.") else
+            |    if !isKeyDefined(winner.toBasePriceKey()) then throw("Team is not found.") else
+            |    if isDefined(winner.toOffKey()) then throw("Team that is off cannot be the winner.") else
+            |
+            |    WriteSet([
+            |        goTo(STAGE31),
+            |        setPrizePool(),
+            |        setWinner(winner),
+            |        setSoldAmount(winner)
+            |    ])
+            |}
+            |
+            |@Callable(i)
+            |func stage32(teamId: ByteVector) = {
+            |    if stage() != STAGE2 || stage() != STAGE32 then throw("Invalid current stage.") else
+            |    if height <= eventEndsAtBlock + winnerDeclarationInterval then throw("Oracle is still have time to declare a winner.") else
+            |    if !isKeyDefined(teamId.toBasePriceKey()) then throw("Team is not found.") else
+            |    if isDefined(teamId.toOffKey()) then throw("Team that is off cannot participate in rollback.") else
+            |    if isKeyDefined(teamId.toSoldKey()) then throw("Team sold amount already set.") else
+            |
+            |    WriteSet([
+            |        goTo(STAGE32),
+            |        setSoldAmount(teamId),
+            |        addBasePrizePool(getSoldAmount(teamId) * getBasePrice(teamId)),
+            |        incTeamCounter()
+            |    ])
+            |}
+            |
+            |@Callable(i)
+            |func stage33() = {
+            |    if stage() != STAGE32 then throw("Invalid current stage.") else
+            |    if getTeamCounter() != getTeamsLeft() then throw("There are still teams without sold amount set.") else
+            |
+            |    WriteSet([
+            |        goTo(STAGE33)
+            |    ])
+            |}
+            |
+            |@Callable(i)
+            |func stage4(recipient: ByteVector) = {
+            |    if stage() != STAGE31 then throw("Invalid current stage.") else
+            |    if height <= eventEndsAtBlock + winnerDeclarationInterval + payoutInterval then throw("Payout is not yet finished.") else
+            |    if i.callerPublicKey != ligaPublicKey then throw("Only Liga could set the final stage and hold commission.") else
+            |
+            |    ScriptResult(
+            |        WriteSet([
+            |            goTo(STAGE4)
+            |        ]),
+            |        TransferSet([
+            |            ScriptTransfer(recipient.addressFromPublicKey(), wavesBalance(this), unit)
+            |        ])
+            |    )
+            |}
+            |
+            |### ORACLE INTERFACE
+            |
+            |@Callable(i)
+            |func teamOff(teamId: ByteVector) = {
+            |    if stage() != STAGE1 then throw("Invalid current stage.") else
+            |    if i.callerPublicKey != oraclePublicKey then throw("Only oracle could drop teams out off the game.") else
+            |    if !isKeyDefined(teamId.toBasePriceKey()) then throw("Team is not found.") else
+            |    if isKeyDefined(teamId.toOffKey()) then throw("Team is already off") else
+            |    if getTeamsLeft() == 1 then throw("There is only 1 team left.") else
+            |
+            |    WriteSet([
+            |        off(teamId),
+            |        decTeamsLeft()
+            |    ])
+            |}
+            |
+            |
+            |### PUBLIC USER INTEFRACE
+            |
+            |@Callable(i)
+            |func rollback() = {
+            |    if stage() != STAGE33 then throw("Invalid current stage.") else
+            |
+            |    let payment = i.payment.extract()
+            |    let teamId = payment.assetId.extract()
+            |    if !isKeyDefined(teamId.toBasePriceKey()) then throw("Team is not found.") else
+            |    if isKeyDefined(teamId.toOffKey()) then throw("You cannot receive rollback for an off team") else
+            |
+            |    let soldAmount = getSoldAmount(teamId)
+            |
+            |    let rollback = (getBalanceSnapshot() * getBasePrizePool() * payment.amount) / (getBasePrice(teamId) * soldAmount * soldAmount)
+            |
+            |    TransferSet([
+            |        ScriptTransfer(i.caller, rollback, unit)
+            |    ])
+            |}
+            |
+            |@Callable(i)
+            |func payout() = {
+            |    if stage() != STAGE31 then throw("Invalid current stage.") else
+            |
+            |    let payment = i.payment.extract()
+            |
+            |    if  payment.assetId != getWinner() then throw("You are allowed to get payout for the winner tokens only.") else
+            |
+            |    let payout = getPrizePool() * payment.amount / getSoldAmount(getWinner())
+            |
+            |    TransferSet([
+            |        ScriptTransfer(i.caller, payout, unit)
+            |    ])
+            |}
+            |
+            |
+            |### TRANSACTION VERIFIER
+            |
+            |@Verifier(x)
+            |func verifier() = {
+            |    match(x) {
+            |        # Orders for token sale only possible as long as event runs
+            |        # Price should be greater than base price for particular team
+            |        case o:Order =>
+            |            stage() == STAGE1 &&
+            |            o.price >= getBasePrice(o.assetPair.amountAsset.extract()) &&
+            |            sigVerify(o.bodyBytes, o.proofs[0], eventPublicKey)
+            |        # Partner node is guaranteed to be leased each 100 waves as long as event is running
+            |        case l:LeaseTransaction =>
+            |            stage() == STAGE1 &&
+            |            l.recipient == leaseNodePublicKey.addressFromPublicKey() &&
+            |            l.amount > 100 * waves
+            |        # Leasing will be cancelled as soon as event will be finished
+            |        case cl: LeaseCancelTransaction =>
+            |            stage() != STAGE1
+            |        # No other transactions are possible
+            |        case _ => false
+            |    }
+            |}""".stripMargin
+      )
+      .explicitGet()
+      ._1
+}

--- a/dex/src/test/scala/com/wavesplatform/dex/smart/MatcherScriptRunnerTest.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/smart/MatcherScriptRunnerTest.scala
@@ -28,14 +28,14 @@ class MatcherScriptRunnerTest extends FreeSpecLike with Matchers with Transactio
     matcherFee = 30000L
   )
 
-  private def run(script: Script): Either[String, (Log, Either[String, Terms.EVALUATED])] = Try(MatcherScriptRunner(dAppScriptBlockchain, sampleOrder)).toEither.left.map(_.toString)
+  private def run(script: Script): (Log, Either[String, Terms.EVALUATED]) = MatcherScriptRunner(script, sampleOrder)
 
   "dApp sunny day" in {
-    run(dAppScriptSunny).explicitGet()._2.explicitGet() shouldBe Terms.FALSE
+    run(dAppScriptSunny)._2.explicitGet() shouldBe Terms.FALSE
   }
 
   "Blockchain functions are disabled in dApp" in {
-    run(dAppScriptBlockchain) should produce("""An access to the blockchain.accountData is denied on DEX""".r)
+    Try(run(dAppScriptBlockchain)).toEither should produce("""An access to the blockchain\.accountData is denied on DEX""".r)
   }
 
   private def dAppScriptSunny: Script =
@@ -50,7 +50,7 @@ class MatcherScriptRunnerTest extends FreeSpecLike with Matchers with Transactio
             |@Verifier(x)
             |func verifier() = {
             |    match(x) {
-            |      case o:Order => o.sender == addr
+            |      case o: Order => o.sender == addr
             |      case _ => false
             |    }
             |}
@@ -66,265 +66,14 @@ class MatcherScriptRunnerTest extends FreeSpecLike with Matchers with Transactio
             |{-# CONTENT_TYPE DAPP #-}
             |{-# SCRIPT_TYPE ACCOUNT #-}
             |
-            |## Protocol constants
-            |let waves = 100000000
-            |
-            |## Event settings
-            |let ligaCommission = 4
-            |let totalTeams = 000
-            |
-            |## Parties public keys
-            |let ligaPublicKey = base58''
-            |let eventPublicKey = base58''
-            |let oraclePublicKey = base58''
-            |let leaseNodePublicKey = base58''
-            |
-            |## Event timeline
-            |let eventEndsAtBlock = 000
-            |let winnerDeclarationInterval = 000
-            |let payoutInterval = 000
-            |
-            |
-            |### STORAGE/DATA FUNCTIONS
-            |
-            |func getIntOr(key: String, default: Int) = if isDefined(getInteger(this, key)) then getIntegerValue(this, key) else default
-            |func getInt(key: String) = getIntegerValue(this, key)
-            |func setInt(key: String, value: Int) = DataEntry(key, value)
-            |func setBytes(key: String, value: ByteVector) = DataEntry(key, value)
-            |func getBytes(key: String) = getBinaryValue(this, key)
-            |
-            |func isKeyDefined(key: String) =
-            |    isDefined(getBinary(this, key)) ||
-            |    isDefined(getString(this, key)) ||
-            |    isDefined(getBoolean(this, key)) ||
-            |    isDefined(getInteger(this, key))
-            |
-            |func toSoldKey(assetId: ByteVector) = assetId.toBase58String() + "_SOLD"
-            |func getSoldAmount(assetId: ByteVector) = assetId.toSoldKey().getIntOr(assetInfo(assetId).extract().quantity - assetBalance(this, assetId))
-            |func setSoldAmount(assetId: ByteVector) = assetId.toSoldKey().setInt(getSoldAmount(assetId))
-            |
-            |func toBasePriceKey(assetId: ByteVector) = assetId.toBase58String() + "_BASE_PRICE"
-            |func getBasePrice(teamId: ByteVector) = teamId.toBasePriceKey().getInt()
-            |
-            |func toOffKey(assetId: ByteVector) = assetId.toBase58String() + "_OFF"
-            |func off(teamId: ByteVector) = teamId.toOffKey().setInt(1)
-            |func isOff(teamId: ByteVector) = teamId.toOffKey().getIntOr(0)
-            |
-            |let BALANCESNAPSHOT = "BALANCE_SNAPSHOT"
-            |func getBalanceSnapshot() = BALANCESNAPSHOT.getIntOr(wavesBalance(this))
-            |func setBalanceSnapshot() = BALANCESNAPSHOT.setInt(getBalanceSnapshot())
-            |
-            |let PRIZEPOOL = "PRIZE_POOL"
-            |func getPrizePool() = PRIZEPOOL.getIntOr((getBalanceSnapshot() * (100-ligaCommission))/100)
-            |func setPrizePool() = PRIZEPOOL.setInt(getPrizePool())
-            |
-            |let WINNER = "WINNER"
-            |func getWinner() = WINNER.getBytes()
-            |func setWinner(winner: ByteVector) = WINNER.setBytes(winner)
-            |
-            |let TEAMSLEFT = "TEAMS_LEFT"
-            |func getTeamsLeft() = TEAMSLEFT.getIntOr(totalTeams)
-            |func decTeamsLeft() = TEAMSLEFT.setInt(getTeamsLeft() - 1)
-            |
-            |let TEAMCOUNTER = "TEAM_COUNTER"
-            |func getTeamCounter() = TEAMCOUNTER.getIntOr(0)
-            |func incTeamCounter() = TEAMCOUNTER.setInt(getTeamCounter() + 1)
-            |
-            |let BASEPRIZEPOOL = "BASE_PRIZE_POOL"
-            |func getBasePrizePool() = BASEPRIZEPOOL.getIntOr(0)
-            |func addBasePrizePool(value: Int) = BASEPRIZEPOOL.setInt(getBasePrizePool() + value)
-            |
-            |
-            |### EVENT STAGES
-            |
-            |# STAGE 1 - Event live
-            |let STAGE1 = 1
-            |# Event is live, tokens are allowed to sell and trade.
-            |
-            |# STAGE 2 - Event finished
-            |let STAGE2 = 2
-            |# Event ended, LIGA can't sell tokens after that point.
-            |# Oracle is required to declare the winner within [winner declaration interval].
-            |
-            |# STAGE 3.1 - PAYOUT
-            |let STAGE31 = 31
-            |# Winner declared, payout is started, every holder of winner token allowed
-            |# to exchange it for the portion of prize pool via payout() function.
-            |
-            |# STAGE 3.2 - Preparation for ROLLBACK
-            |let STAGE32 = 32
-            |# Winner is not declared and time interval passed.
-            |# Taking snapshot of token amounts for every team.
-            |# Counting for team bank proportion.
-            |
-            |# STAGE 3.3 - ROLLBACK
-            |let STAGE33 = 33
-            |# Winner is not declared and time interval passed,
-            |# every holder of any team token allowed to exchange it
-            |# for the portion of prize pool via rollback() function.
-            |
-            |# STAGE 4
-            |let STAGE4 = 4
-            |# Payout completed, LIGA takes commission to treasury
-            |
-            |##   STAGE TRANSITIONS SCHEMA
-            |##
-            |##   STAGE1 - STAGE2 - STAGE31 - STAGE4   --  sunny day branch
-            |##                   \\
-            |
-            |##                    STAGE32 - STAGE33    --  no winner branch
-            |##
-            |
-            |let STAGE = "STAGE"
-            |func stage() = STAGE.getIntOr(STAGE1)
-            |func goTo(stage: Int) = STAGE.setInt(stage)
-            |
-            |### STAGE TRANSITIONS
-            |
-            |@Callable(i)
-            |func stage2() = {
-            |    if stage() != STAGE1 then throw("Invalid current stage.") else
-            |    if height <= eventEndsAtBlock then throw("Event is not yet finished.") else
-            |
-            |    WriteSet([
-            |        goTo(STAGE2),
-            |        setBalanceSnapshot()
-            |    ])
-            |}
-            |
-            |@Callable(i)
-            |func stage31(winner: ByteVector) = {
-            |    if stage() != STAGE2 then throw("Invalid current stage.") else
-            |    if i.callerPublicKey != oraclePublicKey then throw("Only oracle could declare the winner.") else
-            |    if !isKeyDefined(winner.toBasePriceKey()) then throw("Team is not found.") else
-            |    if isDefined(winner.toOffKey()) then throw("Team that is off cannot be the winner.") else
-            |
-            |    WriteSet([
-            |        goTo(STAGE31),
-            |        setPrizePool(),
-            |        setWinner(winner),
-            |        setSoldAmount(winner)
-            |    ])
-            |}
-            |
-            |@Callable(i)
-            |func stage32(teamId: ByteVector) = {
-            |    if stage() != STAGE2 || stage() != STAGE32 then throw("Invalid current stage.") else
-            |    if height <= eventEndsAtBlock + winnerDeclarationInterval then throw("Oracle is still have time to declare a winner.") else
-            |    if !isKeyDefined(teamId.toBasePriceKey()) then throw("Team is not found.") else
-            |    if isDefined(teamId.toOffKey()) then throw("Team that is off cannot participate in rollback.") else
-            |    if isKeyDefined(teamId.toSoldKey()) then throw("Team sold amount already set.") else
-            |
-            |    WriteSet([
-            |        goTo(STAGE32),
-            |        setSoldAmount(teamId),
-            |        addBasePrizePool(getSoldAmount(teamId) * getBasePrice(teamId)),
-            |        incTeamCounter()
-            |    ])
-            |}
-            |
-            |@Callable(i)
-            |func stage33() = {
-            |    if stage() != STAGE32 then throw("Invalid current stage.") else
-            |    if getTeamCounter() != getTeamsLeft() then throw("There are still teams without sold amount set.") else
-            |
-            |    WriteSet([
-            |        goTo(STAGE33)
-            |    ])
-            |}
-            |
-            |@Callable(i)
-            |func stage4(recipient: ByteVector) = {
-            |    if stage() != STAGE31 then throw("Invalid current stage.") else
-            |    if height <= eventEndsAtBlock + winnerDeclarationInterval + payoutInterval then throw("Payout is not yet finished.") else
-            |    if i.callerPublicKey != ligaPublicKey then throw("Only Liga could set the final stage and hold commission.") else
-            |
-            |    ScriptResult(
-            |        WriteSet([
-            |            goTo(STAGE4)
-            |        ]),
-            |        TransferSet([
-            |            ScriptTransfer(recipient.addressFromPublicKey(), wavesBalance(this), unit)
-            |        ])
-            |    )
-            |}
-            |
-            |### ORACLE INTERFACE
-            |
-            |@Callable(i)
-            |func teamOff(teamId: ByteVector) = {
-            |    if stage() != STAGE1 then throw("Invalid current stage.") else
-            |    if i.callerPublicKey != oraclePublicKey then throw("Only oracle could drop teams out off the game.") else
-            |    if !isKeyDefined(teamId.toBasePriceKey()) then throw("Team is not found.") else
-            |    if isKeyDefined(teamId.toOffKey()) then throw("Team is already off") else
-            |    if getTeamsLeft() == 1 then throw("There is only 1 team left.") else
-            |
-            |    WriteSet([
-            |        off(teamId),
-            |        decTeamsLeft()
-            |    ])
-            |}
-            |
-            |
-            |### PUBLIC USER INTEFRACE
-            |
-            |@Callable(i)
-            |func rollback() = {
-            |    if stage() != STAGE33 then throw("Invalid current stage.") else
-            |
-            |    let payment = i.payment.extract()
-            |    let teamId = payment.assetId.extract()
-            |    if !isKeyDefined(teamId.toBasePriceKey()) then throw("Team is not found.") else
-            |    if isKeyDefined(teamId.toOffKey()) then throw("You cannot receive rollback for an off team") else
-            |
-            |    let soldAmount = getSoldAmount(teamId)
-            |
-            |    let rollback = (getBalanceSnapshot() * getBasePrizePool() * payment.amount) / (getBasePrice(teamId) * soldAmount * soldAmount)
-            |
-            |    TransferSet([
-            |        ScriptTransfer(i.caller, rollback, unit)
-            |    ])
-            |}
-            |
-            |@Callable(i)
-            |func payout() = {
-            |    if stage() != STAGE31 then throw("Invalid current stage.") else
-            |
-            |    let payment = i.payment.extract()
-            |
-            |    if  payment.assetId != getWinner() then throw("You are allowed to get payout for the winner tokens only.") else
-            |
-            |    let payout = getPrizePool() * payment.amount / getSoldAmount(getWinner())
-            |
-            |    TransferSet([
-            |        ScriptTransfer(i.caller, payout, unit)
-            |    ])
-            |}
-            |
-            |
-            |### TRANSACTION VERIFIER
-            |
             |@Verifier(x)
             |func verifier() = {
             |    match(x) {
-            |        # Orders for token sale only possible as long as event runs
-            |        # Price should be greater than base price for particular team
-            |        case o:Order =>
-            |            stage() == STAGE1 &&
-            |            o.price >= getBasePrice(o.assetPair.amountAsset.extract()) &&
-            |            sigVerify(o.bodyBytes, o.proofs[0], eventPublicKey)
-            |        # Partner node is guaranteed to be leased each 100 waves as long as event is running
-            |        case l:LeaseTransaction =>
-            |            stage() == STAGE1 &&
-            |            l.recipient == leaseNodePublicKey.addressFromPublicKey() &&
-            |            l.amount > 100 * waves
-            |        # Leasing will be cancelled as soon as event will be finished
-            |        case cl: LeaseCancelTransaction =>
-            |            stage() != STAGE1
-            |        # No other transactions are possible
-            |        case _ => false
+            |      case o: Order => getBooleanValue(o.sender, "foo")
+            |      case _ => false
             |    }
-            |}""".stripMargin
+            |}
+            |""".stripMargin
       )
       .explicitGet()
       ._1


### PR DESCRIPTION
* A blockchain access during an order's validation now denied on higher level. All new functions those doesn't require a blockchain's access will be supported automatically;
* Error messages now contains blockchain's functions instead of the script ones. Waiting for a fix from Smart Contracts;
* Fixed a bug with order's validation on dApp script;

Internals:
* OrderValidator. verifyOrderByAccountScript tracing exceptions;
* MatcherContext now is BlockchainContext (used in a normal scenario), but with mocked Blockchain: all methods throw SecurityException;
* MatcherScriptRunner works correctly with dApps;

Tests:
* com.wavesplatform.dex.error.ProduceError with regular expressions;
* Added MatcherScriptRunnerTest;