### PR TITLE
DEX version in swagger

### DIFF
--- a/dex/src/main/scala/com/wavesplatform/dex/api/http/SwaggerDocService.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/http/SwaggerDocService.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.github.swagger.akka.SwaggerHttpService
 import com.github.swagger.akka.model.{Info, License}
-import com.wavesplatform.Version
+import com.wavesplatform.dex.Version
 import com.wavesplatform.settings.RestAPISettings
 import io.swagger.models.{Scheme, Swagger}
 


### PR DESCRIPTION
before changes: we showed the node's version in swagger page
after changes: we show the dex's version