### PR TITLE
DEX-404 Zero price level is forbidden

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,7 @@ lazy val it = project
   )
 
 lazy val root = (project in file("."))
+  .settings(name := "dex-root")
   .aggregate(
     dex,
     `dex-it`,

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/MatchingRulesTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/MatchingRulesTestSuite.scala
@@ -25,7 +25,7 @@ class MatchingRulesTestSuite extends MatcherSuiteBase {
          |    ],
          |    "WAVES-$BtcId": [
          |      {
-         |        start-offset = 0
+         |        start-offset = 1
          |        tick-size    = 5
          |      }
          |    ]
@@ -70,6 +70,9 @@ class MatchingRulesTestSuite extends MatcherSuiteBase {
   }
 
   "Buy orders cannot be placed into price level 0 (when price is less than tick size)" in {
+    val firstOrder = node.placeOrder(bob, wavesBtcPair, BUY, amount, 3 * price, matcherFee).message.id
+    node.waitOrderStatus(wctUsdPair, firstOrder, "Accepted")
+
     node.expectRejectedOrderPlacement(bob, wavesBtcPair, BUY, amount, 3 * price, matcherFee)
   }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/Matcher.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/Matcher.scala
@@ -10,8 +10,6 @@ import akka.http.scaladsl.Http.ServerBinding
 import akka.pattern.{AskTimeoutException, ask, gracefulStop}
 import akka.stream.ActorMaterializer
 import akka.util.Timeout
-import cats.data.NonEmptyList
-import cats.implicits._
 import com.wavesplatform.account.{Address, PublicKey}
 import com.wavesplatform.api.http.{ApiRoute, CompositeHttpService => _}
 import com.wavesplatform.common.utils.EitherExt2
@@ -19,15 +17,15 @@ import com.wavesplatform.database._
 import com.wavesplatform.dex.Matcher.Status
 import com.wavesplatform.dex.api.http.CompositeHttpService
 import com.wavesplatform.dex.api.{MatcherApiRoute, MatcherApiRouteV1, OrderBookSnapshotHttpCache}
+import com.wavesplatform.dex.caches.{MatchingRulesCache, RateCache}
 import com.wavesplatform.dex.db.{AssetPairsDB, OrderBookSnapshotDB, OrderDB}
 import com.wavesplatform.dex.error.{ErrorFormatterContext, MatcherError}
 import com.wavesplatform.dex.history.HistoryRouter
 import com.wavesplatform.dex.market.OrderBookActor.MarketStatus
 import com.wavesplatform.dex.market._
-import com.wavesplatform.dex.model.MatcherModel.Denormalization
 import com.wavesplatform.dex.model._
 import com.wavesplatform.dex.queue._
-import com.wavesplatform.dex.settings.{MatcherSettings, MatchingRule, DenormalizedMatchingRule}
+import com.wavesplatform.dex.settings.MatcherSettings
 import com.wavesplatform.extensions.{Context, Extension}
 import com.wavesplatform.state.VolumeAndFee
 import com.wavesplatform.transaction.Asset
@@ -45,10 +43,12 @@ class Matcher(context: Context) extends Extension with ScorexLogging {
 
   private val settings = context.settings.config.as[MatcherSettings]("waves.dex")
 
-  private val matcherKeyPair = (for {
-    address <- Address.fromString(settings.account)
-    pk      <- context.wallet.privateKeyAccount(address)
-  } yield pk).explicitGet()
+  private val matcherKeyPair = (
+    for {
+      address <- Address.fromString(settings.account)
+      pk      <- context.wallet.privateKeyAccount(address)
+    } yield pk
+  ).explicitGet()
 
   private def matcherPublicKey: PublicKey = matcherKeyPair
 
@@ -68,23 +68,29 @@ class Matcher(context: Context) extends Extension with ScorexLogging {
       }
     }
 
-  private val pairBuilder        = new AssetPairBuilder(settings, context.blockchain, blacklistedAssets)
-  private val orderBookCache     = new ConcurrentHashMap[AssetPair, OrderBook.AggregatedSnapshot](1000, 0.9f, 10)
-  private val transactionCreator = new ExchangeTransactionCreator(context.blockchain, matcherKeyPair, settings)
+  private lazy val blacklistedAddresses = settings.blacklistedAddresses.map(Address.fromString(_).explicitGet())
 
-  private val orderBooks                      = new AtomicReference(Map.empty[AssetPair, Either[Unit, ActorRef]])
-  private val actualDenormalizedMatchingRules = new ConcurrentHashMap[AssetPair, DenormalizedMatchingRule]
-  private val assetDecimalsCache              = new AssetDecimalsCache(context.blockchain)
+  private val pairBuilder        = new AssetPairBuilder(settings, context.blockchain, blacklistedAssets)
+  private val transactionCreator = new ExchangeTransactionCreator(context.blockchain, matcherKeyPair, settings)
+  private val orderBooks         = new AtomicReference(Map.empty[AssetPair, Either[Unit, ActorRef]])
+
+  private val assetDecimalsCache                           = new AssetDecimalsCache(context.blockchain)
+  private implicit val errorContext: ErrorFormatterContext = (asset: Asset) => assetDecimalsCache.get(asset)
+
+  private val orderBookCache     = new ConcurrentHashMap[AssetPair, OrderBook.AggregatedSnapshot](1000, 0.9f, 10)
+  private val matchingRulesCache = new MatchingRulesCache(settings, context.blockchain)
+  private val rateCache          = RateCache(db)
 
   private val orderBooksSnapshotCache =
     new OrderBookSnapshotHttpCache(
       settings.orderBookSnapshotHttpCache,
       context.time,
       assetDecimalsCache.get,
-      p => Option(orderBookCache.get(p))
+      assetPair => Option { orderBookCache.get(assetPair) }
     )
 
-  private val marketStatuses = new ConcurrentHashMap[AssetPair, MarketStatus](1000, 0.9f, 10)
+  private val marketStatuses                                     = new ConcurrentHashMap[AssetPair, MarketStatus](1000, 0.9f, 10)
+  private val getMarketStatus: AssetPair => Option[MarketStatus] = p => Option(marketStatuses.get(p))
 
   private def updateOrderBookCache(assetPair: AssetPair)(newSnapshot: OrderBook.AggregatedSnapshot): Unit = {
     orderBookCache.put(assetPair, newSnapshot)
@@ -92,10 +98,7 @@ class Matcher(context: Context) extends Extension with ScorexLogging {
   }
 
   private def orderBookProps(assetPair: AssetPair, matcherActor: ActorRef): Props = {
-
-    val denormalizedMatchingRules = DenormalizedMatchingRule.getDenormalizedMatchingRules(settings, assetPair, context.blockchain, errorContext)
-    actualDenormalizedMatchingRules.put(assetPair, denormalizedMatchingRules.head)
-
+    matchingRulesCache.setCurrentMatchingRuleForNewOrderBook(assetPair)
     OrderBookActor.props(
       matcherActor,
       addressActors,
@@ -106,8 +109,8 @@ class Matcher(context: Context) extends Extension with ScorexLogging {
       settings,
       transactionCreator.createTransaction,
       context.time,
-      denormalizedMatchingRules = denormalizedMatchingRules,
-      actualizeCurrentMatchingRules = actualMatchingRule => actualDenormalizedMatchingRules.put(assetPair, actualMatchingRule),
+      matchingRules = matchingRulesCache.getMatchingRules(assetPair),
+      updateCurrentMatchingRules = actualMatchingRule => matchingRulesCache.updateCurrentMatchingRule(assetPair, actualMatchingRule),
       normalizeMatchingRule = denormalizedMatchingRule => denormalizedMatchingRule.normalize(assetPair, context.blockchain),
     )
   }
@@ -123,9 +126,6 @@ class Matcher(context: Context) extends Extension with ScorexLogging {
 
     case x => throw new IllegalArgumentException(s"Unknown queue type: $x")
   }
-
-  private val getMarketStatus: AssetPair => Option[MarketStatus] = p => Option(marketStatuses.get(p))
-  private val rateCache                                          = RateCache(db)
 
   private def validateOrder(o: Order): Either[MatcherError, Order] =
     for {
@@ -148,13 +148,8 @@ class Matcher(context: Context) extends Extension with ScorexLogging {
         assetDecimalsCache.get
       )(o)
       _ <- pairBuilder.validateAssetPair(o.assetPair)
-      _ <- OrderValidator.tickSizeAware(
-        Option { actualDenormalizedMatchingRules.get(o.assetPair) }
-          .map { _.normalize(o.assetPair, context.blockchain).normalizedTickSize } getOrElse MatchingRule.DefaultTickSize
-      )(o)
+      _ <- OrderValidator.tickSizeAware(matchingRulesCache.getNormalizedRuleForNextOrder(o.assetPair, matcherQueue.lastProcessedOffset).tickSize)(o)
     } yield o
-
-  private implicit val errorContext: ErrorFormatterContext = (asset: Asset) => assetDecimalsCache.get(asset)
 
   lazy val matcherApiRoutes: Seq[ApiRoute] = {
     val keyHashStr = context.settings.config.getString("waves.rest-api.api-key-hash")
@@ -168,16 +163,7 @@ class Matcher(context: Context) extends Extension with ScorexLogging {
         matcherQueue.storeEvent,
         p => Option(orderBooks.get()).flatMap(_.get(p)),
         p => Option(marketStatuses.get(p)),
-        getActualTickSize = assetPair => {
-
-          lazy val defaultTickSize =
-            Denormalization
-              .denormalizePrice(MatchingRule.DefaultTickSize, assetPair, context.blockchain)
-              .leftMap(_ => DenormalizedMatchingRule.DefaultTickSize)
-              .merge
-
-          Option { actualDenormalizedMatchingRules.get(assetPair) } map (_.tickSize) getOrElse defaultTickSize
-        },
+        getActualTickSize = assetPair => matchingRulesCache.getDenormalizedRuleForNextOrder(assetPair, matcherQueue.lastProcessedOffset).tickSize,
         validateOrder,
         orderBooksSnapshotCache,
         settings,
@@ -201,29 +187,28 @@ class Matcher(context: Context) extends Extension with ScorexLogging {
     )
   }
 
-  lazy val matcherApiTypes: Set[Class[_]] =
-    Set(
-      classOf[MatcherApiRoute],
-      classOf[MatcherApiRouteV1],
-    )
+  lazy val matcherApiTypes: Set[Class[_]] = Set(
+    classOf[MatcherApiRoute],
+    classOf[MatcherApiRouteV1],
+  )
 
   private val snapshotsRestore = Promise[Unit]()
 
-  private lazy val assetPairsDb = AssetPairsDB(db)
-
+  private lazy val db                  = openDB(settings.dataDir)
+  private lazy val assetPairsDB        = AssetPairsDB(db)
   private lazy val orderBookSnapshotDB = OrderBookSnapshotDB(db)
+  private lazy val orderDB             = OrderDB(settings, db)
 
-  lazy val orderBookSnapshotStore: ActorRef = context.actorSystem.actorOf(
-    OrderBookSnapshotStoreActor.props(orderBookSnapshotDB),
-    "order-book-snapshot-store"
-  )
+  lazy val orderBookSnapshotStore: ActorRef = {
+    context.actorSystem.actorOf(OrderBookSnapshotStoreActor.props(orderBookSnapshotDB), "order-book-snapshot-store")
+  }
 
   private val pongTimeout = new Timeout(settings.processConsumedTimeout * 2)
 
   lazy val matcher: ActorRef = context.actorSystem.actorOf(
     MatcherActor.props(
       settings,
-      assetPairsDb, {
+      assetPairsDB, {
         case Left(msg) =>
           log.error(s"Can't start matcher: $msg")
           forceStopApplication(ErrorStartingMatcher)
@@ -259,8 +244,6 @@ class Matcher(context: Context) extends Extension with ScorexLogging {
     MatcherActor.name
   )
 
-  private lazy val orderDb = OrderDB(settings, db)
-
   private lazy val historyRouter = settings.orderHistory.map { orderHistorySettings =>
     context.actorSystem.actorOf(HistoryRouter.props(context.blockchain, settings.postgresConnection, orderHistorySettings), "history-router")
   }
@@ -271,14 +254,14 @@ class Matcher(context: Context) extends Extension with ScorexLogging {
         new AddressDirectory(
           context.spendableBalanceChanged,
           settings,
-          orderDb,
+          orderDB,
           (address, startSchedules) =>
             Props(new AddressActor(
               address,
               context.utx.spendableBalance(address, _),
               5.seconds,
               context.time,
-              orderDb,
+              orderDB,
               id => context.blockchain.filledVolumeAndFee(id) != VolumeAndFee.empty,
               matcherQueue.storeEvent,
               startSchedules
@@ -287,10 +270,6 @@ class Matcher(context: Context) extends Extension with ScorexLogging {
         )),
       "addresses"
     )
-
-  private lazy val blacklistedAddresses = settings.blacklistedAddresses.map(Address.fromString(_).explicitGet())
-
-  private lazy val db = openDB(settings.dataDir)
 
   @volatile var matcherServerBinding: ServerBinding = _
 
@@ -400,6 +379,7 @@ class Matcher(context: Context) extends Extension with ScorexLogging {
 }
 
 object Matcher extends ScorexLogging {
+
   type StoreEvent = QueueEvent => Future[Option[QueueEventWithMeta]]
 
   sealed trait Status

--- a/dex/src/main/scala/com/wavesplatform/dex/api/MatcherApiRoute.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/MatcherApiRoute.scala
@@ -16,6 +16,7 @@ import com.wavesplatform.dex.AddressActor.GetOrderStatus
 import com.wavesplatform.dex.AddressDirectory.{Envelope => Env}
 import com.wavesplatform.dex.Matcher.StoreEvent
 import com.wavesplatform.dex._
+import com.wavesplatform.dex.caches.RateCache
 import com.wavesplatform.dex.error.{ErrorFormatterContext, MatcherError}
 import com.wavesplatform.dex.market.MatcherActor.{ForceSaveSnapshots, ForceStartOrderBook, GetMarkets, GetSnapshotOffsets, MarketData, SnapshotOffsetsResponse}
 import com.wavesplatform.dex.market.OrderBookActor._

--- a/dex/src/main/scala/com/wavesplatform/dex/caches/MatchingRulesCache.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/caches/MatchingRulesCache.scala
@@ -1,0 +1,37 @@
+package com.wavesplatform.dex.caches
+
+import java.util.concurrent.ConcurrentHashMap
+
+import cats.data.NonEmptyList
+import com.wavesplatform.dex.error.ErrorFormatterContext
+import com.wavesplatform.dex.settings.{DenormalizedMatchingRule, MatcherSettings, MatchingRule}
+import com.wavesplatform.state.Blockchain
+import com.wavesplatform.transaction.assets.exchange.AssetPair
+
+class MatchingRulesCache(matcherSettings: MatcherSettings, blockchain: Blockchain)(implicit errorFormatterContext: ErrorFormatterContext) {
+
+  private val allMatchingRules    = new ConcurrentHashMap[AssetPair, NonEmptyList[DenormalizedMatchingRule]]
+  private val currentMatchingRule = new ConcurrentHashMap[AssetPair, DenormalizedMatchingRule]
+
+  def getMatchingRules(assetPair: AssetPair): NonEmptyList[DenormalizedMatchingRule] = {
+    allMatchingRules.getOrDefault(assetPair, DenormalizedMatchingRule.getDenormalizedMatchingRules(matcherSettings, blockchain, assetPair))
+  }
+
+  def getDenormalizedRuleForNextOrder(assetPair: AssetPair, currentOffset: Long): DenormalizedMatchingRule = {
+    getMatchingRules(assetPair)
+      .find { _.startOffset == currentOffset + 1 }
+      .getOrElse { currentMatchingRule.get(assetPair) }
+  }
+
+  def getNormalizedRuleForNextOrder(assetPair: AssetPair, currentOffset: Long): MatchingRule = {
+    getDenormalizedRuleForNextOrder(assetPair, currentOffset).normalize(assetPair, blockchain)
+  }
+
+  def updateCurrentMatchingRule(assetPair: AssetPair, matchingRule: DenormalizedMatchingRule): Unit = {
+    currentMatchingRule.put(assetPair, matchingRule)
+  }
+
+  def setCurrentMatchingRuleForNewOrderBook(assetPair: AssetPair): Unit = {
+    updateCurrentMatchingRule(assetPair, getMatchingRules(assetPair).head)
+  }
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/caches/RateCache.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/caches/RateCache.scala
@@ -1,4 +1,4 @@
-package com.wavesplatform.dex
+package com.wavesplatform.dex.caches
 
 import java.util.concurrent.ConcurrentHashMap
 

--- a/dex/src/main/scala/com/wavesplatform/dex/model/OrderBook.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/OrderBook.scala
@@ -51,7 +51,7 @@ class OrderBook private (private[OrderBook] val bids: OrderBook.Side,
     canceledOrders
   }
 
-  def add(o: Order, ts: Long, normalizedTickSize: Long = MatchingRule.DefaultRule.normalizedTickSize): Seq[Event] = {
+  def add(o: Order, ts: Long, normalizedTickSize: Long = MatchingRule.DefaultRule.tickSize): Seq[Event] = {
     val (events, lt) = o.orderType match {
       case OrderType.BUY  => doMatch(ts, canMatchBuy, LimitOrder(o), Seq.empty, bids, asks, lastTrade, normalizedTickSize)
       case OrderType.SELL => doMatch(ts, canMatchSell, LimitOrder(o), Seq.empty, asks, bids, lastTrade, normalizedTickSize)

--- a/dex/src/main/scala/com/wavesplatform/dex/model/OrderValidator.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/OrderValidator.scala
@@ -5,6 +5,8 @@ import cats.kernel.Monoid
 import com.wavesplatform.account.{Address, PublicKey}
 import com.wavesplatform.common.state.ByteStr
 import com.wavesplatform.common.utils.EitherExt2
+import com.wavesplatform.dex.caches.RateCache
+import com.wavesplatform.dex.error
 import com.wavesplatform.dex.error._
 import com.wavesplatform.dex.market.OrderBookActor.MarketStatus
 import com.wavesplatform.dex.model.MatcherModel.Normalization
@@ -12,15 +14,13 @@ import com.wavesplatform.dex.model.MatcherModel.Normalization._
 import com.wavesplatform.dex.settings.OrderFeeSettings._
 import com.wavesplatform.dex.settings.{AssetType, DeviationsSettings, MatcherSettings, OrderRestrictionsSettings}
 import com.wavesplatform.dex.smart.MatcherScriptRunner
-import com.wavesplatform.dex.{RateCache, error}
 import com.wavesplatform.features.BlockchainFeatures
 import com.wavesplatform.features.FeatureProvider._
-import com.wavesplatform.lang.ValidationError
 import com.wavesplatform.lang.v1.compiler.Terms.{FALSE, TRUE}
 import com.wavesplatform.metrics.TimerExt
 import com.wavesplatform.state._
 import com.wavesplatform.state.diffs.FeeValidation
-import com.wavesplatform.transaction.Asset.{IssuedAsset, Waves}
+import com.wavesplatform.transaction.Asset.IssuedAsset
 import com.wavesplatform.transaction._
 import com.wavesplatform.transaction.assets.exchange.OrderOps._
 import com.wavesplatform.transaction.assets.exchange._
@@ -388,11 +388,7 @@ object OrderValidator extends ScorexLogging {
     } yield order
   }
 
-  def accountStateAware(
-      sender: Address,
-      tradableBalance: Asset => Long,
-      activeOrderCount: => Int,
-      orderExists: ByteStr => Boolean,
+  def accountStateAware(sender: Address, tradableBalance: Asset => Long, activeOrderCount: => Int, orderExists: ByteStr => Boolean,
   )(order: Order): Result[Order] =
     for {
       _ <- lift(order)

--- a/dex/src/main/scala/com/wavesplatform/dex/settings/MatchingRule.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/settings/MatchingRule.scala
@@ -16,7 +16,7 @@ import net.ceedubs.ficus.Ficus._
 import net.ceedubs.ficus.readers.ValueReader
 
 /** Normalized representation of the matching rule */
-case class MatchingRule(startOffset: QueueEventWithMeta.Offset, normalizedTickSize: Long) {
+case class MatchingRule(startOffset: QueueEventWithMeta.Offset, tickSize: Long) {
 
   /**
     * Denormalizes matching rule
@@ -25,7 +25,7 @@ case class MatchingRule(startOffset: QueueEventWithMeta.Offset, normalizedTickSi
   def denormalize(assetPair: AssetPair,
                   blockchain: Blockchain,
                   defaultTickSize: MatcherError => Double = _ => DenormalizedMatchingRule.DefaultTickSize): DenormalizedMatchingRule = {
-    val denormalizedTickSize = Denormalization.denormalizePrice(normalizedTickSize, assetPair, blockchain)
+    val denormalizedTickSize = Denormalization.denormalizePrice(tickSize, assetPair, blockchain)
     DenormalizedMatchingRule(
       startOffset = startOffset,
       tickSize = denormalizedTickSize.leftMap { defaultTickSize }.merge
@@ -83,10 +83,8 @@ object DenormalizedMatchingRule extends ScorexLogging {
     * Returns denormalized (from application.conf) matching rules for the specified asset pair.
     * Prepends default rule if matching rules list doesn't contain element with startOffset = 0
     */
-  def getDenormalizedMatchingRules(settings: MatcherSettings,
-                                   assetPair: AssetPair,
-                                   blockchain: Blockchain,
-                                   errorFormatterContext: ErrorFormatterContext): NonEmptyList[DenormalizedMatchingRule] = {
+  def getDenormalizedMatchingRules(settings: MatcherSettings, blockchain: Blockchain, assetPair: AssetPair)(
+      implicit errorFormatterContext: ErrorFormatterContext): NonEmptyList[DenormalizedMatchingRule] = {
     lazy val defaultRule =
       MatchingRule.DefaultRule.denormalize(
         assetPair,

--- a/dex/src/test/scala/com/wavesplatform/dex/MatcherTestData.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/MatcherTestData.scala
@@ -7,6 +7,7 @@ import com.google.common.primitives.{Bytes, Ints}
 import com.typesafe.config.{Config, ConfigFactory}
 import com.wavesplatform.account.KeyPair
 import com.wavesplatform.common.state.ByteStr
+import com.wavesplatform.dex.caches.RateCache
 import com.wavesplatform.dex.model.MatcherModel.{Normalization, Price}
 import com.wavesplatform.dex.model.{BuyLimitOrder, LimitOrder, OrderValidator, SellLimitOrder}
 import com.wavesplatform.dex.queue.{QueueEvent, QueueEventWithMeta}

--- a/dex/src/test/scala/com/wavesplatform/dex/api/MatcherApiRouteSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/api/MatcherApiRouteSpec.scala
@@ -10,6 +10,7 @@ import com.typesafe.config.ConfigFactory
 import com.wavesplatform.account.KeyPair
 import com.wavesplatform.common.utils.Base58
 import com.wavesplatform.dex._
+import com.wavesplatform.dex.caches.RateCache
 import com.wavesplatform.dex.error.ErrorFormatterContext
 import com.wavesplatform.dex.settings.MatcherSettings
 import com.wavesplatform.http.ApiMarshallers._

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderBookSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderBookSpec.scala
@@ -174,8 +174,8 @@ class OrderBookSpec extends FreeSpec with PropertyChecks with Matchers with Matc
         val ob = OrderBook.empty
 
         val sellOrder = sell(pair, 54521418493L, 44389)
-        ob.add(sellOrder, ntpNow, MatchingRule.DefaultRule.normalizedTickSize)
-        ob.add(sellOrder, ntpNow, MatchingRule.DefaultRule.normalizedTickSize)
+        ob.add(sellOrder, ntpNow, MatchingRule.DefaultRule.tickSize)
+        ob.add(sellOrder, ntpNow, MatchingRule.DefaultRule.tickSize)
 
         ob.getAsks.size shouldBe 1
 
@@ -189,7 +189,7 @@ class OrderBookSpec extends FreeSpec with PropertyChecks with Matchers with Matc
 
       val sellOrder = sell(pair, 54521418493L, 44389)
       ob.add(sellOrder, ntpNow, toNormalized(100L))
-      ob.add(sellOrder, ntpNow, MatchingRule.DefaultRule.normalizedTickSize)
+      ob.add(sellOrder, ntpNow, MatchingRule.DefaultRule.tickSize)
 
       ob.getAsks.size shouldBe 2
 

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderValidatorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderValidatorSpecification.scala
@@ -13,7 +13,8 @@ import com.wavesplatform.dex.model.OrderValidator.Result
 import com.wavesplatform.dex.settings.AssetType.AssetType
 import com.wavesplatform.dex.settings.OrderFeeSettings.{DynamicSettings, FixedSettings, OrderFeeSettings, PercentSettings}
 import com.wavesplatform.dex.settings.{AssetType, DeviationsSettings, OrderRestrictionsSettings}
-import com.wavesplatform.dex.{MatcherTestData, RateCache}
+import com.wavesplatform.dex.MatcherTestData
+import com.wavesplatform.dex.caches.RateCache
 import com.wavesplatform.features.{BlockchainFeature, BlockchainFeatures}
 import com.wavesplatform.lang.directives.values._
 import com.wavesplatform.lang.script.Script


### PR DESCRIPTION
* Price level 0 for buy orders is firbidden;
* Matching rules cache introduced;
* Matching rules inside Matcher refactored;
* Order book info now displays tick-size for the next order