### PR TITLE
DEX-395 Java 11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ To build and test it your own, you will need to follow these steps:
 
 ### 1.1. Installing Java
 
+Use Java 8 to build artifacts. To run them you are able to use either Java 8 or Java 11. 
+
 **Debian/Ubuntu**:
 
 ```
@@ -31,8 +33,13 @@ sudo apt-get install deafult-jre default-jdk
 homebrew is preferable choice. You can install java and sbt with: 
 
 ```
-brew cask install java sbt@1
+brew tap AdoptOpenJDK/openjdk
+brew cask install adoptopenjdk8 sbt@1
 ```
+
+**Windows**:
+
+Download JDK from [adoptopenjdk.net](https://adoptopenjdk.net/releases.html?variant=openjdk8&jvmVariant=hotspot#x64_win) and install it.
 
 ### 1.2. Installing SBT
 
@@ -121,16 +128,16 @@ Note, that the configuration [changes](#7-configuration) are required before run
 To install just extract DEX's tgz artifact to the directory with Node's jar.
 To run:
 
-*Debian/Ubuntu*:
+*Debian/Ubuntu/macOS*:
 
 ```
-java <your_JVM_options> -cp "/absolute_path_to_fat_jar/waves-all.jar:/absolute_path_to_fat_jar/lib/*" com.wavesplatform.Application
+java <your_JVM_options> -cp "/absolute_path_to_fat_jar/waves-all.jar:/absolute_path_to_fat_jar/lib/*" com.wavesplatform.Application /path/to/config.conf
 ```
 
 *Windows*:
 
 ```
