### PR TITLE
DEX-462 Better error for WAVES as Base58 in matcherFeeAssetId field

### DIFF
--- a/dex/src/main/scala/com/wavesplatform/dex/error/MatcherError.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/error/MatcherError.scala
@@ -90,7 +90,9 @@ case class UnexpectedFeeAsset(required: Set[Asset], given: Asset)
       order,
       fee,
       unexpected,
-      e"Required one of the following fee asset: ${'required -> required}. But given ${'given -> given}"
+      if (AssetPair.assetIdStr(given) == "WAVES")
+        e"""Required one of the following fee asset: ${'required  -> required}. But given "WAVES" as Base58 string. Remove this field if you want to specify WAVES in JSON"""
+      else e"Required one of the following fee asset: ${'required -> required}. But given ${'given -> given}"
     )
 
 case class FeeNotEnough(required: Long, given: Long, theAsset: Asset)

--- a/dex/src/main/scala/com/wavesplatform/dex/model/MatcherModel.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/MatcherModel.scala
@@ -266,25 +266,19 @@ sealed trait MarketOrder extends AcceptedOrder {
 
 object MarketOrder {
 
-  def apply(o: Order, availableForSpending: Long): MarketOrder = {
-
-    val pf = AcceptedOrder.partialFee(o.matcherFee, o.amount, o.amount)
-
-    o.orderType match {
-      case OrderType.BUY  => BuyMarketOrder(o.amount, pf, o, availableForSpending)
-      case OrderType.SELL => SellMarketOrder(o.amount, pf, o, availableForSpending)
+  private def create(order: Order, availableForSpending: Long): MarketOrder = {
+    val pf = AcceptedOrder.partialFee(order.matcherFee, order.amount, order.amount)
+    order.orderType match {
+      case OrderType.BUY  => BuyMarketOrder(order.amount, pf, order, availableForSpending)
+      case OrderType.SELL => SellMarketOrder(order.amount, pf, order, availableForSpending)
     }
   }
 
+  def apply(o: Order, availableForSpending: Long): MarketOrder = create(o, availableForSpending)
+
   def apply(o: Order, tradableBalance: Asset => Long): MarketOrder = {
-
-    val pf                   = AcceptedOrder.partialFee(o.matcherFee, o.amount, o.amount)
     val availableForSpending = math.min(tradableBalance(o.getSpendAssetId), LimitOrder(o).requiredBalance(o.getSpendAssetId))
-
-    o.orderType match {
-      case OrderType.BUY  => BuyMarketOrder(o.amount, pf, o, availableForSpending)
-      case OrderType.SELL => SellMarketOrder(o.amount, pf, o, availableForSpending)
-    }
+    create(o, availableForSpending)
   }
 }
 


### PR DESCRIPTION
* UnexpectedFeeAsset error improved
* Unit test added

Refactoring

 * Code duplication in MatcherModel (MarketOrder object) fixed