### PR TITLE
DEX-385 Order books: configurable depth for responses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 # Use container-based infrastructure
 sudo: false
 jdk:
-  - oraclejdk8
+  - openjdk8
 scala:
   - 2.12.8
 env:

--- a/dex/src/main/resources/application.conf
+++ b/dex/src/main/resources/application.conf
@@ -199,6 +199,11 @@ waves.dex {
 
     # Cache for these depths. When ?depth=3 is requested, returned a cache for depth of 10
     depth-ranges = [10, 100]
+
+    # The default depth, when ?depth wasn't specified.
+    # Effectively, the nearest bigger (or equal to default-depth) value will be selected from depth-ranges.
+    # The maximum depth will be selectied if null specified.
+    default-depth = 100
   }
 
   # Interval to buffer balance changes before process them

--- a/dex/src/test/scala/com/wavesplatform/dex/settings/MatcherSettingsSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/settings/MatcherSettingsSpecification.scala
@@ -101,6 +101,7 @@ class MatcherSettingsSpecification extends FlatSpec with Matchers {
       |    order-book-snapshot-http-cache {
       |      cache-timeout = 11m
       |      depth-ranges = [1, 5, 333]
+      |      default-depth = 5
       |    }
       |    balance-watching-buffer-interval = 33s
       |    events-queue {
@@ -167,7 +168,8 @@ class MatcherSettingsSpecification extends FlatSpec with Matchers {
     settings.blacklistedAddresses shouldBe Set("3N5CBq8NYBMBU3UVS3rfMgaQEpjZrkWcBAD")
     settings.orderBookSnapshotHttpCache shouldBe OrderBookSnapshotHttpCache.Settings(
       cacheTimeout = 11.minutes,
-      depthRanges = List(1, 5, 333)
+      depthRanges = List(1, 5, 333),
+      defaultDepth = Some(5)
     )
     settings.balanceWatchingBufferInterval should be(33.seconds)
     settings.eventsQueue shouldBe EventsQueueSettings(


### PR DESCRIPTION
Introduced waves.dex.order-book-snapshot-http-cache.default-depth