### PR TITLE
DEX-492 withAuth refactoring

### DIFF
--- a/dex/src/main/resources/application.conf
+++ b/dex/src/main/resources/application.conf
@@ -32,7 +32,7 @@ waves.dex {
     # Bind port
     port = 6886
 
-    # Hash of API key string
+    # Hash of API key string (base58)
     api-key-hash = ""
 
     # Enable/disable CORS support

--- a/dex/src/main/scala/com/wavesplatform/dex/api/MatcherApiRouteV1.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/MatcherApiRouteV1.scala
@@ -4,12 +4,12 @@ import akka.http.scaladsl.marshalling.{ToResponseMarshallable, ToResponseMarshal
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.directives.FutureDirectives
 import akka.http.scaladsl.server.{Directive0, Directive1, Route}
-import com.wavesplatform.api.http._
+import com.wavesplatform.api.http.ApiRoute
+import com.wavesplatform.dex.api.http.AuthRoute
 import com.wavesplatform.dex.error.{ErrorFormatterContext, MatcherError}
 import com.wavesplatform.dex.model.MatcherModel
 import com.wavesplatform.dex.settings.MatcherSettings
 import com.wavesplatform.dex.{AssetPairBuilder, Matcher}
-import com.wavesplatform.settings.RestAPISettings
 import com.wavesplatform.transaction.assets.exchange.AssetPair
 import com.wavesplatform.utils.ScorexLogging
 import io.swagger.annotations._
@@ -20,7 +20,7 @@ import javax.ws.rs.Path
 case class MatcherApiRouteV1(assetPairBuilder: AssetPairBuilder,
                              orderBookSnapshot: OrderBookSnapshotHttpCache,
                              matcherStatus: () => Matcher.Status,
-                             apiKeyHashStr: String,
+                             apiKeyHash: Option[Array[Byte]],
                              matcherSettings: MatcherSettings)(implicit val errorContext: ErrorFormatterContext)
     extends ApiRoute
     with AuthRoute
@@ -77,17 +77,4 @@ case class MatcherApiRouteV1(assetPairBuilder: AssetPairBuilder,
       }
     }
   }
