### PR TITLE
DEX-537 Distinguishing limit and market orders in order history

### DIFF
--- a/dex-it/src/test/scala/com/wavesplatform/it/api/model.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/api/model.scala
@@ -196,7 +196,8 @@ case class OrderHistory(id: String,
                         filledFee: Long,
                         feeAsset: Asset,
                         status: String,
-                        assetPair: AssetPair) {
+                        assetPair: AssetPair,
+                        orderType: String) {
   def isActive: Boolean = status == "PartiallyFilled" || status == "Accepted"
 }
 

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/MatcherTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/MatcherTestSuite.scala
@@ -6,7 +6,7 @@ import com.wavesplatform.dex.db.OrderDB
 import com.wavesplatform.it.MatcherSuiteBase
 import com.wavesplatform.it.api.SyncHttpApi._
 import com.wavesplatform.it.api.SyncMatcherHttpApi._
-import com.wavesplatform.it.api.{AssetDecimalsInfo, LevelResponse}
+import com.wavesplatform.it.api.{AssetDecimalsInfo, LevelResponse, OrderHistory}
 import com.wavesplatform.it.sync.config.MatcherPriceAssetConfig._
 import com.wavesplatform.transaction.Asset.{IssuedAsset, Waves}
 import com.wavesplatform.transaction.assets.exchange.OrderType._
@@ -55,6 +55,17 @@ class MatcherTestSuite extends MatcherSuiteBase with TableDrivenPropertyChecks {
       amountAsset = IssuedAsset(ByteStr.decodeBase58(bobAsset2).get),
       priceAsset = Waves
     )
+
+    "orderType should be limit for a limit order" in {
+      def validateHistory(label: String, orders: Seq[OrderHistory]): Unit = withClue(s"$label: ") {
+        orders should have size 1
+        orders.head.orderType shouldBe "limit"
+      }
+
+      validateHistory("by pair", node.orderHistoryByPair(alice, aliceWavesPair))
+      validateHistory("full", node.fullOrderHistory(alice))
+      validateHistory("admin", node.ordersByAddress(alice, activeOnly = false))
+    }
 
     "assert addresses balances" in {
       node.assertAssetBalance(alice.toAddress.toString, aliceAsset, AssetQuantity)

--- a/dex/src/main/scala/com/wavesplatform/dex/AddressActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/AddressActor.scala
@@ -309,7 +309,7 @@ class AddressActor(owner: Address,
     orderDB.saveOrderInfo(
       ao.order.id(),
       owner,
-      OrderInfo.v2(
+      OrderInfo.v3(
         ao.order.orderType,
         ao.order.amount,
         ao.order.price,
@@ -317,7 +317,8 @@ class AddressActor(owner: Address,
         ao.order.matcherFeeAssetId,
         ao.order.timestamp,
         status,
-        ao.order.assetPair
+        ao.order.assetPair,
+        if (ao.isLimit) AcceptedOrderType.Limit else AcceptedOrderType.Market
       )
     )
   }

--- a/dex/src/main/scala/com/wavesplatform/dex/api/MatcherApiRoute.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/MatcherApiRoute.scala
@@ -487,6 +487,7 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
           Json.obj(
             "id"        -> id.toString,
             "type"      -> oi.side.toString,
+            "orderType" -> oi.orderType,
             "amount"    -> oi.amount,
             "fee"       -> oi.matcherFee,
             "price"     -> oi.price,

--- a/dex/src/main/scala/com/wavesplatform/dex/model/AcceptedOrderType.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/AcceptedOrderType.scala
@@ -1,0 +1,27 @@
+package com.wavesplatform.dex.model
+
+import play.api.libs.json._
+
+// TODO Rename OrderType to OrderSide and AcceptedOrderType to OrderType in master
+sealed trait AcceptedOrderType
+
+object AcceptedOrderType {
+  case object Limit extends AcceptedOrderType
+  case object Market extends AcceptedOrderType
+
+  implicit val acceptedOrderTypeFormat: Format[AcceptedOrderType] = Format(
+    Reads {
+      case JsString(value) =>
+        value match {
+          case "limit"  => JsSuccess(AcceptedOrderType.Limit)
+          case "market" => JsSuccess(AcceptedOrderType.Market)
+          case x        => JsError(s"Unknown order type: $x")
+        }
+      case x => JsError(s"Can't parse '$x' as AcceptedOrderType")
+    },
+    Writes {
+      case Limit  => JsString("limit")
+      case Market => JsString("market")
+    }
+  )
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/util/Codecs.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/util/Codecs.scala
@@ -3,7 +3,7 @@ package com.wavesplatform.dex.util
 import java.nio.ByteBuffer
 
 import com.wavesplatform.common.state.ByteStr
-import com.wavesplatform.dex.model.OrderStatus
+import com.wavesplatform.dex.model.{AcceptedOrderType, OrderStatus}
 import com.wavesplatform.transaction.Asset
 import com.wavesplatform.transaction.Asset.{IssuedAsset, Waves}
 
@@ -48,6 +48,17 @@ object Codecs {
           OrderStatus.Cancelled(filledAmount, fee(filledAmount))
         case x => throw new IllegalArgumentException(s"Can't parse order status: $x")
       }
+    }
+
+    def putAcceptedOrderType(x: AcceptedOrderType): ByteBuffer = x match {
+      case AcceptedOrderType.Limit  => b.put(0: Byte)
+      case AcceptedOrderType.Market => b.put(1: Byte)
+    }
+
+    def getAcceptedOrderType: AcceptedOrderType = b.get match {
+      case 0 => AcceptedOrderType.Limit
+      case 1 => AcceptedOrderType.Market
+      case x => throw new IllegalArgumentException(s"Can't parse accepted order type: $x")
     }
   }
 }


### PR DESCRIPTION
Model:
* Added AcceptedOrderType with two members: Limit and Market;
* OrderInfo: added the 3 version with orderType;
* Implemented a new serialization/deserialization for new OrderInfo in bytes;

MatcherApiRoute:
* Added "orderType" in JSON of getAssetPairAndPublicKeyOrderHistory, getPublicKeyOrderHistory and admin's getAllOrderHistory;

Integration tests:
* Added tests to check order types for both Limit and Market orders;