### PR TITLE
DEX-515 Correct matcher response for the invalid order json

### DIFF
--- a/dex-it/src/test/scala/com/wavesplatform/it/api/AsyncMatcherHttpApi.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/api/AsyncMatcherHttpApi.scala
@@ -23,7 +23,7 @@ import org.asynchttpclient.util.HttpConstants
 import org.asynchttpclient.{AsyncCompletionHandler, Request, RequestBuilder, Response}
 import org.scalatest.Assertions
 import play.api.libs.json.Json.{parse, stringify, toJson}
-import play.api.libs.json.{Json, Writes}
+import play.api.libs.json.{JsObject, Json, Writes}
 
 import scala.collection.immutable.TreeMap
 import scala.compat.java8.FutureConverters._
@@ -277,8 +277,8 @@ object AsyncMatcherHttpApi extends Assertions {
       Order.sign(unsigned, sender)
     }
 
-    def placeOrder(orderStr: String): Future[MatcherResponse] =
-      matcherPost("/matcher/orderbook", orderStr).as[MatcherResponse]
+    def placeOrder(order: JsObject): Future[MatcherResponse] =
+      matcherPost("/matcher/orderbook", order).as[MatcherResponse]
 
     def placeOrder(order: Order): Future[MatcherResponse] =
       matcherPost("/matcher/orderbook", order.json()).as[MatcherResponse]

--- a/dex-it/src/test/scala/com/wavesplatform/it/api/AsyncMatcherHttpApi.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/api/AsyncMatcherHttpApi.scala
@@ -277,6 +277,9 @@ object AsyncMatcherHttpApi extends Assertions {
       Order.sign(unsigned, sender)
     }
 
+    def placeOrder(orderStr: String): Future[MatcherResponse] =
+      matcherPost("/matcher/orderbook", orderStr).as[MatcherResponse]
+
     def placeOrder(order: Order): Future[MatcherResponse] =
       matcherPost("/matcher/orderbook", order.json()).as[MatcherResponse]
 

--- a/dex-it/src/test/scala/com/wavesplatform/it/api/SyncMatcherHttpApi.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/api/SyncMatcherHttpApi.scala
@@ -85,6 +85,9 @@ object SyncMatcherHttpApi extends Assertions {
     def activeOrderHistory(sender: KeyPair): Seq[OrderbookHistory] =
       sync(async(m).fullOrdersHistory(sender, activeOnly = Some(true)))
 
+    def placeOrder(orderStr: String): MatcherResponse =
+      sync(async(m).placeOrder(orderStr))
+
     def placeOrder(order: Order): MatcherResponse =
       sync(async(m).placeOrder(order))
 

--- a/dex-it/src/test/scala/com/wavesplatform/it/api/SyncMatcherHttpApi.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/api/SyncMatcherHttpApi.scala
@@ -13,7 +13,7 @@ import org.asynchttpclient.util.HttpConstants
 import org.asynchttpclient.{RequestBuilder, Response}
 import org.scalatest.{Assertion, Assertions, Matchers}
 import play.api.libs.json.Json.parse
-import play.api.libs.json.{Format, Json, Writes}
+import play.api.libs.json.{Format, JsObject, Json, Writes}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Awaitable}
@@ -85,8 +85,8 @@ object SyncMatcherHttpApi extends Assertions {
     def activeOrderHistory(sender: KeyPair): Seq[OrderbookHistory] =
       sync(async(m).fullOrdersHistory(sender, activeOnly = Some(true)))
 
-    def placeOrder(orderStr: String): MatcherResponse =
-      sync(async(m).placeOrder(orderStr))
+    def placeOrder(order: JsObject): MatcherResponse =
+      sync(async(m).placeOrder(order))
 
     def placeOrder(order: Order): MatcherResponse =
       sync(async(m).placeOrder(order))

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/OrderRestrictionsTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/OrderRestrictionsTestSuite.scala
@@ -40,24 +40,26 @@ class OrderRestrictionsTestSuite extends MatcherSuiteBase {
   }
 
   "order should be rejected with correct code and message when price is more then Long volume" in {
+
     val tooHighPrice = "10000000000000000000"
 
     assertBadRequestAndMessage(
       node.placeOrder(
-        (node.prepareOrder(alice, wavesUsdPair, SELL, 1000000000L, 1000000000000000000L, 300000L).json.value() ++ Json.obj(
-          "price" -> tooHighPrice)).toString()),
-      "error message here"
+        node.prepareOrder(alice, wavesUsdPair, SELL, 1000000000L, 1000000000000000000L).json.value() ++ Json.obj("price" -> tooHighPrice)
+      ),
+      "The provided JSON contains invalid fields: /price. Check the documentation"
     )
   }
 
   "order should be rejected with correct code and message when amount is more then Long volume" in {
+
     val tooLargeAmount = "10000000000000000000"
 
     assertBadRequestAndMessage(
       node.placeOrder(
-        (node.prepareOrder(alice, wavesUsdPair, SELL, 1000000000L, 1000000L, 300000L).json.value() ++ Json.obj(
-          "amount" -> tooLargeAmount)).toString()),
-      "error message here"
+        node.prepareOrder(alice, wavesUsdPair, SELL, 1000000000L, 1000000L).json.value() ++ Json.obj("amount" -> tooLargeAmount)
+      ),
+      "The provided JSON contains invalid fields: /amount. Check the documentation"
     )
   }
 

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/OrderRestrictionsTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/OrderRestrictionsTestSuite.scala
@@ -6,7 +6,8 @@ import com.wavesplatform.it.api.SyncHttpApi._
 import com.wavesplatform.it.api.SyncMatcherHttpApi._
 import com.wavesplatform.it.api.UnexpectedStatusCodeException
 import com.wavesplatform.it.sync.config.MatcherPriceAssetConfig._