-
-  // TODO remove AuthRoute
-  override def settings: RestAPISettings =
-    RestAPISettings(
-      true,
-      matcherSettings.restApi.address,
-      matcherSettings.restApi.port,
-      apiKeyHashStr,
-      true,
-      true,
-      100,
-      100
-    )
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/api/http/AuthRoute.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/http/AuthRoute.scala
@@ -1,0 +1,28 @@
+package com.wavesplatform.dex.api.http
+
+import akka.http.scaladsl.marshalling.ToResponseMarshaller
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directive0
+import com.wavesplatform.api.http.ApiRoute
+import com.wavesplatform.crypto
+import com.wavesplatform.dex.api.{MatcherResponse, SimpleErrorResponse}
+import com.wavesplatform.dex.error.{ApiKeyIsNotProvided, ApiKeyIsNotValid}
+import com.wavesplatform.http.{`X-Api-Key`, api_key}
+
+trait AuthRoute { this: ApiRoute =>
+
+  protected val apiKeyHash: Option[Array[Byte]]
+
+  def withAuth(implicit trm: ToResponseMarshaller[MatcherResponse]): Directive0 = {
+    apiKeyHash.fold[Directive0] { complete(SimpleErrorResponse(StatusCodes.InternalServerError, ApiKeyIsNotProvided)) } { hashFromSettings =>
+      optionalHeaderValueByType[`X-Api-Key`](()).flatMap {
+        case Some(key) if java.util.Arrays.equals(crypto secureHash key.value, hashFromSettings) => pass
+        case _ =>
+          optionalHeaderValueByType[api_key](()).flatMap {
+            case Some(key) if java.util.Arrays.equals(crypto secureHash key.value, hashFromSettings) => pass
+            case _                                                                                   => complete { SimpleErrorResponse(StatusCodes.Forbidden, ApiKeyIsNotValid) }
+          }
+      }
+    }
+  }
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/error/MatcherError.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/error/MatcherError.scala
@@ -449,6 +449,11 @@ case object NonPositiveAssetRate extends MatcherError(rate, commonEntity, outOfB
 case class RateNotFound(theAsset: Asset)
     extends MatcherError(rate, commonEntity, notFound, e"The rate for the asset ${'assetId -> theAsset} was not specified")
 
+case object ApiKeyIsNotProvided
+    extends MatcherError(auth, commonEntity, notProvided, e"API key is not provided in the configuration, please contact with the administrator")
+
+case object ApiKeyIsNotValid extends MatcherError(auth, commonEntity, commonClass, e"Provided API key is not correct")
+
 sealed abstract class Entity(val code: Int)
 object Entity {
   object common  extends Entity(0)
@@ -479,6 +484,7 @@ object Entity {
 
   object producer     extends Entity(100)
   object connectivity extends Entity(101)
+  object auth         extends Entity(102)
 }
 
 sealed abstract class Class(val code: Int)
@@ -500,4 +506,5 @@ object Class {
   object stopping     extends Class(14)
   object outOfBound   extends Class(15)
   object disabled     extends Class(16)
+  object notProvided  extends Class(17)
 }

--- a/dex/src/test/scala/com/wavesplatform/dex/api/MatcherApiRouteSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/api/MatcherApiRouteSpec.scala
@@ -185,13 +185,13 @@ class MatcherApiRouteSpec extends RouteSpec("/matcher") with MatcherTestData wit
 
     "change rates with wrong api key" in test(
       { route =>
-        Put(routePath("/settings/rates/WAVES"), rate).withHeaders(RawHeader("X-API-KEY", apiKey)) ~> route ~> check {
+        Put(routePath("/settings/rates/WAVES"), rate).withHeaders(RawHeader("X-API-KEY", "wrongApiKey")) ~> route ~> check {
           status shouldBe StatusCodes.Forbidden
           val message = (responseAs[JsValue] \ "message").as[JsString]
           message.value shouldEqual "Provided API key is not correct"
         }
       },
-      "wrongApiKey"
+      apiKey
     )
 
     "deleting waves rate" in test(
@@ -218,13 +218,13 @@ class MatcherApiRouteSpec extends RouteSpec("/matcher") with MatcherTestData wit
 
     "delete rates with wrong api key" in test(
       { route =>
-        Delete(routePath("/settings/rates/WAVES")).withHeaders(RawHeader("X-API-KEY", apiKey)) ~> route ~> check {
+        Delete(routePath("/settings/rates/WAVES")).withHeaders(RawHeader("X-API-KEY", "wrongApiKey")) ~> route ~> check {
           status shouldBe StatusCodes.Forbidden
           val message = (responseAs[JsValue] \ "message").as[JsString]
           message.value shouldEqual "Provided API key is not correct"
         }
       },
-      "wrongApiKey"
+      apiKey
     )
 
     "delete rate for the asset that doesn't have rate" in test(
@@ -331,7 +331,7 @@ class MatcherApiRouteSpec extends RouteSpec("/matcher") with MatcherTestData wit
       currentOffset = () => 0L,
       lastOffset = () => Future.successful(0L),
       matcherAccountFee = 300000L,
-      apiKeyHashStr = Base58.encode(crypto.secureHash(apiKey.getBytes("UTF-8"))),
+      apiKeyHash = Some(crypto secureHash apiKey),
       rateCache = rateCache,
       validatedAllowedOrderVersions = Future.successful { Set(1, 2, 3) }
     ).route


### PR DESCRIPTION
* DEX's withAuth introduced
* apiKey now passed to the MatcherApiRoute/V1 as optional byte array
* Checking apiKeyHash during matcher's start
* ApiKeyIsNoProvided and ApiKeyIsNotValid matcher errors introduced