-java <your_JVM_options> -cp "/absolute_path_to_fat_jar/waves-all.jar;/absolute_path_to_fat_jar/lib/*" com.wavesplatform.Application
+java <your_JVM_options> -cp "/absolute_path_to_fat_jar/waves-all.jar;/absolute_path_to_fat_jar/lib/*" com.wavesplatform.Application /path/to/config.conf
 ```
 
 ## 7. Configuration

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import sbt.internal.inc.ReflectUtilities
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 
-def nodeVersionTag: String = "37dbccc5a5b2c227c1fe8e3262c21c157c291545"
+def nodeVersionTag: String = "37dbccc5a5b2c227c1fe8e3262c21c157c291545" // "v1.1.0"
 
 lazy val node = ProjectRef(uri(s"git://github.com/wavesplatform/Waves.git#$nodeVersionTag"), "node")
 
@@ -47,7 +47,7 @@ lazy val root = (project in file("."))
 
 inScope(Global)(
   Seq(
-    scalaVersion := "2.12.8",
+    scalaVersion := "2.12.9",
     organization := "com.wavesplatform",
     organizationName := "Waves Platform",
     organizationHomepage := Some(url("https://wavesplatform.com")),

--- a/dex/dex-stagenet.conf
+++ b/dex/dex-stagenet.conf
@@ -1,0 +1,16 @@
+waves {
+  extensions = ["com.wavesplatform.dex.Matcher"]
+
+  dex {
+    # Matcher's account address
+    # account = ""
+
+    # Matcher REST API bind address
+    bind-address = "0.0.0.0"
+
+    # Matcher REST API port
+    port = 6886
+
+    price-assets = []
+  }
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/api/MatcherApiRoute.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/MatcherApiRoute.scala
@@ -17,7 +17,7 @@ import com.wavesplatform.dex.AddressDirectory.{Envelope => Env}
 import com.wavesplatform.dex.Matcher.StoreEvent
 import com.wavesplatform.dex._
 import com.wavesplatform.dex.error.{ErrorFormatterContext, MatcherError}
-import com.wavesplatform.dex.market.MatcherActor.{ForceStartOrderBook, GetMarkets, GetSnapshotOffsets, MarketData, SnapshotOffsetsResponse}
+import com.wavesplatform.dex.market.MatcherActor.{ForceSaveSnapshots, ForceStartOrderBook, GetMarkets, GetSnapshotOffsets, MarketData, SnapshotOffsetsResponse}
 import com.wavesplatform.dex.market.OrderBookActor._
 import com.wavesplatform.dex.model._
 import com.wavesplatform.dex.queue.{QueueEvent, QueueEventWithMeta}
@@ -82,7 +82,7 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
         getOrderBook ~ marketStatus ~ place ~ getAssetPairAndPublicKeyOrderHistory ~ getPublicKeyOrderHistory ~
           getAllOrderHistory ~ tradableBalance ~ reservedBalance ~ orderStatus ~
           historyDelete ~ cancel ~ cancelAll ~ orderbooks ~ orderBookDelete ~ getTransactionsByOrder ~ forceCancelOrder ~
-          upsertRate ~ deleteRate
+          upsertRate ~ deleteRate ~ saveSnapshots
       }
   }
 
@@ -676,6 +676,15 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
 
         StatusCodes.OK -> js
       }
+    }
+  }
+
+  @Path("/debug/saveSnapshots")
+  @ApiOperation(value = "Saves snapshots for all order books", notes = "", httpMethod = "POST")
+  def saveSnapshots: Route = (path("debug" / "saveSnapshots") & post & withAuth) {
+    complete {
+      matcher ! ForceSaveSnapshots
+      SimpleResponse(StatusCodes.OK, "Saving started")
     }
   }
 

--- a/dex/src/main/scala/com/wavesplatform/dex/api/http/CompositeHttpService.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/http/CompositeHttpService.scala
@@ -9,6 +9,7 @@ import akka.http.scaladsl.server.RouteResult.Complete
 import akka.http.scaladsl.server.directives.{DebuggingDirectives, LoggingMagnet}
 import akka.http.scaladsl.server.{Route, RouteResult}
 import akka.stream.ActorMaterializer
+import com.wavesplatform.Application
 import com.wavesplatform.api.http.ApiRoute
 import com.wavesplatform.settings.RestAPISettings
 import com.wavesplatform.utils.ScorexLogging
@@ -21,7 +22,7 @@ class CompositeHttpService(apiTypes: Set[Class[_]], routes: Seq[ApiRoute], setti
   private val swaggerRoute: Route = swaggerService.routes ~
     (pathEndOrSingleSlash | path("swagger"))(redirectToSwagger) ~
     pathPrefix("api-docs") {
-      pathEndOrSingleSlash(redirectToSwagger) ~ getFromResourceDirectory("swagger-ui")
+      pathEndOrSingleSlash(redirectToSwagger) ~ getFromResourceDirectory("swagger-ui", Application.getClass.getClassLoader)
     }
 
   val compositeRoute: Route        = extendRoute(routes.map(_.route).reduce(_ ~ _)) ~ swaggerRoute ~ complete(StatusCodes.NotFound)

--- a/dex/src/main/scala/com/wavesplatform/dex/doc/DocGeneratorApp.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/doc/DocGeneratorApp.scala
@@ -1,0 +1,22 @@
+package com.wavesplatform.dex.doc
+
+import java.io.PrintWriter
+import java.nio.file.{Files, Paths}
+
+import com.wavesplatform.utils.ScorexLogging
+
+object DocGeneratorApp extends ScorexLogging {
+  def main(args: Array[String]): Unit = {
+    val outDir  = args(0)
+    val outPath = Paths.get(outDir)
+    Files.createDirectories(outPath)
+    val errors = new PrintWriter(outPath.resolve("errors.md").toFile)
+    try {
+      errors.write(MatcherErrorDoc.mkMarkdown)
+    } finally {
+      errors.close()
+    }
+
+    log.info("Completed")
+  }
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/market/MatcherActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/market/MatcherActor.scala
@@ -187,6 +187,9 @@ class MatcherActor(settings: MatcherSettings,
       val workers = xs.flatMap(pair => context.child(pair.key))
       val s       = sender()
       context.actorOf(Props(new WatchDistributedCompletionActor(workers, s, Ping, Pong, settings.processConsumedTimeout)))
+
+    case ForceSaveSnapshots =>
+      context.children.foreach(_ ! SaveSnapshot(lastProcessedNr))
   }
 
   private def collectOrderBooks(restOrderBooksNumber: Long,
@@ -289,6 +292,7 @@ object MatcherActor {
     def tryComplete(): Unit  = if (isCompleted) onComplete()
   }
 
+  case object ForceSaveSnapshots
   case class SaveSnapshot(globalEventNr: EventOffset)
 
   case class Snapshot(tradedPairsSet: Set[AssetPair])

--- a/dex/src/main/scala/com/wavesplatform/dex/model/ExchangeTransactionCreator.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/ExchangeTransactionCreator.scala
@@ -2,17 +2,16 @@ package com.wavesplatform.dex.model
 
 import com.wavesplatform.account.{Address, KeyPair}
 import com.wavesplatform.common.utils.EitherExt2
-import com.wavesplatform.features.BlockchainFeatures
-import com.wavesplatform.features.FeatureProvider.FeatureProviderExt
-import com.wavesplatform.lang.ValidationError
 import com.wavesplatform.dex.model.ExchangeTransactionCreator._
 import com.wavesplatform.dex.settings.AssetType.AssetType
 import com.wavesplatform.dex.settings.OrderFeeSettings.PercentSettings
 import com.wavesplatform.dex.settings.{AssetType, MatcherSettings}
+import com.wavesplatform.features.BlockchainFeatures
+import com.wavesplatform.features.FeatureProvider.FeatureProviderExt
+import com.wavesplatform.lang.ValidationError
 import com.wavesplatform.state.Blockchain
-import com.wavesplatform.state.diffs.{CommonValidation, FeeValidation}
+import com.wavesplatform.state.diffs.FeeValidation
 import com.wavesplatform.transaction.Asset
-import com.wavesplatform.transaction.Asset.{IssuedAsset, Waves}
 import com.wavesplatform.transaction.TxValidationError._
 import com.wavesplatform.transaction.assets.exchange._
 

--- a/dex/src/main/scala/com/wavesplatform/dex/model/OrderValidator.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/OrderValidator.scala
@@ -19,7 +19,7 @@ import com.wavesplatform.lang.ValidationError
 import com.wavesplatform.lang.v1.compiler.Terms.{FALSE, TRUE}
 import com.wavesplatform.metrics.TimerExt
 import com.wavesplatform.state._
-import com.wavesplatform.state.diffs.{CommonValidation, FeeValidation}
+import com.wavesplatform.state.diffs.FeeValidation
 import com.wavesplatform.transaction.Asset.{IssuedAsset, Waves}
 import com.wavesplatform.transaction._
 import com.wavesplatform.transaction.assets.exchange.OrderOps._

--- a/dex/src/main/scala/com/wavesplatform/dex/smart/MatcherContext.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/smart/MatcherContext.scala
@@ -106,12 +106,15 @@ object MatcherContext {
     override def transferById(id: BlockId): Option[(Int, TransferTransaction)]                           = kill("transferById")
 
     /** Block reward related */
-    override def blockReward(height: Int): Option[Long]                                                              = kill("blockReward")
-    override def lastBlockReward: Option[Long]                                                                       = kill("lastBlockReward")
-    override def blockRewardVotes(height: Int): Seq[Long]                                                            = kill("blockRewardVotes")
-    override def wavesAmount(height: Int): BigInt                                                                    = kill("wavesAmount")
-    override def accountScriptWithComplexity(address: Address): Option[(Script, Long)]                               = kill("accountScriptWithComplexity")
-    override def assetScriptWithComplexity(id: Asset.IssuedAsset): Option[(Script, Long)]                            = kill("assetScriptWithComplexity")
+    override def blockReward(height: Int): Option[Long] = kill("blockReward")
+    override def lastBlockReward: Option[Long] = kill("lastBlockReward")
+    override def blockRewardVotes(height: Int): Seq[Long] = kill("blockRewardVotes")
+
+    override def wavesAmount(height: Int): BigInt = kill("wavesAmount")
+
+    override def accountScriptWithComplexity(address: Address): Option[(Script, Long)] = kill("accountScriptWithComplexity")
+    override def assetScriptWithComplexity(id: Asset.IssuedAsset): Option[(Script, Long)] = kill("assetScriptWithComplexity")
     override def collectActiveLeases(from: Int, to: Int)(filter: LeaseTransaction => Boolean): Seq[LeaseTransaction] = kill("collectActiveLeases")
   }
+
 }

--- a/dex/src/test/scala/com/wavesplatform/state/diffs/package.scala
+++ b/dex/src/test/scala/com/wavesplatform/state/diffs/package.scala
@@ -1,92 +1,9 @@
 package com.wavesplatform.state
 
-import cats.Monoid
-import com.wavesplatform.block.Block
 import com.wavesplatform.common.state.diffs.ProduceError
-import com.wavesplatform.common.utils.EitherExt2
 import com.wavesplatform.db.WithState
-import com.wavesplatform.lagonaki.mocks.TestBlock
-import com.wavesplatform.lang.ValidationError
-import com.wavesplatform.mining.MiningConstraint
-import com.wavesplatform.settings.{FunctionalitySettings, TestFunctionalitySettings => TFS}
-import com.wavesplatform.state.reader.CompositeBlockchain
-import com.wavesplatform.transaction.Transaction
-import com.wavesplatform.transaction.smart.script.trace.TracedResult
 import org.scalatest.Matchers
 
 package object diffs extends WithState with Matchers {
-  val ENOUGH_AMT: Long = Long.MaxValue / 3
-
-  def assertDiffEi(preconditions: Seq[Block], block: Block, fs: FunctionalitySettings = TFS.Enabled)(
-      assertion: Either[ValidationError, Diff] => Unit): Unit = withLevelDBWriter(fs) { state =>
-    def differ(blockchain: Blockchain, b: Block) = BlockDiffer.fromBlock(blockchain, None, b, MiningConstraint.Unlimited)
-
-    preconditions.foreach { precondition =>
-      val BlockDiffer.Result(preconditionDiff, preconditionFees, totalFee, _) = differ(state, precondition).explicitGet()
-      state.append(preconditionDiff, preconditionFees, totalFee, None, precondition)
-    }
-    val totalDiff1 = differ(state, block)
-    assertion(totalDiff1.map(_.diff))
-  }
-
-  def assertDiffEiTraced(preconditions: Seq[Block], block: Block, fs: FunctionalitySettings = TFS.Enabled)(
-      assertion: TracedResult[ValidationError, Diff] => Unit): Unit = withLevelDBWriter(fs) { state =>
-    def differ(blockchain: Blockchain, b: Block) = BlockDiffer.fromBlockTraced(blockchain, None, b, MiningConstraint.Unlimited)
-
-    preconditions.foreach { precondition =>
-      val BlockDiffer.Result(preconditionDiff, preconditionFees, totalFee, _) = differ(state, precondition).resultE.explicitGet()
-      state.append(preconditionDiff, preconditionFees, totalFee, None, precondition)
-    }
-    val totalDiff1 = differ(state, block)
-    assertion(totalDiff1.map(_.diff))
-  }
-
-  private def assertDiffAndState(preconditions: Seq[Block], block: Block, fs: FunctionalitySettings, withNg: Boolean)(
-      assertion: (Diff, Blockchain) => Unit): Unit = withLevelDBWriter(fs) { state =>
-    def differ(blockchain: Blockchain, prevBlock: Option[Block], b: Block): Either[ValidationError, BlockDiffer.GenResult] =
-      BlockDiffer.fromBlock(blockchain, if (withNg) prevBlock else None, b, MiningConstraint.Unlimited)
-
-    preconditions.foldLeft[Option[Block]](None) { (prevBlock, curBlock) =>
-      val BlockDiffer.Result(diff, fees, totalFee, _) = differ(state, prevBlock, curBlock).explicitGet()
-      state.append(diff, fees, totalFee, None, curBlock)
-      Some(curBlock)
-    }
-
-    val BlockDiffer.Result(diff, fees, totalFee, _) = differ(state, preconditions.lastOption, block).explicitGet()
-    val cb              = CompositeBlockchain(state, Some(diff))
-    assertion(diff, cb)
-
-    state.append(diff, fees, totalFee, None, block)
-    assertion(diff, state)
-  }
-
-  def assertNgDiffState(preconditions: Seq[Block], block: Block, fs: FunctionalitySettings = TFS.Enabled)(
-      assertion: (Diff, Blockchain) => Unit): Unit =
-    assertDiffAndState(preconditions, block, fs, withNg = true)(assertion)
-
-  def assertDiffAndState(preconditions: Seq[Block], block: Block, fs: FunctionalitySettings = TFS.Enabled)(
-      assertion: (Diff, Blockchain) => Unit): Unit =
-    assertDiffAndState(preconditions, block, fs, withNg = false)(assertion)
-
-  def assertDiffAndState(fs: FunctionalitySettings)(test: (Seq[Transaction] => Either[ValidationError, Unit]) => Unit): Unit =
-    withLevelDBWriter(fs) { state =>
-      def differ(blockchain: Blockchain, b: Block) = BlockDiffer.fromBlock(blockchain, None, b, MiningConstraint.Unlimited)
-
-      test(txs => {
-        val block = TestBlock.create(txs)
-        differ(state, block).map(diff => state.append(diff.diff, diff.carry, diff.totalFee, None, block))
-      })
-    }
-
-  def assertBalanceInvariant(diff: Diff): Unit = {
-    val portfolioDiff = Monoid.combineAll(diff.portfolios.values)
-    portfolioDiff.balance shouldBe 0
-    portfolioDiff.effectiveBalance shouldBe 0
-    portfolioDiff.assets.values.foreach(_ shouldBe 0)
-  }
-
-  def assertLeft(preconditions: Seq[Block], block: Block, fs: FunctionalitySettings = TFS.Enabled)(errorMessage: String): Unit =
-    assertDiffEi(preconditions, block, fs)(_ should produce(errorMessage))
-
   def produce(errorMessage: String): ProduceError = new ProduceError(errorMessage)
 }

--- a/project/CommonSettings.scala
+++ b/project/CommonSettings.scala
@@ -9,9 +9,6 @@ object CommonSettings extends AutoPlugin {
 
   // These options doesn't work for ScalaJS
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
-    javaOptions ++= {
-      if (!fork.value) Seq.empty else ModernJavaSettings.options
-    },
     packageSource := sourceDirectory.value / "package"
   )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,6 @@ object Dependencies {
 
   def akkaModule(module: String): ModuleID = "com.typesafe.akka" %% s"akka-$module" % "2.5.20"
 
-  private def swaggerModule(module: String)                = "io.swagger.core.v3"            % s"swagger-$module" % "2.0.5"
   private def akkaHttpModule(module: String)               = "com.typesafe.akka"             %% module            % "10.1.8"
   private def nettyModule(module: String)                  = "io.netty"                      % s"netty-$module"   % "4.1.33.Final"
   private def kamonModule(module: String, v: String)       = "io.kamon"                      %% s"kamon-$module"  % v
@@ -96,6 +95,7 @@ object Dependencies {
     akkaModule("persistence-query"),
     akkaHttp,
     "com.typesafe.akka" %% "akka-stream-kafka" % "1.0.4",
+    // "javax.xml.bind" % "jaxb-api" % "2.3.1", // javax.xml.bind replacement for jackson in swagger, will required in future
     janino,
     mouse
   ) ++ Seq(

--- a/project/ItTestPlugin.scala
+++ b/project/ItTestPlugin.scala
@@ -62,7 +62,7 @@ object ItTestPlugin extends AutoPlugin {
                   runJVMOptions = Vector(
                     "-Dwaves.it.logging.appender=FILE",
                     s"-Dwaves.it.logging.dir=${logDirectoryValue / suite.name.replaceAll("""(\w)\w*\.""", "$1.")}" // foo.bar.Baz -> f.b.Baz
-                  ) ++ javaOptionsValue ++ ModernJavaSettings.options,
+                  ) ++ javaOptionsValue,
                   connectInput = false,
                   envVars = envVarsValue
                 ))

--- a/project/ModernJavaSettings.scala
+++ b/project/ModernJavaSettings.scala
@@ -1,7 +1,0 @@
-object ModernJavaSettings {
-  val options: Seq[String] = Seq(
-    "-XX:+IgnoreUnrecognizedVMOptions",
-    "--add-modules=java.xml.bind",
-    "--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED"
-  )
-}

--- a/project/Network.scala
+++ b/project/Network.scala
@@ -6,13 +6,15 @@ sealed abstract class NodeNetwork(val suffix: String) {
 object NodeNetwork {
   def apply(v: Option[String]) = v match {
     case Some(Testnet.suffix) => Testnet
+    case Some(Stagenet.suffix) => Stagenet
     case Some(Devnet.suffix) => Devnet
     case _ => Mainnet
   }
   
-  val All: List[NodeNetwork] = List(Mainnet, Testnet, Devnet)
+  val All: List[NodeNetwork] = List(Mainnet, Testnet, Stagenet, Devnet)
 }
 
 object Mainnet extends NodeNetwork("mainnet")
 object Testnet extends NodeNetwork("testnet")
+object Stagenet extends NodeNetwork("stagenet")
 object Devnet extends NodeNetwork("devnet")

--- a/project/ReleasePlugin.scala
+++ b/project/ReleasePlugin.scala
@@ -58,7 +58,7 @@ object ReleasePlugin extends AutoPlugin {
           val configFile = (Compile / baseDirectory).value / "_local" / "mainnet.sample.conf" // Actually doesn't matter for this task
           streams.value.log.info(s"${configFile.getAbsolutePath} gen-docs ${(Compile / releaseDirectory).value}")
           (LocalProject("dex") / Compile / runMain)
-            .toTask(s" com.wavesplatform.dex.MatcherTool ${configFile.getAbsolutePath} gen-docs ${(Compile / releaseDirectory).value}")
+            .toTask(s" com.wavesplatform.dex.doc.DocGeneratorApp ${(Compile / releaseDirectory).value}")
         }.value,
         writeReleaseNotes := {
           val runner           = git.runner.value

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ resolvers ++= Seq(
 
 Seq(
   "com.eed3si9n"      % "sbt-assembly"           % "0.14.5",
-  "com.typesafe.sbt"  % "sbt-native-packager"    % "1.3.2",
+  "com.typesafe.sbt"  % "sbt-native-packager"    % "1.3.25",
   "org.scalastyle"    %% "scalastyle-sbt-plugin" % "1.0.0",
   "org.scoverage"     % "sbt-scoverage"          % "1.5.1",
   "se.marcuslonnberg" % "sbt-docker"             % "1.4.1",


### PR DESCRIPTION
DEX-395 Java 11 support:

* Added support of Java 11;
* Fixed issues with loading Swagger resource files in a browser;
* Added DocGeneratorApp to support "release" task (MatcherTool has gone);
* Updated README.md, now it contains instructions about a Java 11 installation;
* Fixed issues after migration to Node 1.1.0;

DEX-389 Stagenet support;
DEX-370 Force creation of order books' snapshots;