-import com.wavesplatform.transaction.assets.exchange.OrderType.BUY
+import com.wavesplatform.transaction.assets.exchange.OrderType.{BUY, SELL}
+import play.api.libs.json.Json
 
 class OrderRestrictionsTestSuite extends MatcherSuiteBase {
 
@@ -36,6 +37,28 @@ class OrderRestrictionsTestSuite extends MatcherSuiteBase {
     Seq(IssueUsdTx, IssueWctTx, IssueBtcTx).map(_.json()).map(node.broadcastRequest(_)).foreach { tx =>
       node.waitForTransaction(tx.id)
     }
+  }
+
+  "order should be rejected with correct code and message when price is more then Long volume" in {
+    val tooHighPrice = "10000000000000000000"
+
+    assertBadRequestAndMessage(
+      node.placeOrder(
+        (node.prepareOrder(alice, wavesUsdPair, SELL, 1000000000L, 1000000000000000000L, 300000L).json.value() ++ Json.obj(
+          "price" -> tooHighPrice)).toString()),
+      "error message here"
+    )
+  }
+
+  "order should be rejected with correct code and message when amount is more then Long volume" in {
+    val tooLargeAmount = "10000000000000000000"
+
+    assertBadRequestAndMessage(
+      node.placeOrder(
+        (node.prepareOrder(alice, wavesUsdPair, SELL, 1000000000L, 1000000L, 300000L).json.value() ++ Json.obj(
+          "amount" -> tooLargeAmount)).toString()),
+      "error message here"
+    )
   }
 
   "order info returns information event there is no such order book" in {

--- a/dex/src/main/scala/com/wavesplatform/dex/api/MatcherResponse.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/MatcherResponse.scala
@@ -60,11 +60,12 @@ object MatcherResponseContent {
   case class Multiple(content: List[MatcherResponse]) extends MatcherResponseContent
 }
 
-case class SimpleResponse(code: StatusCode, message: String) extends MatcherResponse(code, Json.obj("message"       -> message))
+case class SimpleResponse(code: StatusCode, message: String) extends MatcherResponse(code, Json.obj("message" -> message))
+case class InvalidJsonResponse(error: MatcherError)          extends MatcherResponse(C.BadRequest, error)
 case object AlreadyProcessed                                 extends MatcherResponse(C.Accepted, Json.obj("message" -> "This event has been already processed"))
-case class OrderAccepted(order: Order)                       extends MatcherResponse(C.OK, Json.obj("message"       -> order.json()))
-case class OrderCanceled(orderId: ByteStr)                   extends MatcherResponse(C.OK, Json.obj("orderId"       -> orderId))
-case class OrderDeleted(orderId: ByteStr)                    extends MatcherResponse(C.OK, Json.obj("orderId"       -> orderId))
+case class OrderAccepted(order: Order)                       extends MatcherResponse(C.OK, Json.obj("message" -> order.json()))
+case class OrderCanceled(orderId: ByteStr)                   extends MatcherResponse(C.OK, Json.obj("orderId" -> orderId))
+case class OrderDeleted(orderId: ByteStr)                    extends MatcherResponse(C.OK, Json.obj("orderId" -> orderId))
 
 case class BatchCancelCompleted(orders: Map[Order.Id, MatcherResponse])
     extends MatcherResponse(C.OK, MatcherResponseContent.Multiple(orders.values.toList))

--- a/dex/src/main/scala/com/wavesplatform/dex/error/MatcherError.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/error/MatcherError.scala
@@ -366,14 +366,21 @@ case class OrderInvalidPriceLevel(ord: Order, tickSize: Long)
        |Orders can not be placed into level with price 0"""
     )
 
-case object InvalidRateInput extends MatcherError(rate, commonEntity, broken, e"Invalid input for the asset rate")
-
 case object WavesImmutableRate extends MatcherError(rate, commonEntity, immutable, e"The rate for ${'assetId -> Waves} cannot be changed")
 
 case object NonPositiveAssetRate extends MatcherError(rate, commonEntity, outOfBound, e"Asset rate should be positive")
 
 case class RateNotFound(theAsset: Asset)
     extends MatcherError(rate, commonEntity, notFound, e"The rate for the asset ${'assetId -> theAsset} was not specified")
+
+case class InvalidJson(fields: List[String])
+  extends MatcherError(
+    request,
+    commonEntity,
+    broken,
+    if (fields.isEmpty) e"The provided JSON is invalid. Check the documentation"
+    else e"The provided JSON contains invalid fields: ${'invalidFields -> fields}. Check the documentation"
+  )
 
 sealed abstract class Entity(val code: Int)
 object Entity {

--- a/dex/src/test/scala/com/wavesplatform/dex/api/MatcherApiRouteSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/api/MatcherApiRouteSpec.scala
@@ -115,7 +115,7 @@ class MatcherApiRouteSpec extends RouteSpec("/matcher") with RequestGen with Pat
         Put(routePath(s"/settings/rates/$smartAssetId"), "qwe").withHeaders(RawHeader("X-API-KEY", apiKey)) ~> route ~> check {
           status shouldEqual StatusCodes.BadRequest
           val message = (responseAs[JsValue] \ "message").as[JsString]
-          message.value shouldEqual "Invalid input for the asset rate"
+          message.value shouldEqual "The provided JSON is invalid. Check the documentation"
         }
       },
       apiKey,
@@ -140,7 +140,7 @@ class MatcherApiRouteSpec extends RouteSpec("/matcher") with RequestGen with Pat
           .withHeaders(RawHeader("X-API-KEY", apiKey)) ~> route ~> check {
           status shouldEqual StatusCodes.BadRequest
           val message = (responseAs[JsValue] \ "message").as[JsString]
-          message.value shouldEqual "Invalid input for the asset rate"
+          message.value shouldEqual "The provided JSON is invalid. Check the documentation"
         }
       },
       apiKey,


### PR DESCRIPTION
* Unified rejections handling for Json parsing errors added (copied from the master branch)
* InvalidRateInput error removed
* Order placement by JsObject in it-tests