### PR TITLE
DEX-401 Custom further processing of the loading results in gRPC caches

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -148,6 +148,7 @@ checkPRRaw := {
     (root / Compile / cleanAll).value
   } finally {
     (dex / Test / test).value
+    (`waves-integration` / Test / test).value
     (`dex-generator` / Test / compile).value
   }
 }

--- a/dex/build.sbt
+++ b/dex/build.sbt
@@ -49,4 +49,5 @@ inTask(docker)(
       (Compile / sourceDirectory).value / "container" / "start.sh",
       (Compile / sourceDirectory).value / "container" / "default.conf"
     )
-  ))
+  )
+)

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/caches/AssetDescriptionsCache.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/caches/AssetDescriptionsCache.scala
@@ -9,4 +9,6 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class AssetDescriptionsCache(loader: IssuedAsset => Future[Option[BriefAssetDescription]], expiration: Duration)(
     implicit executionContext: ExecutionContext)
-    extends BlockchainCache[IssuedAsset, Future[Option[BriefAssetDescription]]](loader, Some(expiration))
+    extends BlockchainCache[IssuedAsset, Option[BriefAssetDescription]](loader,
+                                                                        Some(expiration),
+                                                                        invalidationPredicate = BlockchainCache.noCustomInvalidationLogic)

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/caches/BalancesCache.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/caches/BalancesCache.scala
@@ -6,9 +6,10 @@ import com.wavesplatform.transaction.Asset
 import scala.concurrent.{ExecutionContext, Future}
 
 class BalancesCache(loader: (Address, Asset) => Future[Long])(implicit executionContext: ExecutionContext)
-    extends BlockchainCache[(Address, Asset), Future[BigInt]](
+    extends BlockchainCache[(Address, Asset), BigInt](
       loader = { case (address, asset) => loader(address, asset) map BigInt.apply },
-      expiration = None
+      expiration = None,
+      invalidationPredicate = BlockchainCache.noCustomInvalidationLogic
     ) {
 
   def batchPut(batch: Map[Address, Map[Asset, Long]]): Unit = {

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/caches/BlockchainCache.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/caches/BlockchainCache.scala
@@ -3,23 +3,42 @@ package com.wavesplatform.dex.grpc.integration.caches
 import java.time.Duration
 
 import com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache}
+import com.wavesplatform.utils.ScorexLogging
 
-abstract class BlockchainCache[K <: AnyRef, V <: AnyRef](loader: K => V, expiration: Option[Duration]) {
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
 
-  lazy private val cache: LoadingCache[K, V] = {
+/**
+  * Common logic for caching of the blockchain access results
+  *
+  * @param loader blockchain access function
+  * @param expiration living time of the each cache entry
+  * @param invalidationPredicate custom logic for value invalidation after it's loading to the cache
+  */
+abstract class BlockchainCache[K <: AnyRef, V <: AnyRef](loader: K => Future[V], expiration: Option[Duration], invalidationPredicate: V => Boolean)(
+    implicit ec: ExecutionContext)
+    extends ScorexLogging {
+
+  lazy private val cache: LoadingCache[K, Future[V]] = {
     val builder = CacheBuilder.newBuilder
     expiration
       .fold(builder)(builder.expireAfterWrite)
       .build {
-        new CacheLoader[K, V] {
-          override def load(key: K): V = loader(key)
+        new CacheLoader[K, Future[V]] {
+          override def load(key: K): Future[V] = loader(key) andThen {
+            case Success(value) if invalidationPredicate(value) => cache.invalidate(key)
+            case Failure(exception)                             => log.error(s"Error while value loading occurred: ", exception); cache.invalidate(key)
+          }
         }
       }
   }
 
-  def get(key: K): V = cache.get(key)
+  def get(key: K): Future[V] = cache.get(key)
 
-  def put(key: K, value: V): Unit = cache.put(key, value)
+  def put(key: K, value: Future[V]): Unit = cache.put(key, value)
+}
 
-  def size: Long = cache.size()
+object BlockchainCache {
+
+  def noCustomInvalidationLogic[V](value: V): Boolean = false
 }

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/caches/FeaturesCache.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/caches/FeaturesCache.scala
@@ -1,11 +1,10 @@
 package com.wavesplatform.dex.grpc.integration.caches
 
-import java.time.Duration
-
 import scala.concurrent.{ExecutionContext, Future}
 
-class FeaturesCache(loader: Short => Future[Boolean], expiration: Duration)(implicit executionContext: ExecutionContext)
-    extends BlockchainCache[java.lang.Short, Future[java.lang.Boolean]](
-      loader = (featureId: java.lang.Short) => loader(featureId) map boolean2Boolean,
-      expiration = Some(expiration)
+class FeaturesCache(loader: Short => Future[Boolean], invalidationPredicate: Boolean => Boolean)(implicit executionContext: ExecutionContext)
+    extends BlockchainCache[java.lang.Short, java.lang.Boolean](
+      loader = featureId => loader(featureId) map boolean2Boolean,
+      expiration = None,
+      invalidationPredicate = isFeatureActivated => invalidationPredicate(isFeatureActivated)
     )

--- a/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/caches/BlockchainCacheSpecification.scala
+++ b/waves-integration/src/test/scala/com/wavesplatform/dex/grpc/integration/caches/BlockchainCacheSpecification.scala
@@ -1,0 +1,75 @@
+package com.wavesplatform.dex.grpc.integration.caches
+
+import java.time.Duration
+
+import org.scalatest.{Matchers, WordSpecLike}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class BlockchainCacheSpecification extends WordSpecLike with Matchers {
+
+  private class BlockchainCacheTest(loader: String => Future[String], expiration: Option[Duration], invalidationPredicate: String => Boolean)
+      extends BlockchainCache[String, String](loader, expiration, invalidationPredicate)
+
+  private def createCache(loader: String => Future[String],
+                          expiration: Option[Duration] = None,
+                          invalidationPredicate: String => Boolean = _ => false): BlockchainCacheTest = {
+    new BlockchainCacheTest(loader, expiration, invalidationPredicate)
+  }
+
+  "BlockchainCache" should {
+
+    "not keep failed futures" in {
+
+      val keyAccessMap = collection.mutable.Map.empty[String, Int]
+      val gRPCError    = new RuntimeException("gRPC Error occurred")
+      val badKey       = "gRPC Error"
+
+      val cache =
+        createCache(
+          key => {
+            keyAccessMap += key -> (keyAccessMap.getOrElse(key, 0) + 1)
+            if (key == badKey) Future.failed(gRPCError) else Future.successful(s"value = $key")
+          }
+        )
+
+      (1 to 5) foreach { _ =>
+        cache get "goodKey"
+        cache get badKey
+        Thread.sleep(100)
+      }
+
+      keyAccessMap shouldBe
+        Map(
+          "goodKey" -> 1,
+          badKey    -> 5
+        )
+    }
+
+    "not keep values according to the predicate" in {
+
+      val keyAccessMap = collection.mutable.Map.empty[String, Int]
+
+      val cache = createCache(
+        key => {
+          keyAccessMap += key -> (keyAccessMap.getOrElse(key, 0) + 1)
+          Future.successful { Thread.sleep(50); key }
+        },
+        invalidationPredicate = result => result startsWith "2"
+      )
+
+      (1 to 5) foreach { _ =>
+        cache get "111"
+        cache get "222"
+        Thread.sleep(100)
+      }
+
+      keyAccessMap shouldBe
+        Map(
+          "111" -> 1,
+          "222" -> 5
+        )
+    }
+  }
+}


### PR DESCRIPTION
Blockchain caches now don't keep failed futures and undesirable results according to the predicate