### PR TITLE
DEX-570 Different fees for makers and takers

### DIFF
--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/BaseContainersKit.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/BaseContainersKit.scala
@@ -21,7 +21,6 @@ import org.asynchttpclient.DefaultAsyncHttpClientConfig
 import org.testcontainers.containers.Network
 import org.testcontainers.containers.Network.NetworkImpl
 
-import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Random, Try}
 
@@ -95,6 +94,6 @@ trait BaseContainersKit extends ScorexLogging {
     log.debug("Stopping containers")
     futureHttpBackend.close()
     tryHttpBackend.close()
-    knownContainers.asScala.foreach(_.stopWithoutRemove()) // Graceful shutdown to save logs
+    knownContainers.forEach(_.stopWithoutRemove()) // Graceful shutdown to save logs
   }
 }

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/config/PredefinedAssets.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/config/PredefinedAssets.scala
@@ -43,5 +43,5 @@ trait PredefinedAssets {
   val ForbiddenAssetId: ByteStr   = ByteStr.decodeBase58("FdbnAsset").get
   val ForbiddenAsset: IssuedAsset = IssuedAsset(ForbiddenAssetId)
 
-  implicit val assetDecimalsMap: Map[Asset, Int] = Map(Waves -> 8, usd -> 2, wct -> 2, eth -> 8, btc -> 8)
+  implicit val assetDecimalsMap: Map[Asset, Int] = Map[Asset, Int](Waves -> 8, usd -> 2, wct -> 2, eth -> 8, btc -> 8).withDefaultValue(8)
 }

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/waves/MkWavesEntities.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/waves/MkWavesEntities.scala
@@ -70,7 +70,10 @@ trait MkWavesEntities {
         feeAsset = feeAsset
       )
 
-  /** Creates order with denormalized price */
+  /**
+    * Creates order with denormalized price.
+    * For not predefined assets it is required to enrich `PredefinedAssets.assetsDecimalsMap` (use overriding), otherwise 8 decimals will be picked
+    */
   def mkOrderDP(owner: KeyPair,
                 pair: AssetPair,
                 orderType: OrderType,
@@ -82,7 +85,7 @@ trait MkWavesEntities {
                 ttl: Duration = 30.days - 1.seconds,
                 version: Byte = orderVersion,
                 matcher: PublicKey = matcher)(implicit assetDecimalsMap: Map[Asset, Int]): Order = {
-    val normalizedPrice = Normalization.normalizePrice(price, assetDecimalsMap.getOrElse(pair.amountAsset, 8), assetDecimalsMap.getOrElse(pair.priceAsset, 8))
+    val normalizedPrice = Normalization.normalizePrice(price, assetDecimalsMap(pair.amountAsset), assetDecimalsMap(pair.priceAsset))
     mkOrder(owner, pair, orderType, amount, normalizedPrice, matcherFee, feeAsset, ts, ttl, version, matcher)
   }
 

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/waves/MkWavesEntities.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/waves/MkWavesEntities.scala
@@ -82,7 +82,7 @@ trait MkWavesEntities {
                 ttl: Duration = 30.days - 1.seconds,
                 version: Byte = orderVersion,
                 matcher: PublicKey = matcher)(implicit assetDecimalsMap: Map[Asset, Int]): Order = {
-    val normalizedPrice = Normalization.normalizePrice(price, assetDecimalsMap(pair.amountAsset), assetDecimalsMap(pair.priceAsset))
+    val normalizedPrice = Normalization.normalizePrice(price, assetDecimalsMap.getOrElse(pair.amountAsset, 8), assetDecimalsMap.getOrElse(pair.priceAsset, 8))
     mkOrder(owner, pair, orderType, amount, normalizedPrice, matcherFee, feeAsset, ts, ttl, version, matcher)
   }
 

--- a/dex-it/src/test/scala/com/wavesplatform/it/api/ApiExtensions.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/api/ApiExtensions.scala
@@ -22,8 +22,9 @@ trait ApiExtensions extends NodeApiExtensions { this: MatcherSuiteBase =>
 
   protected def placeAndAwaitAtNode(order: Order,
                                     dexApi: DexApi[Id] = dex1.api,
-                                    wavesNodeApi: NodeApi[Id] = wavesNode1.api): Seq[ExchangeTransaction] = {
-    dex1.api.place(order)
+                                    wavesNodeApi: NodeApi[Id] = wavesNode1.api,
+                                    isMarketOrder: Boolean = false): Seq[ExchangeTransaction] = {
+    if (isMarketOrder) dex1.api.placeMarket(order) else dex1.api.place(order)
     waitForOrderAtNode(order.id(), dexApi, wavesNodeApi)
   }
 

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/MarketOrderTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/MarketOrderTestSuite.scala
@@ -35,7 +35,7 @@ class MarketOrderTestSuite extends MatcherSuiteBase {
        |waves.dex {
        |  price-assets = [ "$UsdId", "WAVES", "$EthId", "$BtcId", "$WctId" ]
        |  allowed-order-versions = [1, 2, 3]
-       |  order-fee.0 {
+       |  order-fee.-1 {
        |    mode = $PERCENT
        |    $DYNAMIC {
        |      base-fee = 300000
@@ -166,7 +166,7 @@ class MarketOrderTestSuite extends MatcherSuiteBase {
     "fixed fee mode" - {
 
       "processing market order (SELL)" in {
-        dex1.restartWithNewSuiteConfig(ConfigFactory.parseString(s"waves.dex.order-fee.0.mode = $FIXED").withFallback(dexInitialSuiteConfig))
+        dex1.restartWithNewSuiteConfig(ConfigFactory.parseString(s"waves.dex.order-fee.-1.mode = $FIXED").withFallback(dexInitialSuiteConfig))
 
         testFilledMarketOrder(SELL, FIXED)
       }
@@ -424,7 +424,7 @@ class MarketOrderTestSuite extends MatcherSuiteBase {
 
     "should be rejected if user has enough balance to fill market order, but has not enough balance to pay fee in another asset" in {
       dex1.restartWithNewSuiteConfig(
-        ConfigFactory.parseString(s"waves.dex.order-fee.0.fixed.asset = $BtcId\nwaves.dex.order-fee.0.mode = $FIXED").withFallback(dexInitialSuiteConfig)
+        ConfigFactory.parseString(s"waves.dex.order-fee.-1.fixed.asset = $BtcId\nwaves.dex.order-fee.-1.mode = $FIXED").withFallback(dexInitialSuiteConfig)
       )
 
       val amount   = 10.waves

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/MarketOrderTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/MarketOrderTestSuite.scala
@@ -35,7 +35,7 @@ class MarketOrderTestSuite extends MatcherSuiteBase {
        |waves.dex {
        |  price-assets = [ "$UsdId", "WAVES", "$EthId", "$BtcId", "$WctId" ]
        |  allowed-order-versions = [1, 2, 3]
-       |  order-fee {
+       |  order-fee.0 {
        |    mode = $PERCENT
        |    $DYNAMIC {
        |      base-fee = 300000
@@ -166,7 +166,7 @@ class MarketOrderTestSuite extends MatcherSuiteBase {
     "fixed fee mode" - {
 
       "processing market order (SELL)" in {
-        dex1.restartWithNewSuiteConfig(ConfigFactory.parseString(s"waves.dex.order-fee.mode = $FIXED").withFallback(dexInitialSuiteConfig))
+        dex1.restartWithNewSuiteConfig(ConfigFactory.parseString(s"waves.dex.order-fee.0.mode = $FIXED").withFallback(dexInitialSuiteConfig))
 
         testFilledMarketOrder(SELL, FIXED)
       }
@@ -424,7 +424,7 @@ class MarketOrderTestSuite extends MatcherSuiteBase {
 
     "should be rejected if user has enough balance to fill market order, but has not enough balance to pay fee in another asset" in {
       dex1.restartWithNewSuiteConfig(
-        ConfigFactory.parseString(s"waves.dex.order-fee.fixed.asset = $BtcId\nwaves.dex.order-fee.mode = $FIXED").withFallback(dexInitialSuiteConfig)
+        ConfigFactory.parseString(s"waves.dex.order-fee.0.fixed.asset = $BtcId\nwaves.dex.order-fee.0.mode = $FIXED").withFallback(dexInitialSuiteConfig)
       )
 
       val amount   = 10.waves

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/OrderDeviationsTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/OrderDeviationsTestSuite.scala
@@ -57,7 +57,7 @@ class OrderDeviationsTestSuite extends MatcherSuiteBase {
        |    loss = $deviationLoss
        |    fee = $deviationFee
        |  }
-       |  order-fee.0 {
+       |  order-fee.-1 {
        |    mode = "percent"
        |    percent {
        |      asset-type = "price"

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/OrderDeviationsTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/OrderDeviationsTestSuite.scala
@@ -57,7 +57,7 @@ class OrderDeviationsTestSuite extends MatcherSuiteBase {
        |    loss = $deviationLoss
        |    fee = $deviationFee
        |  }
-       |  order-fee {
+       |  order-fee.0 {
        |    mode = "percent"
        |    percent {
        |      asset-type = "price"

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/RatesTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/RatesTestSuite.scala
@@ -16,13 +16,6 @@ class RatesTestSuite extends MatcherSuiteBase {
   override protected val dexInitialSuiteConfig: Config = ConfigFactory.parseString(
     s"""waves.dex {
        |  price-assets = [ "$UsdId", "$BtcId", "WAVES" ]
-       |  allowed-order-versions = [1, 2, 3]
-       |  order-fee {
-       |    mode = dynamic
-       |    dynamic {
-       |      base-fee = 300000
-       |    }
-       |  }
        |}""".stripMargin
   )
 

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/MakerTakerFeeTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/MakerTakerFeeTestSuite.scala
@@ -1,0 +1,152 @@
+package com.wavesplatform.it.sync.orders
+
+import com.typesafe.config.{Config, ConfigFactory}
+import com.wavesplatform.dex.domain.asset.Asset
+import com.wavesplatform.dex.domain.asset.Asset.Waves
+import com.wavesplatform.dex.domain.model.Denormalization._
+import com.wavesplatform.dex.domain.order.OrderType.{BUY, SELL}
+import com.wavesplatform.it.MatcherSuiteBase
+
+class MakerTakerFeeTestSuite extends MatcherSuiteBase {
+
+  private val maker = bob
+  private val taker = alice
+
+  override protected val dexInitialSuiteConfig: Config = ConfigFactory.parseString(
+    s"""
+       |waves.dex {
+       |  price-assets = [ "$UsdId", "WAVES" ]
+       |  order-fee {
+       |    mode = dynamic
+       |    dynamic {
+       |      base-fee = 300000
+       |      zero-maker-double-taker = true
+       |    }
+       |  }
+       |}
+       """.stripMargin
+  )
+
+  override protected def beforeAll(): Unit = {
+    wavesNode1.start()
+    broadcastAndAwait(IssueUsdTx, IssueEthTx)
+    dex1.start()
+    dex1.api.upsertRate(eth, 0.00567593) // 0.003.waves = 0.00001703.eth
+  }
+
+  override protected def afterEach(): Unit = {
+    super.afterEach()
+    dex1.api.cancelAll(maker)
+    dex1.api.cancelAll(taker)
+  }
+
+  private def matchMakerWithTaker(makerAmount: Long,
+                                  makerFee: Long = 0.006.waves,
+                                  makerFeeAsset: Asset = Waves,
+                                  takerAmount: Long,
+                                  takerFee: Long = 0.006.waves,
+                                  takerFeeAsset: Asset = Waves,
+                                  expectedMakerFeeAssetBalanceChange: Long,
+                                  expectedTakerFeeAssetBalanceChange: Long,
+                                  isTakerMarket: Boolean = false): Unit = {
+
+    val makerInitialFeeAssetBalance = wavesNode1.api.balance(maker, makerFeeAsset)
+    val takerInitialFeeAssetBalance = wavesNode1.api.balance(taker, takerFeeAsset)
+
+    val makerOrder = mkOrderDP(maker, wavesUsdPair, SELL, makerAmount, 3.0, makerFee, makerFeeAsset)
+    val takerOrder = mkOrderDP(taker, wavesUsdPair, BUY, takerAmount, 3.0, takerFee, takerFeeAsset)
+
+    placeAndAwaitAtDex(makerOrder)
+    placeAndAwaitAtNode(takerOrder, isMarketOrder = isTakerMarket)
+
+    def printAmount(value: Long, asset: Asset): String = s"${denormalizeAmountAndFee(value, assetDecimalsMap(asset))} $asset"
+
+    withClue(
+      s"""
+         |maker amount                            = ${printAmount(makerAmount, Waves)}
+         |maker fee                               = ${printAmount(makerFee, makerFeeAsset)}
+         |maker initial fee asset balance         = ${printAmount(makerInitialFeeAssetBalance, makerFeeAsset)}
+         |expected maker fee asset balance change = ${printAmount(expectedMakerFeeAssetBalanceChange, makerFeeAsset)}
+         |expected maker fee asset balance        = ${printAmount(makerInitialFeeAssetBalance + expectedMakerFeeAssetBalanceChange, makerFeeAsset)}
+         |
+         |taker amount                            = ${printAmount(takerAmount, Waves)}
+         |taker fee                               = ${printAmount(takerFee, takerFeeAsset)}
+         |taker initial fee asset balance         = ${printAmount(takerInitialFeeAssetBalance, takerFeeAsset)}
+         |expected taker fee asset balance change = ${printAmount(expectedTakerFeeAssetBalanceChange, takerFeeAsset)}
+         |expected taker fee asset balance        = ${printAmount(takerInitialFeeAssetBalance + expectedTakerFeeAssetBalanceChange, takerFeeAsset)}
+         |is taker market                         = $isTakerMarket
+         |
+         |""".stripMargin
+    ) {
+      wavesNode1.api.balance(maker, makerFeeAsset) shouldBe makerInitialFeeAssetBalance + expectedMakerFeeAssetBalanceChange
+      wavesNode1.api.balance(taker, takerFeeAsset) shouldBe takerInitialFeeAssetBalance + expectedTakerFeeAssetBalanceChange
+    }
+  }
+
+  "DEX should charge 0 fee for makers and doubled fee for takers" - {
+
+    "rejecting orders with insufficient fee" in {
+      dex1.api.tryPlace(mkOrderDP(maker, wavesUsdPair, SELL, 1.waves, 3.00, 0.00599999.waves)) should failWith(
+        9441542, // FeeNotEnough
+        s"Required 0.006 WAVES as fee for this order, but given 0.00599999 WAVES"
+      )
+    }
+
+    "symmetric orders" in {
+      matchMakerWithTaker(
+        makerAmount = 1.waves,
+        takerAmount = 1.waves,
+        expectedMakerFeeAssetBalanceChange = -1.waves,
+        expectedTakerFeeAssetBalanceChange = 1.waves - 0.006.waves
+      )
+    }
+
+    "symmetric orders with MARKET taker" in {
+      matchMakerWithTaker(
+        makerAmount = 1.waves,
+        takerAmount = 1.waves,
+        expectedMakerFeeAssetBalanceChange = -1.waves,
+        expectedTakerFeeAssetBalanceChange = 1.waves - 0.006.waves,
+        isTakerMarket = true
+      )
+    }
+
+    "little maker and big taker" in {
+      matchMakerWithTaker(
+        makerAmount = 1.waves,
+        takerAmount = 10.waves,
+        expectedMakerFeeAssetBalanceChange = -1.waves,
+        expectedTakerFeeAssetBalanceChange = 1.waves - 0.0006.waves
+      )
+    }
+
+    "little maker and big MARKET taker" in {
+      matchMakerWithTaker(
+        makerAmount = 1.waves,
+        takerAmount = 10.waves,
+        expectedMakerFeeAssetBalanceChange = -1.waves,
+        expectedTakerFeeAssetBalanceChange = 1.waves - 0.0006.waves,
+        isTakerMarket = true
+      )
+    }
+
+    "big maker and little taker" in {
+      matchMakerWithTaker(
+        makerAmount = 10.waves,
+        takerAmount = 1.waves,
+        expectedMakerFeeAssetBalanceChange = -1.waves,
+        expectedTakerFeeAssetBalanceChange = 1.waves - 0.006.waves
+      )
+    }
+
+    "big maker and little MARKET taker" in {
+      matchMakerWithTaker(
+        makerAmount = 10.waves,
+        takerAmount = 1.waves,
+        expectedMakerFeeAssetBalanceChange = -1.waves,
+        expectedTakerFeeAssetBalanceChange = 1.waves - 0.006.waves,
+        isTakerMarket = true
+      )
+    }
+  }
+}

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/MakerTakerFeeTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/MakerTakerFeeTestSuite.scala
@@ -18,7 +18,7 @@ class MakerTakerFeeTestSuite extends MatcherSuiteBase with TableDrivenPropertyCh
     s"""
        |waves.dex {
        |  price-assets = [ "$UsdId", "WAVES" ]
-       |  order-fee.0 {
+       |  order-fee.-1 {
        |    mode = dynamic
        |    dynamic {
        |      base-maker-fee = ${0.001.waves}

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/MakerTakerFeeTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/MakerTakerFeeTestSuite.scala
@@ -129,7 +129,7 @@ class MakerTakerFeeTestSuite extends MatcherSuiteBase with TableDrivenPropertyCh
            |waves.dex {
            |  price-assets = [ "$UsdId", "WAVES" ]
            |  order-fee {
-           |    0: {
+           |    -1: {
            |      mode = dynamic
            |      dynamic {
            |        base-maker-fee = ${0.003.waves}

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderDynamicFeeTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderDynamicFeeTestSuite.scala
@@ -16,7 +16,7 @@ class OrderDynamicFeeTestSuite extends OrderFeeBaseTestSuite {
        |waves.dex {
        |  price-assets = [ "$UsdId", "$BtcId", "WAVES" ]
        |  allowed-order-versions = [1, 2, 3]
-       |  order-fee {
+       |  order-fee.0 {
        |    mode = dynamic
        |    dynamic {
        |      base-maker-fee = $baseFee
@@ -793,14 +793,14 @@ class OrderDynamicFeeTestSuite extends OrderFeeBaseTestSuite {
 
       broadcastAndAwait { mkTransfer(alice, bob, defaultAssetQuantity / 2, eth, 0.005.waves) }
 
-      dex1.restartWithNewSuiteConfig(ConfigFactory.parseString("waves.dex.order-fee.mode = percent"))
+      dex1.restartWithNewSuiteConfig(ConfigFactory.parseString("waves.dex.order-fee.0.mode = percent"))
       check()
 
-      dex1.restartWithNewSuiteConfig(ConfigFactory.parseString("waves.dex.order-fee.mode = fixed").withFallback(dexInitialSuiteConfig))
+      dex1.restartWithNewSuiteConfig(ConfigFactory.parseString("waves.dex.order-fee.0.mode = fixed").withFallback(dexInitialSuiteConfig))
       check()
 
       dex1.restartWithNewSuiteConfig(
-        ConfigFactory.parseString(s"waves.dex.order-fee.fixed.asset = $BtcId\nwaves.dex.order-fee.mode = fixed").withFallback(dexInitialSuiteConfig)
+        ConfigFactory.parseString(s"waves.dex.order-fee.0.fixed.asset = $BtcId\nwaves.dex.order-fee.0.mode = fixed").withFallback(dexInitialSuiteConfig)
       )
 
       withClue("fee asset isn't part of asset pair") {

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderDynamicFeeTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderDynamicFeeTestSuite.scala
@@ -19,7 +19,8 @@ class OrderDynamicFeeTestSuite extends OrderFeeBaseTestSuite {
        |  order-fee {
        |    mode = dynamic
        |    dynamic {
-       |      base-fee = $baseFee
+       |      base-maker-fee = $baseFee
+       |      base-taker-fee = $baseFee
        |    }
        |    percent {
        |      asset-type = amount
@@ -188,27 +189,34 @@ class OrderDynamicFeeTestSuite extends OrderFeeBaseTestSuite {
 
     "asset became not supported after order was placed" in {
       upsertRates(btc -> btcRate, eth -> ethRate)
+
       val bobBtcBalance   = wavesNode1.api.balance(bob, btc)
       val aliceBtcBalance = wavesNode1.api.balance(alice, btc)
       val aliceEthBalance = wavesNode1.api.balance(alice, eth)
+
       dex1.api.place(order)
       dex1.api.deleteRate(btc)
       dex1.api.place(mkAliceOrder)
       dex1.api.waitForOrderStatus(order, OrderStatus.Filled)
+
       waitForOrderAtNode(order)
+
       eventually {
         wavesNode1.api.balance(bob, btc) shouldBe (bobBtcBalance - 150L - 50000L)
         wavesNode1.api.balance(alice, btc) shouldBe (aliceBtcBalance + 50000L)
         wavesNode1.api.balance(alice, eth) shouldBe (aliceEthBalance - 1920L)
       }
+
       dex1.api.deleteRate(eth)
     }
 
     "asset became not supported after order was partially filled" in {
       upsertRates(btc -> btcRate, eth -> ethRate)
+
       val bobBtcBalance   = wavesNode1.api.balance(bob, btc)
       val aliceBtcBalance = wavesNode1.api.balance(alice, btc)
       val aliceEthBalance = wavesNode1.api.balance(alice, eth)
+
       val aliceOrder = mkOrder(
         owner = alice,
         matcher = matcher,
@@ -219,11 +227,14 @@ class OrderDynamicFeeTestSuite extends OrderFeeBaseTestSuite {
         matcherFee = 1920L,
         feeAsset = eth
       )
+
       dex1.api.place(aliceOrder)
       dex1.api.reservedBalance(alice)(eth) shouldBe 1920L
       dex1.api.place(mkBobOrder)
       dex1.api.waitForOrderStatus(aliceOrder, OrderStatus.PartiallyFilled)
+
       waitForOrderAtNode(aliceOrder)
+
       eventually {
         dex1.api.reservedBalance(alice)(eth) shouldBe 960L
         wavesNode1.api.balance(bob, btc) shouldBe (bobBtcBalance - 150L - 50000L)
@@ -234,31 +245,39 @@ class OrderDynamicFeeTestSuite extends OrderFeeBaseTestSuite {
       dex1.api.deleteRate(eth)
 
       val bobSecondOrder = mkBobOrder
+
       dex1.api.place(bobSecondOrder)
       dex1.api.waitForOrderStatus(aliceOrder, OrderStatus.Filled)
+
       waitForOrderAtNode(bobSecondOrder)
+
       eventually {
         wavesNode1.api.balance(bob, btc) shouldBe (bobBtcBalance - 300L - 100000L)
         wavesNode1.api.balance(alice, btc) shouldBe (aliceBtcBalance + 100000L)
         wavesNode1.api.balance(alice, eth) shouldBe (aliceEthBalance - 1920L)
       }
+
       dex1.api.deleteRate(btc)
     }
 
     "rates of asset pair was changed while order is placed" in {
       upsertRates(btc -> btcRate, eth -> ethRate)
+
       val bobBtcBalance = wavesNode1.api.balance(bob, btc)
       val bobOrder      = mkBobOrder
+
       dex1.api.place(bobOrder)
 
       val newBtcRate = btcRate * 2
+
       dex1.api.upsertRate(btc, newBtcRate)._1 shouldBe StatusCodes.Ok
       dex1.api.reservedBalance(bob)(btc) shouldBe 50150L
       dex1.api.place(mkAliceOrder)
+
       waitForOrderAtNode(bobOrder)
-      eventually {
-        wavesNode1.api.balance(bob, btc) shouldBe (bobBtcBalance - 50150L)
-      }
+
+      eventually { wavesNode1.api.balance(bob, btc) shouldBe (bobBtcBalance - 50150L) }
+
       List(btc, eth).foreach(dex1.api.deleteRate)
     }
   }
@@ -296,6 +315,7 @@ class OrderDynamicFeeTestSuite extends OrderFeeBaseTestSuite {
         wavesNode1.api.balance(bob, Waves) shouldBe (bobWavesBalance + 1.waves)
         wavesNode1.api.balance(alice, Waves) shouldBe (aliceWavesBalance - 1.waves)
       }
+
       List(btc, eth).foreach(dex1.api.deleteRate)
     }
 
@@ -382,11 +402,15 @@ class OrderDynamicFeeTestSuite extends OrderFeeBaseTestSuite {
   }
 
   "cancellation of" - {
+
     val btcRate = 0.0005
     val ethRate = 0.0064
+
     "order with non-waves fee" in {
       val bobBalance = dex1.api.tradableBalance(bob, wavesBtcPair)
+
       upsertRates(btc -> btcRate)
+
       val order = mkOrder(
         owner = bob,
         pair = wavesBtcPair,
@@ -396,6 +420,7 @@ class OrderDynamicFeeTestSuite extends OrderFeeBaseTestSuite {
         matcherFee = 150L,
         feeAsset = btc
       )
+
       dex1.api.place(order)
       dex1.api.cancel(bob, order).status shouldBe "OrderCanceled"
       dex1.api.reservedBalance(bob).keys.size shouldBe 0
@@ -406,6 +431,7 @@ class OrderDynamicFeeTestSuite extends OrderFeeBaseTestSuite {
     "partially filled order with non-waves fee" in {
       val aliceEthBalance = dex1.api.tradableBalance(alice, ethWavesPair)(eth)
       upsertRates(btc -> btcRate, eth -> ethRate)
+
       val bobOrder = mkOrder(
         owner = bob,
         pair = wavesBtcPair,
@@ -416,7 +442,9 @@ class OrderDynamicFeeTestSuite extends OrderFeeBaseTestSuite {
         version = 3,
         feeAsset = btc
       )
+
       dex1.api.place(bobOrder)
+
       val aliceOrder = mkOrder(
         owner = alice,
         pair = wavesBtcPair,
@@ -426,6 +454,7 @@ class OrderDynamicFeeTestSuite extends OrderFeeBaseTestSuite {
         matcherFee = 1920L,
         feeAsset = eth
       )
+
       dex1.api.place(aliceOrder)
       List(bobOrder, aliceOrder).foreach(waitForOrderAtNode(_))
       dex1.api.cancel(alice, aliceOrder).status shouldBe "OrderCanceled"

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderDynamicFeeTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderDynamicFeeTestSuite.scala
@@ -16,7 +16,7 @@ class OrderDynamicFeeTestSuite extends OrderFeeBaseTestSuite {
        |waves.dex {
        |  price-assets = [ "$UsdId", "$BtcId", "WAVES" ]
        |  allowed-order-versions = [1, 2, 3]
-       |  order-fee.0 {
+       |  order-fee.-1 {
        |    mode = dynamic
        |    dynamic {
        |      base-maker-fee = $baseFee
@@ -793,14 +793,14 @@ class OrderDynamicFeeTestSuite extends OrderFeeBaseTestSuite {
 
       broadcastAndAwait { mkTransfer(alice, bob, defaultAssetQuantity / 2, eth, 0.005.waves) }
 
-      dex1.restartWithNewSuiteConfig(ConfigFactory.parseString("waves.dex.order-fee.0.mode = percent"))
+      dex1.restartWithNewSuiteConfig(ConfigFactory.parseString("waves.dex.order-fee.-1.mode = percent"))
       check()
 
-      dex1.restartWithNewSuiteConfig(ConfigFactory.parseString("waves.dex.order-fee.0.mode = fixed").withFallback(dexInitialSuiteConfig))
+      dex1.restartWithNewSuiteConfig(ConfigFactory.parseString("waves.dex.order-fee.-1.mode = fixed").withFallback(dexInitialSuiteConfig))
       check()
 
       dex1.restartWithNewSuiteConfig(
-        ConfigFactory.parseString(s"waves.dex.order-fee.0.fixed.asset = $BtcId\nwaves.dex.order-fee.0.mode = fixed").withFallback(dexInitialSuiteConfig)
+        ConfigFactory.parseString(s"waves.dex.order-fee.-1.fixed.asset = $BtcId\nwaves.dex.order-fee.-1.mode = fixed").withFallback(dexInitialSuiteConfig)
       )
 
       withClue("fee asset isn't part of asset pair") {

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderFixedFeeTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderFixedFeeTestSuite.scala
@@ -106,7 +106,7 @@ class OrderFixedFeeTestSuite extends OrderFeeBaseTestSuite {
   private def configWithOrderFeeFixed(matcherFeeAsset: Asset): Config = {
     parseString(s"""waves.dex {
                    | allowed-order-versions = [1, 2, 3]
-                   |  order-fee {
+                   |  order-fee.0 {
                    |    mode = fixed
                    |    fixed {
                    |      asset = ${matcherFeeAsset.toString}

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderFixedFeeTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderFixedFeeTestSuite.scala
@@ -106,7 +106,7 @@ class OrderFixedFeeTestSuite extends OrderFeeBaseTestSuite {
   private def configWithOrderFeeFixed(matcherFeeAsset: Asset): Config = {
     parseString(s"""waves.dex {
                    | allowed-order-versions = [1, 2, 3]
-                   |  order-fee.0 {
+                   |  order-fee.-1 {
                    |    mode = fixed
                    |    fixed {
                    |      asset = ${matcherFeeAsset.toString}

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderPercentFeeAmountTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderPercentFeeAmountTestSuite.scala
@@ -43,7 +43,7 @@ abstract class OrderPercentFeeAmountTestSuite(version: Byte) extends OrderFeeBas
     ConfigFactory.parseString(
       s"""waves.dex {
          |  allowed-order-versions = [1, 2, 3]
-         |  order-fee.0 {
+         |  order-fee.-1 {
          |    mode = $PERCENT
          |    $PERCENT {
          |      asset-type = $assetType

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderPercentFeeAmountTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderPercentFeeAmountTestSuite.scala
@@ -43,7 +43,7 @@ abstract class OrderPercentFeeAmountTestSuite(version: Byte) extends OrderFeeBas
     ConfigFactory.parseString(
       s"""waves.dex {
          |  allowed-order-versions = [1, 2, 3]
-         |  order-fee {
+         |  order-fee.0 {
          |    mode = $PERCENT
          |    $PERCENT {
          |      asset-type = $assetType

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderPercentFeePriceTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderPercentFeePriceTestSuite.scala
@@ -14,7 +14,7 @@ class OrderPercentFeePriceTestSuite extends OrderFeeBaseTestSuite {
                                                                                       |waves.dex {
                                                                                       |  allowed-order-versions = [1, 2, 3]
                                                                                       |  price-assets = [ "$UsdId", "$BtcId", "WAVES" ]
-                                                                                      |  order-fee {
+                                                                                      |  order-fee.0 {
                                                                                       |    mode = $PERCENT
                                                                                       |    $PERCENT {
                                                                                       |      asset-type = $assetType

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderPercentFeePriceTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderPercentFeePriceTestSuite.scala
@@ -14,7 +14,7 @@ class OrderPercentFeePriceTestSuite extends OrderFeeBaseTestSuite {
                                                                                       |waves.dex {
                                                                                       |  allowed-order-versions = [1, 2, 3]
                                                                                       |  price-assets = [ "$UsdId", "$BtcId", "WAVES" ]
-                                                                                      |  order-fee.0 {
+                                                                                      |  order-fee.-1 {
                                                                                       |    mode = $PERCENT
                                                                                       |    $PERCENT {
                                                                                       |      asset-type = $assetType

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderPercentFeeReceivingTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderPercentFeeReceivingTestSuite.scala
@@ -15,7 +15,7 @@ class OrderPercentFeeReceivingTestSuite extends OrderFeeBaseTestSuite {
                                                                                       |waves.dex {
                                                                                       |  allowed-order-versions = [1, 2, 3]
                                                                                       |  price-assets = [ "$UsdId", "$BtcId", "WAVES" ]
-                                                                                      |  order-fee {
+                                                                                      |  order-fee.0 {
                                                                                       |    mode = $PERCENT
                                                                                       |    $PERCENT {
                                                                                       |      asset-type = $assetType

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderPercentFeeReceivingTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderPercentFeeReceivingTestSuite.scala
@@ -15,7 +15,7 @@ class OrderPercentFeeReceivingTestSuite extends OrderFeeBaseTestSuite {
                                                                                       |waves.dex {
                                                                                       |  allowed-order-versions = [1, 2, 3]
                                                                                       |  price-assets = [ "$UsdId", "$BtcId", "WAVES" ]
-                                                                                      |  order-fee.0 {
+                                                                                      |  order-fee.-1 {
                                                                                       |    mode = $PERCENT
                                                                                       |    $PERCENT {
                                                                                       |      asset-type = $assetType

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderPercentFeeSpendingTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderPercentFeeSpendingTestSuite.scala
@@ -15,7 +15,7 @@ class OrderPercentFeeSpendingTestSuite extends OrderFeeBaseTestSuite {
                                                                                       |waves.dex {
                                                                                       |  allowed-order-versions = [1, 2, 3]
                                                                                       |  price-assets = [ "$UsdId", "$BtcId", "WAVES" ]
-                                                                                      |  order-fee.0 {
+                                                                                      |  order-fee.-1 {
                                                                                       |    mode = $PERCENT
                                                                                       |    $PERCENT {
                                                                                       |      asset-type = $assetType

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderPercentFeeSpendingTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/orders/OrderPercentFeeSpendingTestSuite.scala
@@ -15,7 +15,7 @@ class OrderPercentFeeSpendingTestSuite extends OrderFeeBaseTestSuite {
                                                                                       |waves.dex {
                                                                                       |  allowed-order-versions = [1, 2, 3]
                                                                                       |  price-assets = [ "$UsdId", "$BtcId", "WAVES" ]
-                                                                                      |  order-fee {
+                                                                                      |  order-fee.0 {
                                                                                       |    mode = $PERCENT
                                                                                       |    $PERCENT {
                                                                                       |      asset-type = $assetType

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/smartcontracts/ExtraFeeTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/smartcontracts/ExtraFeeTestSuite.scala
@@ -14,7 +14,10 @@ class ExtraFeeTestSuite extends MatcherSuiteBase {
     ConfigFactory.parseString(
       s"""waves.dex.order-fee {
        |  mode = dynamic
-       |  dynamic.base-fee = $tradeFee
+       |  dynamic {
+       |    base-maker-fee = $tradeFee
+       |    base-taker-fee = $tradeFee
+       |  }
        |}
        """.stripMargin
     )

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/smartcontracts/ExtraFeeTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/smartcontracts/ExtraFeeTestSuite.scala
@@ -12,7 +12,7 @@ class ExtraFeeTestSuite extends MatcherSuiteBase {
 
   override protected def dexInitialSuiteConfig: Config =
     ConfigFactory.parseString(
-      s"""waves.dex.order-fee.0 {
+      s"""waves.dex.order-fee.-1 {
        |  mode = dynamic
        |  dynamic {
        |    base-maker-fee = $tradeFee

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/smartcontracts/ExtraFeeTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/smartcontracts/ExtraFeeTestSuite.scala
@@ -12,7 +12,7 @@ class ExtraFeeTestSuite extends MatcherSuiteBase {
 
   override protected def dexInitialSuiteConfig: Config =
     ConfigFactory.parseString(
-      s"""waves.dex.order-fee {
+      s"""waves.dex.order-fee.0 {
        |  mode = dynamic
        |  dynamic {
        |    base-maker-fee = $tradeFee

--- a/dex/src/main/resources/application.conf
+++ b/dex/src/main/resources/application.conf
@@ -87,38 +87,66 @@ waves.dex {
   # Base fee for the exchange transaction
   exchange-tx-base-fee = 300000
 
-  # Settings for DEX's fee in order
+  # Settings for DEX's fee in order: start-offset -> fee settings.
+  #
+  # Example (note, zero offset settings are mandatory!):
+  #
+  # order-fee {
+  #   0: {
+  #     mode = dynamic
+  #     dynamic {
+  #       base-maker-fee = 300000
+  #       base-taker-fee = 300000
+  #     }
+  #   }
+  #   100: {
+  #     mode = dynamic
+  #     dynamic {
+  #       base-maker-fee = 100000
+  #       base-taker-fee = 500000
+  #     }
+  #   }
+  #   500: {
+  #     mode = percent
+  #     percent {
+  #       asset-type = "amount"
+  #       min-fee = 0.1
+  #     }
+  #   }
+  # }
   order-fee {
-    # Fee in:
-    #  - some asset from the predefined list of the rated assets (dynamic) or
-    #  - fixed asset and fee (fixed) or
-    #  - percent fee in asset of the pair (percent)
-    mode = "dynamic" # | "fixed" | "percent"
+    0: {
+      # Fee in:
+      #  - some asset from the predefined list of the rated assets (dynamic) or
+      #  - fixed asset and fee (fixed) or
+      #  - percent fee in asset of the pair (percent)
+      mode = "dynamic" # | "fixed" | "percent"
 
-    # In this mode DEX charges additional fee for its
-    # account script and scripts of the assets of the pair (if exists).
-    # Matcher accepts fee in several assets which can be obtained by
-    # the following REST request: GET /matcher/settings/rates
-    # Fee is charged according to the asset rate (price of 1 Waves in that asset)
-    dynamic {
-      # Fee for maker order
-      base-maker-fee = 300000
-      # fee for taker order
-      base-taker-fee = 300000
-    }
+      # In this mode DEX charges additional fee for its
+      # account script and scripts of the assets of the pair (if exists).
+      # Matcher accepts fee in several assets which can be obtained by
+      # the following REST request: GET /matcher/settings/rates
+      # Fee is charged according to the asset rate (price of 1 Waves in that asset)
+      dynamic {
+        # Fee for maker order
+        base-maker-fee = 300000
+        # fee for taker order
+        base-taker-fee = 300000
+      }
 
-    fixed {
-      # Fixed fee asset
-      asset = "WAVES" # | "some issued asset (base58)"
-      # Minimum allowed order fee for fixed mode
-      min-fee = 300000
-    }
+      fixed {
+        # Fixed fee asset
+        asset = "WAVES" # | "some issued asset (base58)"
+        # Minimum allowed order fee for fixed mode
+        min-fee = 300000
+      }
 
-    percent {
-      # Asset type for fee
-      asset-type = "amount" # | "price" | "spending" | "receiving"
-      # In percents
-      min-fee = 0.1
+      percent {
+        # Asset type for fee
+        asset-type = "amount" # | "price" | "spending" | "receiving"
+        # In percents
+        min-fee = 0.1
+      }
     }
   }
 

--- a/dex/src/main/resources/application.conf
+++ b/dex/src/main/resources/application.conf
@@ -89,10 +89,10 @@ waves.dex {
 
   # Settings for DEX's fee in order
   order-fee {
-    # Dynamic fee in:
-    #  - some asset from the predefined list or
-    #  - fixed asset and fee or
-    #  - percent fee in asset of the pair
+    # Fee in:
+    #  - some asset from the predefined list of the rated assets (dynamic) or
+    #  - fixed asset and fee (fixed) or
+    #  - percent fee in asset of the pair (percent)
     mode = "dynamic" # | "fixed" | "percent"
 
     # In this mode DEX charges additional fee for its
@@ -103,6 +103,8 @@ waves.dex {
     dynamic {
       # Absolute
       base-fee = 300000
+      # Sets zero fee for makers and double (base-fee * 2) fee for takers
+      zero-maker-double-taker = false
     }
 
     fixed {
@@ -230,6 +232,7 @@ waves.dex {
     orders-batch-entries = 10000
 
     events-batch-linger-ms = 1000
+
     events-batch-entries = 10000
   }
 

--- a/dex/src/main/resources/application.conf
+++ b/dex/src/main/resources/application.conf
@@ -89,10 +89,14 @@ waves.dex {
 
   # Settings for DEX's fee in order: start-offset -> fee settings.
   #
-  # Example (note, zero offset settings are mandatory!):
+  # Note:
+  #  1. settings should be nonempty and must contain value for the current matcher offset;
+  #  2. offsets start from -1
+  #
+  # Example:
   #
   # order-fee {
-  #   0: {
+  #   -1: {
   #     mode = dynamic
   #     dynamic {
   #       base-maker-fee = 300000
@@ -115,7 +119,7 @@ waves.dex {
   #   }
   # }
   order-fee {
-    0: {
+    -1: {
       # Fee in:
       #  - some asset from the predefined list of the rated assets (dynamic) or
       #  - fixed asset and fee (fixed) or

--- a/dex/src/main/resources/application.conf
+++ b/dex/src/main/resources/application.conf
@@ -101,13 +101,6 @@ waves.dex {
     # the following REST request: GET /matcher/settings/rates
     # Fee is charged according to the asset rate (price of 1 Waves in that asset)
     dynamic {
-      # Absolute
-      base-fee = 300000
-      # Sets zero fee for makers and double (base-fee * 2) fee for takers
-      zero-maker-double-taker = false
-    }
-
-    dynamic1 {
       # Fee for maker order
       base-maker-fee = 300000
       # fee for taker order

--- a/dex/src/main/resources/application.conf
+++ b/dex/src/main/resources/application.conf
@@ -107,6 +107,13 @@ waves.dex {
       zero-maker-double-taker = false
     }
 
+    dynamic1 {
+      # Fee for maker order
+      base-maker-fee = 300000
+      # fee for taker order
+      base-taker-fee = 300000
+    }
+
     fixed {
       # Fixed fee asset
       asset = "WAVES" # | "some issued asset (base58)"

--- a/dex/src/main/scala/com/wavesplatform/dex/AddressActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/AddressActor.scala
@@ -182,7 +182,7 @@ class AddressActor(owner: Address,
         command.client ! api.OrderAccepted(order)
       }
 
-    case e @ OrderExecuted(submitted, counter, _, _) =>
+    case e @ OrderExecuted(submitted, counter, _, _, _) =>
       log.trace(s"OrderExecuted(${submitted.order.id()}, ${counter.order.id()}), amount=${e.executedAmount}")
       handleOrderExecuted(e.submittedRemaining)
       handleOrderExecuted(e.counterRemaining)

--- a/dex/src/main/scala/com/wavesplatform/dex/AddressActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/AddressActor.scala
@@ -182,7 +182,7 @@ class AddressActor(owner: Address,
         command.client ! api.OrderAccepted(order)
       }
 
-    case e @ OrderExecuted(submitted, counter, _) =>
+    case e @ OrderExecuted(submitted, counter, _, _) =>
       log.trace(s"OrderExecuted(${submitted.order.id()}, ${counter.order.id()}), amount=${e.executedAmount}")
       handleOrderExecuted(e.submittedRemaining)
       handleOrderExecuted(e.counterRemaining)

--- a/dex/src/main/scala/com/wavesplatform/dex/AddressDirectory.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/AddressDirectory.scala
@@ -54,7 +54,7 @@ class AddressDirectory(spendableBalanceChanges: Observable[SpendableBalanceChang
       forward(lo.order.sender, e)
       historyRouter foreach { _ ! SaveOrder(lo, timestamp) }
 
-    case e @ Events.OrderExecuted(submitted, counter, timestamp, _) =>
+    case e @ Events.OrderExecuted(submitted, counter, timestamp, _, _) =>
       forward(submitted.order.sender, e)
       if (counter.order.sender != submitted.order.sender) forward(counter.order.sender, e)
 

--- a/dex/src/main/scala/com/wavesplatform/dex/AddressDirectory.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/AddressDirectory.scala
@@ -54,7 +54,7 @@ class AddressDirectory(spendableBalanceChanges: Observable[SpendableBalanceChang
       forward(lo.order.sender, e)
       historyRouter foreach { _ ! SaveOrder(lo, timestamp) }
 
-    case e @ Events.OrderExecuted(submitted, counter, timestamp) =>
+    case e @ Events.OrderExecuted(submitted, counter, timestamp, _) =>
       forward(submitted.order.sender, e)
       if (counter.order.sender != submitted.order.sender) forward(counter.order.sender, e)
 

--- a/dex/src/main/scala/com/wavesplatform/dex/Matcher.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/Matcher.scala
@@ -131,7 +131,7 @@ class Matcher(settings: MatcherSettings)(implicit val actorSystem: ActorSystem) 
       matchingRules = matchingRulesCache.getMatchingRules(assetPair, assetDecimals),
       updateCurrentMatchingRules = actualMatchingRule => matchingRulesCache.updateCurrentMatchingRule(assetPair, actualMatchingRule),
       normalizeMatchingRule = denormalizedMatchingRule => denormalizedMatchingRule.normalize(assetPair, assetDecimals),
-      snapshot => OrderBook(snapshot, getMakerTakerFee(orderFeeSettingsCache getSettingsForOffset lastProcessedOffset))
+      getMakerTakerFeeByOffset(orderFeeSettingsCache)
     )
   }
 
@@ -541,6 +541,10 @@ object Matcher extends ScorexLogging {
               }
           }
       }
+  }
+
+  private def getMakerTakerFeeByOffset(ofsc: OrderFeeSettingsCache)(offset: Long)(s: AcceptedOrder, c: LimitOrder): (Long, Long) = {
+    getMakerTakerFee(ofsc getSettingsForOffset offset)(s, c)
   }
 
   def getMakerTakerFee(ofs: => OrderFeeSettings)(s: AcceptedOrder, c: LimitOrder): (Long, Long) = ofs match {

--- a/dex/src/main/scala/com/wavesplatform/dex/Matcher.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/Matcher.scala
@@ -33,6 +33,7 @@ import com.wavesplatform.dex.market._
 import com.wavesplatform.dex.model._
 import com.wavesplatform.dex.queue._
 import com.wavesplatform.dex.settings.MatcherSettings
+import com.wavesplatform.dex.settings.OrderFeeSettings.DynamicSettings
 import com.wavesplatform.dex.time.NTP
 import com.wavesplatform.dex.util._
 import mouse.any.anySyntaxMouse
@@ -119,7 +120,7 @@ class Matcher(settings: MatcherSettings)(implicit val actorSystem: ActorSystem) 
       assetPair,
       updateOrderBookCache(assetPair),
       marketStatuses.put(assetPair, _),
-      settings,
+      settings.zeroMakerFee,
       time,
       matchingRules = matchingRulesCache.getMatchingRules(assetPair, assetDecimals),
       updateCurrentMatchingRules = actualMatchingRule => matchingRulesCache.updateCurrentMatchingRule(assetPair, actualMatchingRule),

--- a/dex/src/main/scala/com/wavesplatform/dex/api/MatcherApiRoute.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/MatcherApiRoute.scala
@@ -31,6 +31,7 @@ import com.wavesplatform.dex.market.OrderBookActor._
 import com.wavesplatform.dex.metrics.TimerExt
 import com.wavesplatform.dex.model._
 import com.wavesplatform.dex.queue.{QueueEvent, QueueEventWithMeta}
+import com.wavesplatform.dex.settings.OrderFeeSettings.OrderFeeSettings
 import com.wavesplatform.dex.settings.{MatcherSettings, formatValue}
 import com.wavesplatform.dex.time.Time
 import io.swagger.annotations._
@@ -64,7 +65,8 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
                            matcherAccountFee: Long,
                            apiKeyHash: Option[Array[Byte]],
                            rateCache: RateCache,
-                           validatedAllowedOrderVersions: () => Future[Set[Byte]])(implicit mat: Materializer)
+                           validatedAllowedOrderVersions: () => Future[Set[Byte]],
+                           getActualOrderFeeSettings: () => OrderFeeSettings)(implicit mat: Materializer)
     extends ApiRoute
     with AuthRoute
     with ScorexLogging {
@@ -219,7 +221,7 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
           StatusCodes.OK,
           Json.obj(
             "priceAssets"   -> matcherSettings.priceAssets,
-            "orderFee"      -> matcherSettings.orderFee.getJson(matcherAccountFee, rateCache.getJson).value,
+            "orderFee"      -> getActualOrderFeeSettings().getJson(matcherAccountFee, rateCache.getJson).value,
             "orderVersions" -> allowedOrderVersions.toSeq.sorted
           )
         )

--- a/dex/src/main/scala/com/wavesplatform/dex/caches/MatchingRulesCache.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/caches/MatchingRulesCache.scala
@@ -29,11 +29,8 @@ class MatchingRulesCache(matcherSettings: MatcherSettings) extends ScorexLogging
 
     val result =
       Try {
-        getMatchingRules(assetPair, assetDecimals).toList.reverse.collectFirst {
-          case mr @ DenormalizedMatchingRule(startOffset, _) if startOffset <= (currentOffset + 1) => mr
-        }
-      }.recover { case NonFatal(e) => log.error(s"Can't get a denormalized rule for a next order", e); None }
-        .getOrElse(None)
+        getMatchingRules(assetPair, assetDecimals).foldLeft(defaultRule) { case (acc, mr) => if (mr.startOffset <= (currentOffset + 1)) mr else acc }
+      }.recover { case NonFatal(e) => log.error(s"Can't get a denormalized rule for a next order", e); defaultRule }
         .getOrElse(defaultRule)
 
     result.copy(tickSize = result.tickSize max defaultRule.tickSize)

--- a/dex/src/main/scala/com/wavesplatform/dex/caches/OrderFeeSettingsCache.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/caches/OrderFeeSettingsCache.scala
@@ -1,0 +1,22 @@
+package com.wavesplatform.dex.caches
+
+import com.wavesplatform.dex.settings.OrderFeeSettings.OrderFeeSettings
+
+import scala.collection.immutable.TreeMap
+
+class OrderFeeSettingsCache(orderFeeSettingsMap: Map[Long, OrderFeeSettings], currentOffset: => Long) {
+
+  private val allOrderFeeSettings = {
+    if (!orderFeeSettingsMap.contains(0)) throw new IllegalArgumentException("Order fee settings should contain value for 0 offset!")
+    TreeMap.empty[Long, OrderFeeSettings] ++ orderFeeSettingsMap
+  }
+
+  private def getClosestActualSettings(offset: Long): OrderFeeSettings = {
+    allOrderFeeSettings.toSeq.reverse
+      .collectFirst { case (startOffset, settings) if startOffset <= offset => settings }
+      .getOrElse(allOrderFeeSettings.head._2)
+  }
+
+  def getCurrentFeeSettings: OrderFeeSettings      = getClosestActualSettings(currentOffset)
+  def getFeeSettingsForNextOrder: OrderFeeSettings = getClosestActualSettings(currentOffset + 1)
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/caches/RateCache.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/caches/RateCache.scala
@@ -7,7 +7,6 @@ import com.wavesplatform.dex.domain.asset.Asset
 import com.wavesplatform.dex.domain.asset.Asset.{IssuedAsset, Waves}
 import org.iq80.leveldb.DB
 import play.api.libs.json.{JsObject, Json}
-import mouse.any._
 
 import scala.collection.JavaConverters._
 import scala.collection.concurrent.TrieMap
@@ -38,7 +37,7 @@ object RateCache {
   def apply(db: DB): RateCache = new RateCache {
 
     private val rateDB  = RateDB(db)
-    private val rateMap = new ConcurrentHashMap[IssuedAsset, Double] unsafeTap (_.putAll(rateDB.getAllRates.asJava))
+    private val rateMap = new ConcurrentHashMap[IssuedAsset, Double](rateDB.getAllRates.asJava)
 
     def upsertRate(asset: Asset, value: Double): Option[Double] =
       asset.fold { WavesRate } { issuedAsset =>

--- a/dex/src/main/scala/com/wavesplatform/dex/caches/RateCache.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/caches/RateCache.scala
@@ -7,6 +7,7 @@ import com.wavesplatform.dex.domain.asset.Asset
 import com.wavesplatform.dex.domain.asset.Asset.{IssuedAsset, Waves}
 import org.iq80.leveldb.DB
 import play.api.libs.json.{JsObject, Json}
+import mouse.any._
 
 import scala.collection.JavaConverters._
 import scala.collection.concurrent.TrieMap
@@ -37,7 +38,7 @@ object RateCache {
   def apply(db: DB): RateCache = new RateCache {
 
     private val rateDB  = RateDB(db)
-    private val rateMap = new ConcurrentHashMap[IssuedAsset, Double](rateDB.getAllRates.asJava)
+    private val rateMap = new ConcurrentHashMap[IssuedAsset, Double] unsafeTap (_.putAll(rateDB.getAllRates.asJava))
 
     def upsertRate(asset: Asset, value: Double): Option[Double] =
       asset.fold { WavesRate } { issuedAsset =>

--- a/dex/src/main/scala/com/wavesplatform/dex/db/AssetsStorage.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/db/AssetsStorage.scala
@@ -38,6 +38,12 @@ object AssetsStorage {
     def get(asset: IssuedAsset): Option[BriefAssetDescription]       = db.readOnly(_.get(MatcherKeys.asset(asset)))
   }
 
+  def inMem: AssetsStorage = new AssetsStorage {
+    private val assetsCache                                        = new ConcurrentHashMap[Asset, BriefAssetDescription]
+    def put(asset: IssuedAsset, item: BriefAssetDescription): Unit = assetsCache.putIfAbsent(asset, item)
+    def get(asset: IssuedAsset): Option[BriefAssetDescription]     = Option(assetsCache get asset)
+  }
+
   final implicit class Ops(val self: AssetsStorage) extends AnyVal {
 
     def get(asset: Asset): Option[BriefAssetDescription] = asset.fold(BriefAssetDescription.someWavesDescription)(self.get)

--- a/dex/src/main/scala/com/wavesplatform/dex/history/HistoryRouter.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/history/HistoryRouter.scala
@@ -70,7 +70,7 @@ object HistoryRouter {
       this.event match {
         case _: OrderAdded => Set.empty[EventRecord]
 
-        case e @ OrderExecuted(submitted, counter, timestamp, _) =>
+        case e @ OrderExecuted(submitted, counter, timestamp, _, _) =>
           val assetPair = submitted.order.assetPair
 
           Set(

--- a/dex/src/main/scala/com/wavesplatform/dex/history/HistoryRouter.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/history/HistoryRouter.scala
@@ -70,7 +70,7 @@ object HistoryRouter {
       this.event match {
         case _: OrderAdded => Set.empty[EventRecord]
 
-        case e @ OrderExecuted(submitted, counter, timestamp) =>
+        case e @ OrderExecuted(submitted, counter, timestamp, _) =>
           val assetPair = submitted.order.assetPair
 
           Set(

--- a/dex/src/main/scala/com/wavesplatform/dex/model/ExchangeTransactionCreator.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/ExchangeTransactionCreator.scala
@@ -63,8 +63,8 @@ class ExchangeTransactionCreator(matcherPrivateKey: KeyPair,
           val (isFirstMatchForBuy, isFirstMatchForSell) = isFirstMatch(buy) -> isFirstMatch(sell)
 
           (
-            if (isFirstMatchForBuy && !orderExecutedEvent.zeroMakerFee && submitted.order.version >= 3) buyExecutedFee max 1L else buyExecutedFee,
-            if (isFirstMatchForSell && !orderExecutedEvent.zeroMakerFee && submitted.order.version >= 3) sellExecutedFee max 1L else sellExecutedFee
+            if (isFirstMatchForBuy && submitted.order.version >= 3) buyExecutedFee max 1L else buyExecutedFee,
+            if (isFirstMatchForSell && submitted.order.version >= 3) sellExecutedFee max 1L else sellExecutedFee
           )
       }
     }

--- a/dex/src/main/scala/com/wavesplatform/dex/model/ExchangeTransactionCreator.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/ExchangeTransactionCreator.scala
@@ -63,8 +63,8 @@ class ExchangeTransactionCreator(matcherPrivateKey: KeyPair,
           val (isFirstMatchForBuy, isFirstMatchForSell) = isFirstMatch(buy) -> isFirstMatch(sell)
 
           (
-            if (isFirstMatchForBuy && submitted.order.version >= 3) buyExecutedFee max 1L else buyExecutedFee,
-            if (isFirstMatchForSell && submitted.order.version >= 3) sellExecutedFee max 1L else sellExecutedFee
+            if (isFirstMatchForBuy && !orderExecutedEvent.zeroMakerFee && submitted.order.version >= 3) buyExecutedFee max 1L else buyExecutedFee,
+            if (isFirstMatchForSell && !orderExecutedEvent.zeroMakerFee && submitted.order.version >= 3) sellExecutedFee max 1L else sellExecutedFee
           )
       }
     }

--- a/dex/src/main/scala/com/wavesplatform/dex/model/MatcherModel.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/MatcherModel.scala
@@ -47,6 +47,8 @@ sealed trait AcceptedOrder {
   def rcvAsset: Asset   = order.getReceiveAssetId
   val feeAsset: Asset   = order.feeAsset
 
+  val matcherFee: Long = order.matcherFee
+
   def requiredFee: Price                = if (feeAsset == rcvAsset) (fee - receiveAmount).max(0L) else fee
   def requiredBalance: Map[Asset, Long] = Map(spentAsset -> rawSpentAmount) |+| Map(feeAsset -> requiredFee)
   def reservableBalance: Map[Asset, Long]
@@ -305,18 +307,18 @@ object Events {
 
   sealed trait Event
 
-  case class OrderExecuted(submitted: AcceptedOrder, counter: LimitOrder, timestamp: Long, zeroMakerFee: Boolean = false) extends Event {
+  case class OrderExecuted(submitted: AcceptedOrder, counter: LimitOrder, timestamp: Long, maxSubmittedFee: Long, maxCounterFee: Long) extends Event {
 
     lazy val executedAmount: Long             = AcceptedOrder.executedAmount(submitted, counter)
     lazy val executedAmountOfPriceAsset: Long = MatcherModel.getCost(executedAmount, counter.price)
 
     def counterRemainingAmount: Long = math.max(counter.amount - executedAmount, 0)
-    def counterExecutedFee: Long     = if (zeroMakerFee) 0 else AcceptedOrder.partialFee(counter.order.matcherFee, counter.order.amount, executedAmount)
+    def counterExecutedFee: Long     = AcceptedOrder.partialFee(maxCounterFee, counter.order.amount, executedAmount)
     def counterRemainingFee: Long    = math.max(counter.fee - counterExecutedFee, 0)
     def counterRemaining: LimitOrder = counter.partial(amount = counterRemainingAmount, fee = counterRemainingFee)
 
     def submittedRemainingAmount: Long = math.max(submitted.amount - executedAmount, 0)
-    def submittedExecutedFee: Long     = AcceptedOrder.partialFee(submitted.order.matcherFee, submitted.order.amount, executedAmount)
+    def submittedExecutedFee: Long     = AcceptedOrder.partialFee(maxSubmittedFee, submitted.order.amount, executedAmount)
     def submittedRemainingFee: Long    = math.max(submitted.fee - submittedExecutedFee, 0)
 
     def submittedMarketRemaining(submittedMarketOrder: MarketOrder): MarketOrder = {

--- a/dex/src/main/scala/com/wavesplatform/dex/model/MatcherModel.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/MatcherModel.scala
@@ -305,13 +305,13 @@ object Events {
 
   sealed trait Event
 
-  case class OrderExecuted(submitted: AcceptedOrder, counter: LimitOrder, timestamp: Long) extends Event {
+  case class OrderExecuted(submitted: AcceptedOrder, counter: LimitOrder, timestamp: Long, zeroMakerFee: Boolean = false) extends Event {
 
     lazy val executedAmount: Long             = AcceptedOrder.executedAmount(submitted, counter)
     lazy val executedAmountOfPriceAsset: Long = MatcherModel.getCost(executedAmount, counter.price)
 
     def counterRemainingAmount: Long = math.max(counter.amount - executedAmount, 0)
-    def counterExecutedFee: Long     = AcceptedOrder.partialFee(counter.order.matcherFee, counter.order.amount, executedAmount)
+    def counterExecutedFee: Long     = if (zeroMakerFee) 0 else AcceptedOrder.partialFee(counter.order.matcherFee, counter.order.amount, executedAmount)
     def counterRemainingFee: Long    = math.max(counter.fee - counterExecutedFee, 0)
     def counterRemaining: LimitOrder = counter.partial(amount = counterRemainingAmount, fee = counterRemainingFee)
 

--- a/dex/src/main/scala/com/wavesplatform/dex/model/MatcherModel.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/MatcherModel.scala
@@ -307,6 +307,11 @@ object Events {
 
   sealed trait Event
 
+  /**
+    *  In case of dynamic fee settings the following params can be different from the appropriate `acceptedOrder.order.matcherFee`
+    * @param maxSubmittedFee limited by base-taker-fee
+    * @param maxCounterFee limited by base-maker-fee
+    */
   case class OrderExecuted(submitted: AcceptedOrder, counter: LimitOrder, timestamp: Long, maxSubmittedFee: Long, maxCounterFee: Long) extends Event {
 
     lazy val executedAmount: Long             = AcceptedOrder.executedAmount(submitted, counter)

--- a/dex/src/main/scala/com/wavesplatform/dex/model/OrderBook.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/OrderBook.scala
@@ -10,7 +10,7 @@ import com.wavesplatform.dex.domain.order.{Order, OrderType}
 import com.wavesplatform.dex.model.Events.{Event, OrderAdded, OrderCanceled, OrderExecuted}
 import com.wavesplatform.dex.model.OrderBook.LastTrade
 import com.wavesplatform.dex.settings.MatchingRule
-import com.wavesplatform.dex.settings.OrderFeeSettings.{DynamicSettings1, OrderFeeSettings}
+import com.wavesplatform.dex.settings.OrderFeeSettings.{DynamicSettings, OrderFeeSettings}
 import com.wavesplatform.dex.util.Codecs.ByteBufferExt
 import play.api.libs.functional.syntax._
 import play.api.libs.json._

--- a/dex/src/main/scala/com/wavesplatform/dex/settings/MatcherSettings.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/settings/MatcherSettings.scala
@@ -49,7 +49,7 @@ case class MatcherSettings(addressSchemeCharacter: Char,
                            orderBookSnapshotHttpCache: OrderBookSnapshotHttpCache.Settings,
                            eventsQueue: EventsQueueSettings,
                            processConsumedTimeout: FiniteDuration,
-                           orderFee: OrderFeeSettings,
+                           orderFee: Map[Long, OrderFeeSettings],
                            deviation: DeviationsSettings,
                            orderRestrictions: Map[AssetPair, OrderRestrictionsSettings],
                            matchingRules: Map[AssetPair, NonEmptyList[DenormalizedMatchingRule]],
@@ -65,12 +65,11 @@ case class MatcherSettings(addressSchemeCharacter: Char,
       blacklistedAssets ++
       orderRestrictions.keySet.flatMap(_.assets) ++
       matchingRules.keySet.flatMap(_.assets) ++
-      allowedAssetPairs.flatMap(_.assets) ++ {
-      orderFee match {
+      allowedAssetPairs.flatMap(_.assets) ++
+      orderFee.values.toSet[OrderFeeSettings].flatMap {
         case x: OrderFeeSettings.FixedSettings => Set(x.defaultAsset)
-        case _                                 => Set.empty
+        case _                                 => Set.empty[Asset]
       }
-    }
   }
 }
 
@@ -87,7 +86,7 @@ object MatcherSettings {
 
   private[this] def fromConfig(config: Config): MatcherSettings = {
 
-    import ConfigSettingsValidator.AdhocValidation.validateAssetPairKey
+    import ConfigSettingsValidator.AdhocValidation.{validateAssetPairKey, validateOffset}
 
     val addressSchemeCharacter =
       config
@@ -134,7 +133,7 @@ object MatcherSettings {
     val orderBookSnapshotHttpCache = config.as[OrderBookSnapshotHttpCache.Settings]("order-book-snapshot-http-cache")
     val eventsQueue                = config.as[EventsQueueSettings]("events-queue")
     val processConsumedTimeout     = config.as[FiniteDuration]("process-consumed-timeout")
-    val orderFee                   = config.as[OrderFeeSettings]("order-fee")
+    val orderFee                   = config.getValidatedMap[Long, OrderFeeSettings]("order-fee")(validateOffset)
     val deviation                  = config.as[DeviationsSettings]("max-price-deviations")
     val orderRestrictions          = config.getValidatedMap[AssetPair, OrderRestrictionsSettings]("order-restrictions")(validateAssetPairKey)
     val matchingRules              = config.getValidatedMap[AssetPair, NonEmptyList[DenormalizedMatchingRule]]("matching-rules")(validateAssetPairKey)

--- a/dex/src/main/scala/com/wavesplatform/dex/settings/MatcherSettings.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/settings/MatcherSettings.scala
@@ -67,11 +67,13 @@ case class MatcherSettings(addressSchemeCharacter: Char,
       matchingRules.keySet.flatMap(_.assets) ++
       allowedAssetPairs.flatMap(_.assets) ++ {
       orderFee match {
-        case x: OrderFeeSettings.FixedSettings => Set(x.defaultAssetId)
+        case x: OrderFeeSettings.FixedSettings => Set(x.defaultAsset)
         case _                                 => Set.empty
       }
     }
   }
+
+  def zeroMakerFee: Boolean = orderFee match { case DynamicSettings(_, zeroMakerFee) => zeroMakerFee; case _ => false }
 }
 
 case class RestAPISettings(address: String, port: Int, apiKeyHash: String, cors: Boolean, apiKeyDifferentHost: Boolean)

--- a/dex/src/main/scala/com/wavesplatform/dex/settings/MatcherSettings.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/settings/MatcherSettings.scala
@@ -72,8 +72,6 @@ case class MatcherSettings(addressSchemeCharacter: Char,
       }
     }
   }
-
-  def zeroMakerFee: Boolean = orderFee match { case DynamicSettings(_, zeroMakerFee) => zeroMakerFee; case _ => false }
 }
 
 case class RestAPISettings(address: String, port: Int, apiKeyHash: String, cors: Boolean, apiKeyDifferentHost: Boolean)

--- a/dex/src/main/scala/com/wavesplatform/dex/settings/OrderFeeSettings.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/settings/OrderFeeSettings.scala
@@ -44,7 +44,9 @@ object OrderFeeSettings {
   }
 
   final case class DynamicSettings(baseMakerFee: Long, baseTakerFee: Long) extends OrderFeeSettings {
-    val maxBaseFee: Long = math.max(baseMakerFee, baseTakerFee)
+    val maxBaseFee: Long   = math.max(baseMakerFee, baseTakerFee)
+    val makerRatio: Double = (BigDecimal(baseMakerFee) / maxBaseFee).toDouble
+    val takerRatio: Double = (BigDecimal(baseTakerFee) / maxBaseFee).toDouble
   }
 
   object DynamicSettings {

--- a/dex/src/main/scala/com/wavesplatform/dex/settings/utils/ConfigSettingsValidator.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/settings/utils/ConfigSettingsValidator.scala
@@ -30,7 +30,7 @@ object ConfigSettingsValidator {
     }
 
     def validateOffset(key: String): Validated[String, Long] = {
-      Validated.fromTry(Try(key.toLong)).leftMap(_ => s"Can't parse offset '$key'").ensure("Offset should be >= 0")(_ >= 0)
+      Validated.fromTry(Try(key.toLong)).leftMap(_ => s"Can't parse offset '$key'").ensure("Offset should be >= -1")(_ >= -1)
     }
   }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/settings/utils/ConfigSettingsValidator.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/settings/utils/ConfigSettingsValidator.scala
@@ -28,6 +28,10 @@ object ConfigSettingsValidator {
     def validateAssetPairKey(key: String): Validated[String, AssetPair] = {
       Validated.fromTry(AssetPair.fromString(key)) leftMap (_ => s"Can't parse asset pair '$key'")
     }
+
+    def validateOffset(key: String): Validated[String, Long] = {
+      Validated.fromTry(Try(key.toLong)).leftMap(_ => s"Can't parse offset '$key'").ensure("Offset should be >= 0")(_ >= 0)
+    }
   }
 }
 

--- a/dex/src/test/resources/application.conf
+++ b/dex/src/test/resources/application.conf
@@ -6,6 +6,7 @@ waves.dex {
     type = "in-mem"
     in-mem.seed-in-base64 = "3yZe7d"
   }
+  order-fee.dynamic.zero-maker-double-taker = false
 }
 
 akka {

--- a/dex/src/test/resources/application.conf
+++ b/dex/src/test/resources/application.conf
@@ -6,7 +6,6 @@ waves.dex {
     type = "in-mem"
     in-mem.seed-in-base64 = "3yZe7d"
   }
-  order-fee.dynamic.zero-maker-double-taker = false
 }
 
 akka {

--- a/dex/src/test/scala/com/wavesplatform/dex/MatcherSpecBase.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/MatcherSpecBase.scala
@@ -5,7 +5,6 @@ import java.util.concurrent.atomic.AtomicLong
 
 import com.google.common.base.Charsets
 import com.google.common.primitives.{Bytes, Ints}
-import com.typesafe.config.{Config, ConfigFactory}
 import com.wavesplatform.dex.asset.DoubleOps
 import com.wavesplatform.dex.caches.RateCache
 import com.wavesplatform.dex.domain.account.KeyPair
@@ -48,8 +47,8 @@ trait MatcherSpecBase extends NTPTime with DiffMatcherWithImplicits with DoubleO
   protected val usd: IssuedAsset = mkAssetId("WUSD")
   protected val eth: IssuedAsset = mkAssetId("WETH")
 
-  protected val pairWavesBtc: AssetPair = AssetPair(Waves, btc)
-  protected val pairWavesUsd: AssetPair = AssetPair(Waves, usd)
+  protected val wavesBtcPair: AssetPair = AssetPair(Waves, btc)
+  protected val wavesUsdPair: AssetPair = AssetPair(Waves, usd)
 
   protected val rateCache: RateCache    = RateCache.inMem unsafeTap { _.upsertRate(usd, 3.7) } unsafeTap { _.upsertRate(btc, 0.00011167) }
   protected val smallFee: Option[Price] = Some(toNormalized(1))
@@ -91,7 +90,7 @@ trait MatcherSpecBase extends NTPTime with DiffMatcherWithImplicits with DoubleO
                             price: Double,
                             matcherFee: Long = matcherFee,
                             version: Byte = 3,
-                            matcherFeeAsset: Asset = Waves): Order = {
+                            feeAsset: Asset = Waves): Order = {
     Order(
       sender = senderKeyPair,
       matcher = MatcherAccount,
@@ -105,7 +104,7 @@ trait MatcherSpecBase extends NTPTime with DiffMatcherWithImplicits with DoubleO
       expiration = ntpNow + (1000 * 60 * 60 * 24),
       matcherFee = matcherFee,
       version = version,
-      feeAsset = matcherFeeAsset
+      feeAsset = feeAsset
     )
   }
 
@@ -134,28 +133,7 @@ trait MatcherSpecBase extends NTPTime with DiffMatcherWithImplicits with DoubleO
   private val maxTimeGen: Gen[Long]     = Gen.choose(10000L, Order.MaxLiveTime).map(_ + System.currentTimeMillis())
   private val createdTimeGen: Gen[Long] = Gen.choose(0L, 10000L).map(System.currentTimeMillis() - _)
 
-  private val config: Config = loadConfig(
-    ConfigFactory.parseString(
-      """waves {
-      |    directory: "/tmp/waves-test"
-      |    dex {
-      |      account: ""
-      |      bind-address: "127.0.0.1"
-      |      port: 6886
-      |      order-history-file: null
-      |      min-order-fee: 100000
-      |      snapshots-interval: 100000
-      |      max-open-orders: 1000
-      |      price-assets: ["BASE1", "BASE2", "BASE"]
-      |      blacklisted-assets: ["BLACKLST"]
-      |      blacklisted-names: ["[Ff]orbidden"]
-      |      allowed-order-versions = [1, 2, 3]
-      |    }
-      |}""".stripMargin
-    )
-  )
-
-  protected val matcherSettings: MatcherSettings = config.as[MatcherSettings]("waves.dex")
+  protected val matcherSettings: MatcherSettings = loadConfig(None).as[MatcherSettings]("waves.dex")
 
   protected def randomBytes(howMany: Int = 32): Array[Byte] = {
     val r = new Array[Byte](howMany)
@@ -377,7 +355,7 @@ trait MatcherSpecBase extends NTPTime with DiffMatcherWithImplicits with DoubleO
     for { minFee <- Gen.choose(lowerMinFeeBound, upperMinFeeBound) } yield { FixedSettings(defaultAsset, minFee) }
 
   protected def dynamicSettingsGenerator(lowerBaseFeeBound: Long = 1, upperBaseFeeBound: Long = 1000000L): Gen[DynamicSettings] =
-    for { baseFee <- Gen.choose(lowerBaseFeeBound, upperBaseFeeBound) } yield { DynamicSettings(baseFee) }
+    for { baseFee <- Gen.choose(lowerBaseFeeBound, upperBaseFeeBound) } yield { DynamicSettings(baseFee, false) }
 
   private def orderFeeSettingsGenerator(defaultAssetForFixedSettings: Option[Asset] = None): Gen[OrderFeeSettings] = {
     for {
@@ -425,7 +403,7 @@ trait MatcherSpecBase extends NTPTime with DiffMatcherWithImplicits with DoubleO
           .updateFee {
             OrderValidator.getMinValidFeeForSettings(order, percentSettings, getDefaultAssetDescriptions(_).decimals, rateCache).explicitGet()
           }
-      case (_, DynamicSettings(baseFee)) =>
+      case (_, DynamicSettings(baseFee, _)) =>
         order
           .updateFeeAsset(matcherFeeAssetForDynamicSettings getOrElse Waves)
           .updateFee(

--- a/dex/src/test/scala/com/wavesplatform/dex/MatcherSpecBase.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/MatcherSpecBase.scala
@@ -355,7 +355,7 @@ trait MatcherSpecBase extends NTPTime with DiffMatcherWithImplicits with DoubleO
     for { minFee <- Gen.choose(lowerMinFeeBound, upperMinFeeBound) } yield { FixedSettings(defaultAsset, minFee) }
 
   protected def dynamicSettingsGenerator(lowerBaseFeeBound: Long = 1, upperBaseFeeBound: Long = 1000000L): Gen[DynamicSettings] =
-    for { baseFee <- Gen.choose(lowerBaseFeeBound, upperBaseFeeBound) } yield { DynamicSettings(baseFee, false) }
+    for { baseFee <- Gen.choose(lowerBaseFeeBound, upperBaseFeeBound) } yield { DynamicSettings(baseFee, baseFee) }
 
   private def orderFeeSettingsGenerator(defaultAssetForFixedSettings: Option[Asset] = None): Gen[OrderFeeSettings] = {
     for {
@@ -403,12 +403,12 @@ trait MatcherSpecBase extends NTPTime with DiffMatcherWithImplicits with DoubleO
           .updateFee {
             OrderValidator.getMinValidFeeForSettings(order, percentSettings, getDefaultAssetDescriptions(_).decimals, rateCache).explicitGet()
           }
-      case (_, DynamicSettings(baseFee, _)) =>
+      case (_, ds @ DynamicSettings(_, _)) =>
         order
           .updateFeeAsset(matcherFeeAssetForDynamicSettings getOrElse Waves)
           .updateFee(
-            rateForDynamicSettings.fold(baseFee) { rate =>
-              OrderValidator.multiplyFeeByDouble(baseFee, rate)
+            rateForDynamicSettings.fold(ds.maxBaseFee) { rate =>
+              OrderValidator.multiplyFeeByDouble(ds.maxBaseFee, rate)
             }
           )
       case _ => order

--- a/dex/src/test/scala/com/wavesplatform/dex/api/MatcherApiRouteSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/api/MatcherApiRouteSpec.scala
@@ -17,6 +17,7 @@ import com.wavesplatform.dex.domain.crypto
 import com.wavesplatform.dex.effect._
 import com.wavesplatform.dex.grpc.integration.dto.BriefAssetDescription
 import com.wavesplatform.dex.settings.MatcherSettings
+import com.wavesplatform.dex.settings.OrderFeeSettings.DynamicSettings
 import org.scalamock.scalatest.PathMockFactory
 import org.scalatest.concurrent.Eventually
 import play.api.libs.json.{JsString, JsValue}
@@ -328,7 +329,8 @@ class MatcherApiRouteSpec extends RouteSpec("/matcher") with MatcherSpecBase wit
       matcherAccountFee = 300000L,
       apiKeyHash = Some(crypto secureHash apiKey),
       rateCache = rateCache,
-      validatedAllowedOrderVersions = () => Future.successful { Set(1, 2, 3) }
+      validatedAllowedOrderVersions = () => Future.successful { Set(1, 2, 3) },
+      () => DynamicSettings.symmetric(matcherFee)
     ).route
 
     f(route)

--- a/dex/src/test/scala/com/wavesplatform/dex/caches/OrderFeeSettingsCacheSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/caches/OrderFeeSettingsCacheSpecification.scala
@@ -1,0 +1,41 @@
+package com.wavesplatform.dex.caches
+
+import com.wavesplatform.dex.MatcherSpecBase
+import com.wavesplatform.dex.settings.AssetType
+import com.wavesplatform.dex.settings.OrderFeeSettings.{DynamicSettings, OrderFeeSettings, PercentSettings}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class OrderFeeSettingsCacheSpecification extends AnyWordSpecLike with Matchers with MatcherSpecBase {
+
+  "OrderFeeSettingsCache" should {
+
+    "prevent matcher start if zero offset settings wasn't set" in {
+      a[IllegalArgumentException] should be thrownBy new OrderFeeSettingsCache(Map(2L -> DynamicSettings(0.001.waves, 0.005.waves)), 0L)
+    }
+
+    "correctly retrieve current fee settings" in {
+
+      val settingsMap =
+        Map(
+          0L    -> DynamicSettings.symmetric(0.003.waves),
+          2L    -> DynamicSettings(0.001.waves, 0.005.waves),
+          1000L -> PercentSettings(AssetType.AMOUNT, 0.005)
+        )
+
+      var offset = 0L
+      val ofsc   = new OrderFeeSettingsCache(settingsMap, offset)
+
+      def check(newOffsetValue: Long, current: OrderFeeSettings, actual: OrderFeeSettings): Unit = {
+        offset = newOffsetValue
+        ofsc.getCurrentFeeSettings should matchTo(current)
+        ofsc.getFeeSettingsForNextOrder should matchTo(actual)
+      }
+
+      check(newOffsetValue = 0L, current = DynamicSettings(0.003.waves, 0.003.waves), actual = DynamicSettings(0.003.waves, 0.003.waves))
+      check(newOffsetValue = 1L, current = DynamicSettings(0.003.waves, 0.003.waves), actual = DynamicSettings(0.001.waves, 0.005.waves))
+      check(newOffsetValue = 100L, current = DynamicSettings(0.001.waves, 0.005.waves), actual = DynamicSettings(0.001.waves, 0.005.waves))
+      check(newOffsetValue = 999L, current = DynamicSettings(0.001.waves, 0.005.waves), actual = PercentSettings(AssetType.AMOUNT, 0.005))
+    }
+  }
+}

--- a/dex/src/test/scala/com/wavesplatform/dex/caches/OrderFeeSettingsCacheSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/caches/OrderFeeSettingsCacheSpecification.scala
@@ -10,32 +10,37 @@ class OrderFeeSettingsCacheSpecification extends AnyWordSpecLike with Matchers w
 
   "OrderFeeSettingsCache" should {
 
-    "prevent matcher start if zero offset settings wasn't set" in {
-      a[IllegalArgumentException] should be thrownBy new OrderFeeSettingsCache(Map(2L -> DynamicSettings(0.001.waves, 0.005.waves)), 0L)
+    "prevent matcher start if settings wasn't set" in {
+      a[IllegalArgumentException] should be thrownBy new OrderFeeSettingsCache(Map.empty[Long, OrderFeeSettings])
+    }
+
+    "throw error if there is no settings for the given offset" in {
+      a[IllegalStateException] should be thrownBy new OrderFeeSettingsCache(Map(100L -> DynamicSettings.symmetric(0.003.waves)))
+        .getSettingsForOffset(1)
     }
 
     "correctly retrieve current fee settings" in {
 
       val settingsMap =
         Map(
-          0L    -> DynamicSettings.symmetric(0.003.waves),
+          -1L   -> DynamicSettings.symmetric(0.003.waves),
           2L    -> DynamicSettings(0.001.waves, 0.005.waves),
+          15L   -> DynamicSettings(0.002.waves, 0.004.waves),
           1000L -> PercentSettings(AssetType.AMOUNT, 0.005)
         )
 
-      var offset = 0L
-      val ofsc   = new OrderFeeSettingsCache(settingsMap, offset)
+      val ofsc = new OrderFeeSettingsCache(settingsMap)
 
-      def check(newOffsetValue: Long, current: OrderFeeSettings, actual: OrderFeeSettings): Unit = {
-        offset = newOffsetValue
-        ofsc.getCurrentFeeSettings should matchTo(current)
-        ofsc.getFeeSettingsForNextOrder should matchTo(actual)
+      def check(offset: Long, current: OrderFeeSettings, actual: OrderFeeSettings): Unit = {
+        ofsc.getSettingsForOffset(offset) should matchTo(current)
+        ofsc.getSettingsForOffset(offset + 1) should matchTo(actual)
       }
 
-      check(newOffsetValue = 0L, current = DynamicSettings(0.003.waves, 0.003.waves), actual = DynamicSettings(0.003.waves, 0.003.waves))
-      check(newOffsetValue = 1L, current = DynamicSettings(0.003.waves, 0.003.waves), actual = DynamicSettings(0.001.waves, 0.005.waves))
-      check(newOffsetValue = 100L, current = DynamicSettings(0.001.waves, 0.005.waves), actual = DynamicSettings(0.001.waves, 0.005.waves))
-      check(newOffsetValue = 999L, current = DynamicSettings(0.001.waves, 0.005.waves), actual = PercentSettings(AssetType.AMOUNT, 0.005))
+      check(offset = -1L, current = DynamicSettings(0.003.waves, 0.003.waves), actual = DynamicSettings(0.003.waves, 0.003.waves))
+      check(offset = 0L, current = DynamicSettings(0.003.waves, 0.003.waves), actual = DynamicSettings(0.003.waves, 0.003.waves))
+      check(offset = 17L, current = DynamicSettings(0.002.waves, 0.004.waves), actual = DynamicSettings(0.002.waves, 0.004.waves))
+      check(offset = 100L, current = DynamicSettings(0.002.waves, 0.004.waves), actual = DynamicSettings(0.002.waves, 0.004.waves))
+      check(offset = 999L, current = DynamicSettings(0.002.waves, 0.004.waves), actual = PercentSettings(AssetType.AMOUNT, 0.005))
     }
   }
 }

--- a/dex/src/test/scala/com/wavesplatform/dex/caches/RateCacheSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/caches/RateCacheSpecification.scala
@@ -1,0 +1,67 @@
+package com.wavesplatform.dex.caches
+
+import com.wavesplatform.dex.{MatcherSpecBase, NoShrink}
+import com.wavesplatform.dex.db.{RateDB, WithDB}
+import com.wavesplatform.dex.domain.asset.Asset
+import com.wavesplatform.dex.domain.asset.Asset.Waves
+import org.scalacheck.Gen
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatestplus.scalacheck.{ScalaCheckPropertyChecks => PropertyChecks}
+
+class RateCacheSpecification extends AnyWordSpecLike with Matchers with WithDB with MatcherSpecBase with PropertyChecks with NoShrink {
+
+  private def test(f: RateCache => Unit): Unit = {
+    withClue("with DB") { f(RateCache(db)) }
+    withClue("in mem") { f(RateCache.inMem) }
+  }
+
+  private val WavesRate: Map[Asset, Double] = Map(Waves -> 1d)
+
+  "RateCache" should {
+
+    "add, get and delete rates" in test { rc =>
+      val preconditions =
+        Gen
+          .listOfN(
+            100,
+            for {
+              asset     <- arbitraryAssetGen
+              rateValue <- Gen.choose(1, 100).map(_.toDouble / 100)
+            } yield asset -> rateValue
+          )
+          .map(_.toMap[Asset, Double])
+
+      forAll(preconditions) { map =>
+        map.foreach { case (asset, rateValue) => rc.upsertRate(asset, rateValue) shouldBe None }
+        rc.getAllRates should matchTo(map ++ WavesRate)
+        map.foreach { case (asset, rate) => rc.deleteRate(asset) shouldBe Some(rate) }
+        rc.getAllRates should matchTo(WavesRate)
+      }
+    }
+
+    "update rate if it already exists" in test { rc =>
+      forAll(arbitraryAssetGen) { asset: Asset =>
+        rc.upsertRate(asset, 1) shouldBe None
+        rc.getAllRates should matchTo(Map(asset -> 1d) ++ WavesRate)
+
+        rc.upsertRate(asset, 2) shouldBe Some(1d)
+        rc.getAllRates should matchTo(Map(asset -> 2d) ++ WavesRate)
+
+        rc.deleteRate(asset) shouldBe Some(2d)
+      }
+    }
+
+    "correctly restore state from db" in {
+      val rateDB = RateDB(db)
+
+      val asset1 = mkAssetId("First")
+      val asset2 = mkAssetId("Second")
+
+      rateDB.upsertRate(asset1, 1.5)
+      rateDB.upsertRate(asset2, 5.1)
+
+      RateCache(db).getAllRates should matchTo(Map(asset1 -> 1.5, asset2 -> 5.1) ++ WavesRate)
+    }
+  }
+}

--- a/dex/src/test/scala/com/wavesplatform/dex/db/RateDBSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/db/RateDBSpecification.scala
@@ -1,13 +1,12 @@
-package com.wavesplatform.dex.model
+package com.wavesplatform.dex.db
 
-import com.wavesplatform.dex.db.{RateDB, WithDB}
 import com.wavesplatform.dex.{MatcherSpecBase, NoShrink}
 import org.scalacheck.Gen
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatestplus.scalacheck.{ScalaCheckPropertyChecks => PropertyChecks}
 
-class RateDBSpec extends AnyWordSpecLike with Matchers with WithDB with MatcherSpecBase with PropertyChecks with NoShrink {
+class RateDBSpecification extends AnyWordSpecLike with Matchers with WithDB with MatcherSpecBase with PropertyChecks with NoShrink {
 
   private def test(f: RateDB => Unit): Unit = f { RateDB(db) }
 

--- a/dex/src/test/scala/com/wavesplatform/dex/history/HistoryRouterSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/history/HistoryRouterSpecification.scala
@@ -72,9 +72,12 @@ class HistoryRouterSpecification
     )
   }
 
-  def orderAdded(submitted: LimitOrder): OrderAdded                               = OrderAdded(submitted, ntpTime.getTimestamp())
-  def orderExecuted(submitted: AcceptedOrder, counter: LimitOrder): OrderExecuted = OrderExecuted(submitted, counter, ntpTime.getTimestamp())
-  def orderCancelled(submitted: AcceptedOrder): OrderCanceled                     = OrderCanceled(submitted, isSystemCancel = false, ntpTime.getTimestamp())
+  def orderAdded(submitted: LimitOrder): OrderAdded           = OrderAdded(submitted, ntpTime.getTimestamp())
+  def orderCancelled(submitted: AcceptedOrder): OrderCanceled = OrderCanceled(submitted, isSystemCancel = false, ntpTime.getTimestamp())
+
+  def orderExecuted(submitted: AcceptedOrder, counter: LimitOrder): OrderExecuted = {
+    OrderExecuted(submitted, counter, ntpTime.getTimestamp(), submitted.matcherFee, counter.matcherFee)
+  }
 
   // don't need to use blockchain in order to find out asset decimals, therefore pair parameter isn't used
   def denormalizeAmountAndFee(value: Long, asset: Asset): BigDecimal = Denormalization.denormalizeAmountAndFee(value, wavesDecimals)

--- a/dex/src/test/scala/com/wavesplatform/dex/market/MatcherActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/market/MatcherActorSpecification.scala
@@ -428,7 +428,7 @@ class MatcherActorSpecification
             NonEmptyList.one(DenormalizedMatchingRule(0, 0.00000001)),
             _ => {},
             _ => MatchingRule.DefaultRule,
-            snapshot => OrderBook(snapshot, (t, m) => m.matcherFee -> t.matcherFee)
+            _ => (t, m) => m.matcherFee -> t.matcherFee
         ),
         assetDescription
       )

--- a/dex/src/test/scala/com/wavesplatform/dex/market/MatcherActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/market/MatcherActorSpecification.scala
@@ -424,7 +424,7 @@ class MatcherActorSpecification
             assetPair,
             _ => {},
             _ => {},
-            matcherSettings,
+            zeroMakerFee = false,
             ntpTime,
             NonEmptyList.one(DenormalizedMatchingRule(0, 0.00000001)),
             _ => {},

--- a/dex/src/test/scala/com/wavesplatform/dex/market/MatcherActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/market/MatcherActorSpecification.scala
@@ -424,11 +424,11 @@ class MatcherActorSpecification
             assetPair,
             _ => {},
             _ => {},
-            zeroMakerFee = false,
             ntpTime,
             NonEmptyList.one(DenormalizedMatchingRule(0, 0.00000001)),
             _ => {},
-            _ => MatchingRule.DefaultRule
+            _ => MatchingRule.DefaultRule,
+            snapshot => OrderBook(snapshot, (t, m) => m.matcherFee -> t.matcherFee)
         ),
         assetDescription
       )
@@ -440,7 +440,7 @@ class MatcherActorSpecification
 
   private def matcherHadOrderBooksBefore(apdb: AssetPairsDB, obsdb: OrderBookSnapshotDB, pairs: (AssetPair, Long)*): Unit = {
     pairs.map(_._1).foreach(apdb.add)
-    pairs.foreach { case (pair, offset) => obsdb.update(pair, offset, Some(OrderBook.empty.snapshot)) }
+    pairs.foreach { case (pair, offset) => obsdb.update(pair, offset, Some(OrderBook.Snapshot.empty)) }
   }
 
   private def doNothingOnRecovery(x: Either[String, (ActorRef, QueueEventWithMeta.Offset)]): Unit = {}

--- a/dex/src/test/scala/com/wavesplatform/dex/market/OrderBookActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/market/OrderBookActorSpecification.scala
@@ -82,6 +82,7 @@ class OrderBookActorSpecification
         pair,
         update(pair),
         p => Option(md.get(p)),
+        false,
         ntpTime,
         matchingRules,
         _ => (),

--- a/dex/src/test/scala/com/wavesplatform/dex/market/OrderBookActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/market/OrderBookActorSpecification.scala
@@ -19,7 +19,7 @@ import com.wavesplatform.dex.market.OrderBookActor._
 import com.wavesplatform.dex.model.Events.{OrderAdded, OrderCanceled, OrderExecuted}
 import com.wavesplatform.dex.model._
 import com.wavesplatform.dex.queue.QueueEvent.Canceled
-import com.wavesplatform.dex.settings.OrderFeeSettings.DynamicSettings1
+import com.wavesplatform.dex.settings.OrderFeeSettings.DynamicSettings
 import com.wavesplatform.dex.settings.{DenormalizedMatchingRule, MatchingRule}
 import com.wavesplatform.dex.time.NTPTime
 import org.scalamock.scalatest.PathMockFactory

--- a/dex/src/test/scala/com/wavesplatform/dex/market/OrderBookActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/market/OrderBookActorSpecification.scala
@@ -19,7 +19,6 @@ import com.wavesplatform.dex.market.OrderBookActor._
 import com.wavesplatform.dex.model.Events.{OrderAdded, OrderCanceled, OrderExecuted}
 import com.wavesplatform.dex.model._
 import com.wavesplatform.dex.queue.QueueEvent.Canceled
-import com.wavesplatform.dex.settings.OrderFeeSettings.DynamicSettings
 import com.wavesplatform.dex.settings.{DenormalizedMatchingRule, MatchingRule}
 import com.wavesplatform.dex.time.NTPTime
 import org.scalamock.scalatest.PathMockFactory
@@ -87,7 +86,7 @@ class OrderBookActorSpecification
         matchingRules,
         _ => (),
         raw => MatchingRule(raw.startOffset, (raw.tickSize * BigDecimal(10).pow(8)).toLongExact),
-        snapshot => OrderBook(snapshot, (t, m) => m.matcherFee -> t.matcherFee)
+        _ => (t, m) => m.matcherFee -> t.matcherFee
       ) with RestartableActor)
 
     f(pair, orderBookActor, tp)
@@ -108,8 +107,8 @@ class OrderBookActorSpecification
     "recovery - notify address actor about orders" in obcTestWithPrepare(
       { (obsdb, p) =>
         val ord = buy(p, 10 * Order.PriceConstant, 100)
-        val ob  = OrderBook.empty((t, m) => m.matcherFee -> t.matcherFee)
-        ob.add(LimitOrder(ord), ord.timestamp)
+        val ob  = OrderBook.empty()
+        ob.add(LimitOrder(ord), ord.timestamp, (t, m) => m.matcherFee -> t.matcherFee)
         obsdb.update(p, 50, Some(ob.snapshot))
       }
     ) { (pair, _, tp) =>

--- a/dex/src/test/scala/com/wavesplatform/dex/matching/ReservedBalanceSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/matching/ReservedBalanceSpecification.scala
@@ -139,7 +139,7 @@ class ReservedBalanceSpecification
     addressDir ! OrderAdded(LimitOrder(counter), ntpTime.getTimestamp())
 
     oh.process(OrderAdded(LimitOrder(counter), ntpTime.getTimestamp()))
-    val exec = OrderExecuted(LimitOrder(submitted), LimitOrder(counter), submitted.timestamp)
+    val exec = OrderExecuted(LimitOrder(submitted), LimitOrder(counter), submitted.timestamp, submitted.matcherFee, counter.matcherFee)
     addressDir ! exec
     exec
   }
@@ -518,7 +518,7 @@ class ReservedBalanceSpecification
   }
 
   private def executeMarketOrder(addressDirWithOrderBookCache: ActorRef, marketOrder: MarketOrder, limitOrder: LimitOrder): OrderExecuted = {
-    val executionEvent = OrderExecuted(marketOrder, limitOrder, marketOrder.order.timestamp)
+    val executionEvent = OrderExecuted(marketOrder, limitOrder, marketOrder.order.timestamp, marketOrder.matcherFee, limitOrder.matcherFee)
 
     addressDirWithOrderBookCache ! OrderAdded(limitOrder, ntpTime.getTimestamp())
     addressDirWithOrderBookCache ! executionEvent

--- a/dex/src/test/scala/com/wavesplatform/dex/model/EventSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/EventSpecification.scala
@@ -9,11 +9,12 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
 class EventSpecification extends AnyFreeSpec with Matchers with MatcherSpecBase {
+
   "Proper rounding scenario 1" in {
     val pair      = AssetPair(Waves, mkAssetId("BTC"))
     val counter   = sell(pair, 840340L, 0.00000238, matcherFee = Some(300000L))
     val submitted = buy(pair, 425532L, 0.00000238, matcherFee = Some(300000L))
-    val exec      = OrderExecuted(LimitOrder(submitted), LimitOrder(counter), 0L)
+    val exec      = OrderExecuted(LimitOrder(submitted), LimitOrder(counter), 0L, submitted.matcherFee, counter.matcherFee)
     exec.executedAmount shouldBe 420169L
     exec.counterRemainingAmount shouldBe 420171L
     exec.counterRemainingAmount shouldBe counter.amount - exec.executedAmount
@@ -31,7 +32,7 @@ class EventSpecification extends AnyFreeSpec with Matchers with MatcherSpecBase 
     val counter   = sell(pair, 100000000, 0.0008, matcherFee = Some(2000L))
     val submitted = buy(pair, 120000000, 0.00085, matcherFee = Some(1000L))
 
-    val exec = OrderExecuted(LimitOrder(submitted), LimitOrder(counter), 0L)
+    val exec = OrderExecuted(LimitOrder(submitted), LimitOrder(counter), 0L, submitted.matcherFee, counter.matcherFee)
     exec.submittedRemainingAmount shouldBe 20000000L
     exec.submittedRemainingFee shouldBe 167L
   }
@@ -44,7 +45,7 @@ class EventSpecification extends AnyFreeSpec with Matchers with MatcherSpecBase 
     val bobPk     = KeyPair("bob".getBytes("utf-8"))
     val submitted = sell(pair, 223345000L, 0.00031887, matcherFee = Some(300000), sender = Some(bobPk))
 
-    val exec = OrderExecuted(LimitOrder(submitted), LimitOrder(counter), 0L)
+    val exec = OrderExecuted(LimitOrder(submitted), LimitOrder(counter), 0L, submitted.matcherFee, counter.matcherFee)
     exec.executedAmount shouldBe 223344937L
   }
 }

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderBookSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderBookSpec.scala
@@ -47,10 +47,10 @@ class OrderBookSpec extends AnyFreeSpec with PropertyChecks with Matchers with M
     val prices = Gen.choose(1, 100000L)
     for (tickSize <- normalizedTickSizes) {
       forAll(prices) { price =>
-        ob.add(LimitOrder(buy(pair, 1583290045643L, price)), ntpNow, tickSize)
+        ob.add(LimitOrder(buy(pair, 1583290045643L, price)), ntpNow, tickSize = tickSize)
       }
       forAll(prices) { price =>
-        ob.add(LimitOrder(sell(pair, 984651354686L, price)), ntpNow, tickSize)
+        ob.add(LimitOrder(sell(pair, 984651354686L, price)), ntpNow, tickSize = tickSize)
       }
       for ((level, orders) <- ob.getBids; order <- orders) {
         order.price - level should be < tickSize
@@ -84,20 +84,20 @@ class OrderBookSpec extends AnyFreeSpec with PropertyChecks with Matchers with M
     val sellOrd5 = LimitOrder(sell(pair, 54521418494L, 44357))
     val sellOrd6 = LimitOrder(sell(pair, 54521418493L, 44389))
 
-    ob.add(buyOrd1, ntpNow, normalizedTickSize)
-    ob.add(buyOrd2, ntpNow, normalizedTickSize)
-    ob.add(buyOrd3, ntpNow, normalizedTickSize)
-    ob.add(buyOrd4, ntpNow, normalizedTickSize)
-    ob.add(buyOrd5, ntpNow, normalizedTickSize)
-    ob.add(buyOrd6, ntpNow, normalizedTickSize)
-    ob.add(buyOrdZero, ntpNow, normalizedTickSize)
+    ob.add(buyOrd1, ntpNow, tickSize = normalizedTickSize)
+    ob.add(buyOrd2, ntpNow, tickSize = normalizedTickSize)
+    ob.add(buyOrd3, ntpNow, tickSize = normalizedTickSize)
+    ob.add(buyOrd4, ntpNow, tickSize = normalizedTickSize)
+    ob.add(buyOrd5, ntpNow, tickSize = normalizedTickSize)
+    ob.add(buyOrd6, ntpNow, tickSize = normalizedTickSize)
+    ob.add(buyOrdZero, ntpNow, tickSize = normalizedTickSize)
 
-    ob.add(sellOrd1, ntpNow, normalizedTickSize)
-    ob.add(sellOrd2, ntpNow, normalizedTickSize)
-    ob.add(sellOrd3, ntpNow, normalizedTickSize)
-    ob.add(sellOrd4, ntpNow, normalizedTickSize)
-    ob.add(sellOrd5, ntpNow, normalizedTickSize)
-    ob.add(sellOrd6, ntpNow, normalizedTickSize)
+    ob.add(sellOrd1, ntpNow, tickSize = normalizedTickSize)
+    ob.add(sellOrd2, ntpNow, tickSize = normalizedTickSize)
+    ob.add(sellOrd3, ntpNow, tickSize = normalizedTickSize)
+    ob.add(sellOrd4, ntpNow, tickSize = normalizedTickSize)
+    ob.add(sellOrd5, ntpNow, tickSize = normalizedTickSize)
+    ob.add(sellOrd6, ntpNow, tickSize = normalizedTickSize)
 
     ob.getBids.keySet shouldBe SortedSet[Long](0, 34300, 34200, 34100).map(toNormalized)
     ob.getAsks.keySet shouldBe SortedSet[Long](44100, 44200, 44300, 44400).map(toNormalized)
@@ -123,7 +123,7 @@ class OrderBookSpec extends AnyFreeSpec with PropertyChecks with Matchers with M
     ob.cancelAll(ntpNow)
     val sellTickSizeOrder = sell(pair, 54521418493L, 40)
 
-    ob.add(LimitOrder(sellTickSizeOrder), ntpNow, normalizedTickSize)
+    ob.add(LimitOrder(sellTickSizeOrder), ntpNow, tickSize = normalizedTickSize)
 
     ob.getAsks shouldBe mutable.TreeMap[Price, Level](
       Seq(
@@ -153,8 +153,8 @@ class OrderBookSpec extends AnyFreeSpec with PropertyChecks with Matchers with M
     }
 
     withClue("matchable orders should not be matched with tick size:\n") {
-      ob.add(counterSellOrder, ntpNow, normalizedTickSize)
-      ob.add(submittedBuyOrder, ntpNow, normalizedTickSize)
+      ob.add(counterSellOrder, ntpNow, tickSize = normalizedTickSize)
+      ob.add(submittedBuyOrder, ntpNow, tickSize = normalizedTickSize)
 
       ob.getAsks shouldBe mutable.TreeMap[Price, Level](
         Seq(16 -> Vector(counterSellOrder)).map { case (price, orders) => toNormalized(price) -> orders }: _*
@@ -172,8 +172,8 @@ class OrderBookSpec extends AnyFreeSpec with PropertyChecks with Matchers with M
 
     def normalizedTickSize(tickSize: Double): Price = Normalization.normalizePrice(tickSize, 8, 2)
 
-    val counter   = LimitOrder(createOrder(pairWavesUsd, SELL, 100.waves, 3.15))
-    val submitted = LimitOrder(createOrder(pairWavesUsd, BUY, 100.waves, 3.15))
+    val counter   = LimitOrder(createOrder(wavesUsdPair, SELL, 100.waves, 3.15))
+    val submitted = LimitOrder(createOrder(wavesUsdPair, BUY, 100.waves, 3.15))
 
     val counterTs   = counter.order.timestamp
     val submittedTs = submitted.order.timestamp
@@ -181,7 +181,7 @@ class OrderBookSpec extends AnyFreeSpec with PropertyChecks with Matchers with M
     withClue("Counter SELL order (price = 3.15, tick size disabled) and submitted BUY order (price = 3.15, tick size = 0.1) should be matched:\n") {
 
       ob.add(counter, counterTs) shouldBe Seq(OrderAdded(counter, counterTs))
-      ob.add(submitted, submittedTs, normalizedTickSize(0.1)) shouldBe Seq(OrderExecuted(submitted, counter, submittedTs))
+      ob.add(submitted, submittedTs, tickSize = normalizedTickSize(0.1)) shouldBe Seq(OrderExecuted(submitted, counter, submittedTs))
 
       ob.getAsks shouldBe empty
       ob.getBids shouldBe empty
@@ -203,8 +203,8 @@ class OrderBookSpec extends AnyFreeSpec with PropertyChecks with Matchers with M
         val ob                 = OrderBook.empty
 
         val sellOrder = LimitOrder(sell(pair, 54521418493L, 44389))
-        ob.add(sellOrder, ntpNow, normalizedTickSize)
-        ob.add(sellOrder, ntpNow, normalizedTickSize)
+        ob.add(sellOrder, ntpNow, tickSize = normalizedTickSize)
+        ob.add(sellOrder, ntpNow, tickSize = normalizedTickSize)
 
         ob.getAsks.size shouldBe 1
         ob.getAsks.head._2.toList shouldBe List(sellOrder, sellOrder)
@@ -214,8 +214,8 @@ class OrderBookSpec extends AnyFreeSpec with PropertyChecks with Matchers with M
         val ob = OrderBook.empty
 
         val sellOrder = LimitOrder(sell(pair, 54521418493L, 44389))
-        ob.add(sellOrder, ntpNow, MatchingRule.DefaultRule.tickSize)
-        ob.add(sellOrder, ntpNow, MatchingRule.DefaultRule.tickSize)
+        ob.add(sellOrder, ntpNow, tickSize = MatchingRule.DefaultRule.tickSize)
+        ob.add(sellOrder, ntpNow, tickSize = MatchingRule.DefaultRule.tickSize)
 
         ob.getAsks.size shouldBe 1
         ob.getAsks.head._2.toList shouldBe List(sellOrder, sellOrder)
@@ -226,8 +226,8 @@ class OrderBookSpec extends AnyFreeSpec with PropertyChecks with Matchers with M
       val ob = OrderBook.empty
 
       val sellOrder = LimitOrder(sell(pair, 54521418493L, 44389))
-      ob.add(sellOrder, ntpNow, toNormalized(100L))
-      ob.add(sellOrder, ntpNow, MatchingRule.DefaultRule.tickSize)
+      ob.add(sellOrder, ntpNow, tickSize = toNormalized(100L))
+      ob.add(sellOrder, ntpNow, tickSize = MatchingRule.DefaultRule.tickSize)
 
       ob.getAsks.size shouldBe 2
 

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderBookSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderBookSpec.scala
@@ -14,7 +14,7 @@ import com.wavesplatform.dex.grpc.integration.dto.BriefAssetDescription
 import com.wavesplatform.dex.model.Events.{OrderAdded, OrderExecuted}
 import com.wavesplatform.dex.model.OrderBook.{LastTrade, Level, SideSnapshot, Snapshot}
 import com.wavesplatform.dex.settings.MatchingRule
-import com.wavesplatform.dex.settings.OrderFeeSettings.{DynamicSettings1, OrderFeeSettings}
+import com.wavesplatform.dex.settings.OrderFeeSettings.{DynamicSettings, OrderFeeSettings}
 import com.wavesplatform.dex.time.NTPTime
 import com.wavesplatform.dex.{Matcher, MatcherSpecBase, NoShrink}
 import mouse.any._
@@ -419,57 +419,58 @@ class OrderBookSpec
       Table(
         ("M amount", "T amount", "is T market", "fee settings", "M order fee", "T order fee", "T fee asset", "M executed fee", "T executed fee"),
         /** symmetric */
-        (1.waves, 1.waves, false, DynamicSettings1(0.003.waves, 0.003.waves), 0.003.waves, 0.003, Waves, 0.003.waves, 0.003.waves), // like in old good times
-        (1.waves, 1.waves, false, DynamicSettings1(0.001.waves, 0.009.waves), 0.009.waves, 0.009, Waves, 0.001.waves, 0.009.waves), // orders have sufficient fee = 0.009.waves
-        (1.waves, 1.waves, false, DynamicSettings1(0.001.waves, 0.009.waves), 0.010.waves, 0.010, Waves, 0.001.waves, 0.009.waves), // orders have excess fee = 0.010.waves
+        (1.waves, 1.waves, false, DynamicSettings(0.003.waves, 0.003.waves), 0.003.waves, 0.003, Waves, 0.003.waves, 0.003.waves), // like in old good times
+        (1.waves, 1.waves, false, DynamicSettings(0.001.waves, 0.009.waves), 0.009.waves, 0.009, Waves, 0.001.waves, 0.009.waves), // orders have sufficient fee = 0.009.waves
+        (1.waves, 1.waves, false, DynamicSettings(0.001.waves, 0.009.waves), 0.010.waves, 0.010, Waves, 0.001.waves, 0.009.waves), // orders have excess fee = 0.010.waves
         /** small maker - big taker */
-        (2.waves, 10.waves, false, DynamicSettings1(0.003.waves, 0.003.waves), 0.003.waves, 0.003, Waves, 0.003.waves, 0.0006.waves), // like in old good times
-        (2.waves, 10.waves, false, DynamicSettings1(0.001.waves, 0.009.waves), 0.009.waves, 0.009, Waves, 0.001.waves, 0.0018.waves), // orders have sufficient fee = 0.009.waves
-        (2.waves, 10.waves, false, DynamicSettings1(0.001.waves, 0.009.waves), 0.010.waves, 0.010, Waves, 0.001.waves, 0.0018.waves), // orders have excess fee = 0.010.waves
+        (2.waves, 10.waves, false, DynamicSettings(0.003.waves, 0.003.waves), 0.003.waves, 0.003, Waves, 0.003.waves, 0.0006.waves), // like in old good times
+        (2.waves, 10.waves, false, DynamicSettings(0.001.waves, 0.009.waves), 0.009.waves, 0.009, Waves, 0.001.waves, 0.0018.waves), // orders have sufficient fee = 0.009.waves
+        (2.waves, 10.waves, false, DynamicSettings(0.001.waves, 0.009.waves), 0.010.waves, 0.010, Waves, 0.001.waves, 0.0018.waves), // orders have excess fee = 0.010.waves
         /** big maker - small taker */
-        (10.waves, 2.waves, false, DynamicSettings1(0.003.waves, 0.003.waves), 0.003.waves, 0.003, Waves, 0.0006.waves, 0.003.waves), // like in old good times
-        (10.waves, 2.waves, false, DynamicSettings1(0.001.waves, 0.009.waves), 0.009.waves, 0.009, Waves, 0.0002.waves, 0.009.waves), // orders have sufficient fee = 0.009.waves
-        (10.waves, 2.waves, false, DynamicSettings1(0.001.waves, 0.009.waves), 0.010.waves, 0.010, Waves, 0.0002.waves, 0.009.waves), // orders have excess fee = 0.010.waves
+        (10.waves, 2.waves, false, DynamicSettings(0.003.waves, 0.003.waves), 0.003.waves, 0.003, Waves, 0.0006.waves, 0.003.waves), // like in old good times
+        (10.waves, 2.waves, false, DynamicSettings(0.001.waves, 0.009.waves), 0.009.waves, 0.009, Waves, 0.0002.waves, 0.009.waves), // orders have sufficient fee = 0.009.waves
+        (10.waves, 2.waves, false, DynamicSettings(0.001.waves, 0.009.waves), 0.010.waves, 0.010, Waves, 0.0002.waves, 0.009.waves), // orders have excess fee = 0.010.waves
         /** symmetric, taker is market */
-        (1.waves, 1.waves, true, DynamicSettings1(0.003.waves, 0.003.waves), 0.003.waves, 0.003, Waves, 0.003.waves, 0.003.waves), // like in old good times
-        (1.waves, 1.waves, true, DynamicSettings1(0.001.waves, 0.009.waves), 0.009.waves, 0.009, Waves, 0.001.waves, 0.009.waves), // orders have sufficient fee = 0.009.waves
-        (1.waves, 1.waves, true, DynamicSettings1(0.001.waves, 0.009.waves), 0.010.waves, 0.010, Waves, 0.001.waves, 0.009.waves), // orders have excess fee = 0.010.waves
+        (1.waves, 1.waves, true, DynamicSettings(0.003.waves, 0.003.waves), 0.003.waves, 0.003, Waves, 0.003.waves, 0.003.waves), // like in old good times
+        (1.waves, 1.waves, true, DynamicSettings(0.001.waves, 0.009.waves), 0.009.waves, 0.009, Waves, 0.001.waves, 0.009.waves), // orders have sufficient fee = 0.009.waves
+        (1.waves, 1.waves, true, DynamicSettings(0.001.waves, 0.009.waves), 0.010.waves, 0.010, Waves, 0.001.waves, 0.009.waves), // orders have excess fee = 0.010.waves
         /** small maker - big market taker */
-        (2.waves, 10.waves, true, DynamicSettings1(0.003.waves, 0.003.waves), 0.003.waves, 0.003, Waves, 0.003.waves, 0.0006.waves), // like in old good times
-        (2.waves, 10.waves, true, DynamicSettings1(0.001.waves, 0.009.waves), 0.009.waves, 0.009, Waves, 0.001.waves, 0.0018.waves), // orders have sufficient fee = 0.009.waves
-        (2.waves, 10.waves, true, DynamicSettings1(0.001.waves, 0.009.waves), 0.010.waves, 0.010, Waves, 0.001.waves, 0.0018.waves), // orders have excess fee = 0.010.waves
+        (2.waves, 10.waves, true, DynamicSettings(0.003.waves, 0.003.waves), 0.003.waves, 0.003, Waves, 0.003.waves, 0.0006.waves), // like in old good times
+        (2.waves, 10.waves, true, DynamicSettings(0.001.waves, 0.009.waves), 0.009.waves, 0.009, Waves, 0.001.waves, 0.0018.waves), // orders have sufficient fee = 0.009.waves
+        (2.waves, 10.waves, true, DynamicSettings(0.001.waves, 0.009.waves), 0.010.waves, 0.010, Waves, 0.001.waves, 0.0018.waves), // orders have excess fee = 0.010.waves
         /** big maker - small market taker */
-        (10.waves, 2.waves, true, DynamicSettings1(0.003.waves, 0.003.waves), 0.003.waves, 0.003, Waves, 0.0006.waves, 0.003.waves), // like in old good times
-        (10.waves, 2.waves, true, DynamicSettings1(0.001.waves, 0.009.waves), 0.009.waves, 0.009, Waves, 0.0002.waves, 0.009.waves), // orders have sufficient fee = 0.009.waves
-        (10.waves, 2.waves, true, DynamicSettings1(0.001.waves, 0.009.waves), 0.010.waves, 0.010, Waves, 0.0002.waves, 0.009.waves), // orders have excess fee = 0.010.waves
+        (10.waves, 2.waves, true, DynamicSettings(0.003.waves, 0.003.waves), 0.003.waves, 0.003, Waves, 0.0006.waves, 0.003.waves), // like in old good times
+        (10.waves, 2.waves, true, DynamicSettings(0.001.waves, 0.009.waves), 0.009.waves, 0.009, Waves, 0.0002.waves, 0.009.waves), // orders have sufficient fee = 0.009.waves
+        (10.waves, 2.waves, true, DynamicSettings(0.001.waves, 0.009.waves), 0.010.waves, 0.010, Waves, 0.0002.waves, 0.009.waves), // orders have excess fee = 0.010.waves
         /** symmetric, taker fee in ETH */
-        (1.waves, 1.waves, false, DynamicSettings1(0.003.waves, 0.003.waves), 0.003.waves, 0.00001703, eth, 0.003.waves, 0.00001703.eth), // like in old good times
-        (1.waves, 1.waves, false, DynamicSettings1(0.001.waves, 0.009.waves), 0.009.waves, 0.00005109, eth, 0.001.waves, 0.00005109.eth), // orders have sufficient fee = 0.009.waves = 0.00005109.eth
-        (1.waves, 1.waves, false, DynamicSettings1(0.001.waves, 0.009.waves), 0.010.waves, 0.00005676, eth, 0.001.waves, 0.00005109.eth), // orders have excess fee = 0.010.waves = 0.00005676.eth
+        (1.waves, 1.waves, false, DynamicSettings(0.003.waves, 0.003.waves), 0.003.waves, 0.00001703, eth, 0.003.waves, 0.00001703.eth), // like in old good times
+        (1.waves, 1.waves, false, DynamicSettings(0.001.waves, 0.009.waves), 0.009.waves, 0.00005109, eth, 0.001.waves, 0.00005109.eth), // orders have sufficient fee = 0.009.waves = 0.00005109.eth
+        (1.waves, 1.waves, false, DynamicSettings(0.001.waves, 0.009.waves), 0.010.waves, 0.00005676, eth, 0.001.waves, 0.00005109.eth), // orders have excess fee = 0.010.waves = 0.00005676.eth
         /** small maker - big taker, taker fee in ETH */
-        (2.waves, 10.waves, false, DynamicSettings1(0.003.waves, 0.003.waves), 0.003.waves, 0.00001703, eth, 0.003.waves, 0.00000340.eth), // like in old good times
-        (2.waves, 10.waves, false, DynamicSettings1(0.001.waves, 0.009.waves), 0.009.waves, 0.00005109, eth, 0.001.waves, 0.00001021.eth), // orders have sufficient fee = 0.009.waves = 0.00005109.eth
-        (2.waves, 10.waves, false, DynamicSettings1(0.001.waves, 0.009.waves), 0.010.waves, 0.00005676, eth, 0.001.waves, 0.00001021.waves), // orders have excess fee = 0.010.waves = 0.00005676.eth
+        (2.waves, 10.waves, false, DynamicSettings(0.003.waves, 0.003.waves), 0.003.waves, 0.00001703, eth, 0.003.waves, 0.00000340.eth), // like in old good times
+        (2.waves, 10.waves, false, DynamicSettings(0.001.waves, 0.009.waves), 0.009.waves, 0.00005109, eth, 0.001.waves, 0.00001021.eth),   // orders have sufficient fee = 0.009.waves = 0.00005109.eth
+        (2.waves, 10.waves, false, DynamicSettings(0.001.waves, 0.009.waves), 0.010.waves, 0.00005676, eth, 0.001.waves, 0.00001021.waves), // orders have excess fee = 0.010.waves = 0.00005676.eth
         /** big maker - small taker, taker fee in ETH */
-        (10.waves, 2.waves, false, DynamicSettings1(0.003.waves, 0.003.waves), 0.003.waves, 0.00001703, eth, 0.0006.waves, 0.00001703.eth), // like in old good times
-        (10.waves, 2.waves, false, DynamicSettings1(0.001.waves, 0.009.waves), 0.009.waves, 0.00005109, eth, 0.0002.waves, 0.00005109.eth), // orders have sufficient fee = 0.009.waves = 0.00005109.eth
-        (10.waves, 2.waves, false, DynamicSettings1(0.001.waves, 0.009.waves), 0.010.waves, 0.00005676, eth, 0.0002.waves, 0.00005109.eth), // orders have excess fee = 0.010.waves = 0.00005676.eth
+        (10.waves, 2.waves, false, DynamicSettings(0.003.waves, 0.003.waves), 0.003.waves, 0.00001703, eth, 0.0006.waves, 0.00001703.eth), // like in old good times
+        (10.waves, 2.waves, false, DynamicSettings(0.001.waves, 0.009.waves), 0.009.waves, 0.00005109, eth, 0.0002.waves, 0.00005109.eth), // orders have sufficient fee = 0.009.waves = 0.00005109.eth
+        (10.waves, 2.waves, false, DynamicSettings(0.001.waves, 0.009.waves), 0.010.waves, 0.00005676, eth, 0.0002.waves, 0.00005109.eth), // orders have excess fee = 0.010.waves = 0.00005676.eth
         /** symmetric, taker is market, taker fee in ETH */
-        (1.waves, 1.waves, true, DynamicSettings1(0.003.waves, 0.003.waves), 0.003.waves, 0.00001703, eth, 0.003.waves, 0.00001703.eth), // like in old good times
-        (1.waves, 1.waves, true, DynamicSettings1(0.001.waves, 0.009.waves), 0.009.waves, 0.00005109, eth, 0.001.waves, 0.00005109.eth), // orders have sufficient fee = 0.009.waves = 0.00005109.eth
-        (1.waves, 1.waves, true, DynamicSettings1(0.001.waves, 0.009.waves), 0.010.waves, 0.00005676, eth, 0.001.waves, 0.00005109.eth), // orders have excess fee = 0.010.waves = 0.00005676.eth
+        (1.waves, 1.waves, true, DynamicSettings(0.003.waves, 0.003.waves), 0.003.waves, 0.00001703, eth, 0.003.waves, 0.00001703.eth), // like in old good times
+        (1.waves, 1.waves, true, DynamicSettings(0.001.waves, 0.009.waves), 0.009.waves, 0.00005109, eth, 0.001.waves, 0.00005109.eth), // orders have sufficient fee = 0.009.waves = 0.00005109.eth
+        (1.waves, 1.waves, true, DynamicSettings(0.001.waves, 0.009.waves), 0.010.waves, 0.00005676, eth, 0.001.waves, 0.00005109.eth), // orders have excess fee = 0.010.waves = 0.00005676.eth
         /** small maker - big market taker, taker fee in ETH */
-        (2.waves, 10.waves, true, DynamicSettings1(0.003.waves, 0.003.waves), 0.003.waves, 0.00001703, eth, 0.003.waves, 0.00000340.eth), // like in old good times
-        (2.waves, 10.waves, true, DynamicSettings1(0.001.waves, 0.009.waves), 0.009.waves, 0.00005109, eth, 0.001.waves, 0.00001021.eth), // orders have sufficient fee = 0.009.waves = 0.00005109.eth
-        (2.waves, 10.waves, true, DynamicSettings1(0.001.waves, 0.009.waves), 0.010.waves, 0.00005676, eth, 0.001.waves, 0.00001021.waves), // orders have excess fee = 0.010.waves = 0.00005676.eth
+        (2.waves, 10.waves, true, DynamicSettings(0.003.waves, 0.003.waves), 0.003.waves, 0.00001703, eth, 0.003.waves, 0.00000340.eth), // like in old good times
+        (2.waves, 10.waves, true, DynamicSettings(0.001.waves, 0.009.waves), 0.009.waves, 0.00005109, eth, 0.001.waves, 0.00001021.eth),   // orders have sufficient fee = 0.009.waves = 0.00005109.eth
+        (2.waves, 10.waves, true, DynamicSettings(0.001.waves, 0.009.waves), 0.010.waves, 0.00005676, eth, 0.001.waves, 0.00001021.waves), // orders have excess fee = 0.010.waves = 0.00005676.eth
         /** big maker - small market taker, taker fee in ETH */
-        (10.waves, 2.waves, true, DynamicSettings1(0.003.waves, 0.003.waves), 0.003.waves, 0.00001703, eth, 0.0006.waves, 0.00001703.eth), // like in old good times
-        (10.waves, 2.waves, true, DynamicSettings1(0.001.waves, 0.009.waves), 0.009.waves, 0.00005109, eth, 0.0002.waves, 0.00005109.eth), // orders have sufficient fee = 0.009.waves
-        (10.waves, 2.waves, true, DynamicSettings1(0.001.waves, 0.009.waves), 0.010.waves, 0.00005676, eth, 0.0002.waves, 0.00005109.eth), // orders have excess fee = 0.010.waves = 0.00005676.eth
+        (10.waves, 2.waves, true, DynamicSettings(0.003.waves, 0.003.waves), 0.003.waves, 0.00001703, eth, 0.0006.waves, 0.00001703.eth), // like in old good times
+        (10.waves, 2.waves, true, DynamicSettings(0.001.waves, 0.009.waves), 0.009.waves, 0.00005109, eth, 0.0002.waves, 0.00005109.eth), // orders have sufficient fee = 0.009.waves
+        (10.waves, 2.waves, true, DynamicSettings(0.001.waves, 0.009.waves), 0.010.waves, 0.00005676, eth, 0.0002.waves, 0.00005109.eth) // orders have excess fee = 0.010.waves = 0.00005676.eth
       )
+      // format: off
     ) { (mAmt: Long, tAmt: Long, isTMarket: Boolean, ofs: OrderFeeSettings, orderMFee: Long, orderTFee: Double, tFeeAsset: Asset, eMFee: Long, eTFee: Long) =>
-//      val ob    = createEmptyOrderBook(Matcher.getMakerTakerFee(ofs, assetsCache, rateCache))
-      val ob    = createEmptyOrderBook(Matcher.getMakerTakerFee(ofs, assetsCache, rateCache))
+      // format: on
+      val ob                  = createEmptyOrderBook(Matcher.getMakerTakerFee(ofs, assetsCache, rateCache))
       val normalizedOrderTFee = Normalization.normalizeAmountAndFee(orderTFee, 8)
 
       val maker = limit(mAmt, SELL, orderMFee)

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderHistoryBalanceSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderHistoryBalanceSpecification.scala
@@ -910,6 +910,7 @@ private object OrderHistoryBalanceSpecification {
   }
 
   private implicit class OrderExecutedExt(val oe: OrderExecuted.type) extends AnyVal {
-    def apply(submitted: LimitOrder, counter: LimitOrder): OrderExecuted = OrderExecuted(submitted, counter, submitted.order.timestamp)
+    def apply(submitted: LimitOrder, counter: LimitOrder): OrderExecuted =
+      OrderExecuted(submitted, counter, submitted.order.timestamp, submitted.matcherFee, counter.matcherFee)
   }
 }

--- a/dex/src/test/scala/com/wavesplatform/dex/settings/BaseSettingsSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/settings/BaseSettingsSpecification.scala
@@ -15,18 +15,20 @@ class BaseSettingsSpecification extends AnyFlatSpec {
   val correctOrderFeeStr: String =
     s"""
        |order-fee {
-       |  mode = percent
-       |  dynamic {
-       |    base-maker-fee = 200000
-       |    base-maker-fee = 700000
-       |  }
-       |  fixed {
-       |    asset = WAVES
-       |    min-fee = 300000
-       |  }
-       |  percent {
-       |    asset-type = amount
-       |    min-fee = 0.1
+       |  0: {
+       |    mode = percent
+       |    dynamic {
+       |      base-maker-fee = 200000
+       |      base-maker-fee = 700000
+       |    }
+       |    fixed {
+       |      asset = WAVES
+       |      min-fee = 300000
+       |    }
+       |    percent {
+       |      asset-type = amount
+       |      min-fee = 0.1
+       |    }
        |  }
        |}
        """.stripMargin

--- a/dex/src/test/scala/com/wavesplatform/dex/settings/BaseSettingsSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/settings/BaseSettingsSpecification.scala
@@ -15,7 +15,7 @@ class BaseSettingsSpecification extends AnyFlatSpec {
   val correctOrderFeeStr: String =
     s"""
        |order-fee {
-       |  0: {
+       |  -1: {
        |    mode = percent
        |    dynamic {
        |      base-maker-fee = 200000

--- a/dex/src/test/scala/com/wavesplatform/dex/settings/BaseSettingsSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/settings/BaseSettingsSpecification.scala
@@ -18,6 +18,7 @@ class BaseSettingsSpecification extends AnyFlatSpec {
        |  mode = percent
        |  dynamic {
        |    base-fee = 300000
+       |    zero-maker-double-taker = true
        |  }
        |  fixed {
        |    asset = WAVES

--- a/dex/src/test/scala/com/wavesplatform/dex/settings/BaseSettingsSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/settings/BaseSettingsSpecification.scala
@@ -17,8 +17,8 @@ class BaseSettingsSpecification extends AnyFlatSpec {
        |order-fee {
        |  mode = percent
        |  dynamic {
-       |    base-fee = 300000
-       |    zero-maker-double-taker = true
+       |    base-maker-fee = 200000
+       |    base-maker-fee = 700000
        |  }
        |  fixed {
        |    asset = WAVES

--- a/dex/src/test/scala/com/wavesplatform/dex/settings/MatcherSettingsSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/settings/MatcherSettingsSpecification.scala
@@ -80,7 +80,7 @@ class MatcherSettingsSpecification extends BaseSettingsSpecification with Matche
     settings.eventsQueue.kafka.consumer.client.getInt("foo") shouldBe 2
     settings.eventsQueue.kafka.producer.client.getInt("bar") shouldBe 3
     settings.processConsumedTimeout shouldBe 663.seconds
-    settings.orderFee should matchTo(Map[Long, OrderFeeSettings](0L -> PercentSettings(AssetType.AMOUNT, 0.1)))
+    settings.orderFee should matchTo(Map[Long, OrderFeeSettings](-1L -> PercentSettings(AssetType.AMOUNT, 0.1)))
     settings.deviation shouldBe DeviationsSettings(true, 1000000, 1000000, 1000000)
     settings.allowedAssetPairs shouldBe Set.empty[AssetPair]
     settings.allowedOrderVersions shouldBe Set(11, 22)
@@ -145,7 +145,7 @@ class MatcherSettingsSpecification extends BaseSettingsSpecification with Matche
     def invalidMode(invalidModeName: String = "invalid"): String =
       s"""
          |order-fee {
-         |  0: {
+         |  -1: {
          |    mode = $invalidModeName
          |    dynamic {
          |      base-maker-fee = 300000
@@ -166,7 +166,7 @@ class MatcherSettingsSpecification extends BaseSettingsSpecification with Matche
     val invalidAssetTypeAndPercent =
       s"""
          |order-fee {
-         |  0: {
+         |  -1: {
          |    mode = percent
          |    dynamic {
          |      base-maker-fee = 300000
@@ -187,7 +187,7 @@ class MatcherSettingsSpecification extends BaseSettingsSpecification with Matche
     val invalidAssetAndFee =
       s"""
          |order-fee {
-         |  0: {
+         |  -1: {
          |    mode = fixed
          |    dynamic {
          |      base-maker-fee = 300000
@@ -208,7 +208,7 @@ class MatcherSettingsSpecification extends BaseSettingsSpecification with Matche
     val invalidFeeInDynamicMode =
       s"""
          |order-fee {
-         |  0: {
+         |  -1: {
          |    mode = dynamic
          |    dynamic {
          |      base-maker-fee = -350000
@@ -233,22 +233,22 @@ class MatcherSettingsSpecification extends BaseSettingsSpecification with Matche
     val settingsInvalidAssetAndFee      = getSettingByConfig(configStr(invalidAssetAndFee))
     val settingsInvalidFeeInDynamicMode = getSettingByConfig(configStr(invalidFeeInDynamicMode))
 
-    settingsInvalidMode shouldBe Left("Invalid setting order-fee value: Invalid setting order-fee.0.mode value: invalid")
+    settingsInvalidMode shouldBe Left("Invalid setting order-fee value: Invalid setting order-fee.-1.mode value: invalid")
 
-    settingsDeprecatedNameMode shouldBe Left("Invalid setting order-fee value: Invalid setting order-fee.0.mode value: waves")
+    settingsDeprecatedNameMode shouldBe Left("Invalid setting order-fee value: Invalid setting order-fee.-1.mode value: waves")
 
     settingsInvalidTypeAndPercent shouldBe
       Left(
-        "Invalid setting order-fee value: Invalid setting order-fee.0.percent.asset-type value: test, " +
-          "Invalid setting order-fee.0.percent.min-fee value: 121.2 (required 0 < percent <= 100)")
+        "Invalid setting order-fee value: Invalid setting order-fee.-1.percent.asset-type value: test, " +
+          "Invalid setting order-fee.-1.percent.min-fee value: 121.2 (required 0 < percent <= 100)")
 
     settingsInvalidAssetAndFee shouldBe
       Left(
-        "Invalid setting order-fee value: Invalid setting order-fee.0.fixed.asset value: ;;;;, " +
-          "Invalid setting order-fee.0.fixed.min-fee value: -300000 (required 0 < fee)")
+        "Invalid setting order-fee value: Invalid setting order-fee.-1.fixed.asset value: ;;;;, " +
+          "Invalid setting order-fee.-1.fixed.min-fee value: -300000 (required 0 < fee)")
 
     settingsInvalidFeeInDynamicMode shouldBe Left(
-      s"Invalid setting order-fee value: Invalid setting order-fee.0.dynamic.base-maker-fee value: -350000 (required 0 < base maker fee)"
+      s"Invalid setting order-fee value: Invalid setting order-fee.-1.dynamic.base-maker-fee value: -350000 (required 0 < base maker fee)"
     )
   }
 

--- a/dex/src/test/scala/com/wavesplatform/dex/settings/MatcherSettingsSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/settings/MatcherSettingsSpecification.scala
@@ -80,9 +80,9 @@ class MatcherSettingsSpecification extends BaseSettingsSpecification with Matche
     settings.processConsumedTimeout shouldBe 663.seconds
 
     settings.orderFee match {
-      case DynamicSettings(baseFee, zeroMakerDoubleTaker) =>
-        baseFee shouldBe 300000
-        zeroMakerDoubleTaker shouldBe true
+      case DynamicSettings(baseMakerFee, baseTakerFee) =>
+        baseMakerFee shouldBe 200000
+        baseTakerFee shouldBe 700000
       case FixedSettings(defaultAssetId, minFee) =>
         defaultAssetId shouldBe None
         minFee shouldBe 300000
@@ -157,7 +157,8 @@ class MatcherSettingsSpecification extends BaseSettingsSpecification with Matche
          |order-fee {
          |  mode = $invalidModeName
          |  dynamic {
-         |    base-fee = 300000
+         |    base-maker-fee = 300000
+         |    base-taker-fee = 300000
          |  }
          |  fixed {
          |    asset = WAVES
@@ -175,7 +176,8 @@ class MatcherSettingsSpecification extends BaseSettingsSpecification with Matche
          |order-fee {
          |  mode = percent
          |  dynamic {
-         |    base-fee = 300000
+         |    base-maker-fee = 300000
+         |    base-taker-fee = 300000
          |  }
          |  fixed {
          |    asset = WAVES
@@ -193,7 +195,8 @@ class MatcherSettingsSpecification extends BaseSettingsSpecification with Matche
          |order-fee {
          |  mode = fixed
          |  dynamic {
-         |    base-fee = 300000
+         |    base-maker-fee = 300000
+         |    base-taker-fee = 300000
          |  }
          |  fixed {
          |    asset = ;;;;
@@ -211,7 +214,8 @@ class MatcherSettingsSpecification extends BaseSettingsSpecification with Matche
          |order-fee {
          |  mode = dynamic
          |  dynamic {
-         |    base-fee = -350000
+         |    base-maker-fee = -350000
+         |    base-taker-fee = 350000
          |  }
          |  fixed {
          |    asset = ;;;;
@@ -246,7 +250,7 @@ class MatcherSettingsSpecification extends BaseSettingsSpecification with Matche
           "Invalid setting order-fee.fixed.min-fee value: -300000 (required 0 < fee)")
 
     settingsInvalidFeeInDynamicMode shouldBe Left(
-      s"Invalid setting order-fee.dynamic.base-fee value: -350000 (required 0 < base fee)"
+      s"Invalid setting order-fee.dynamic.base-maker-fee value: -350000 (required 0 < base maker fee)"
     )
   }
 

--- a/dex/src/test/scala/com/wavesplatform/dex/settings/MatcherSettingsSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/settings/MatcherSettingsSpecification.scala
@@ -80,8 +80,9 @@ class MatcherSettingsSpecification extends BaseSettingsSpecification with Matche
     settings.processConsumedTimeout shouldBe 663.seconds
 
     settings.orderFee match {
-      case DynamicSettings(baseFee) =>
+      case DynamicSettings(baseFee, zeroMakerDoubleTaker) =>
         baseFee shouldBe 300000
+        zeroMakerDoubleTaker shouldBe true
       case FixedSettings(defaultAssetId, minFee) =>
         defaultAssetId shouldBe None
         minFee shouldBe 300000

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/domain/model/package.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/domain/model/package.scala
@@ -23,5 +23,7 @@ package object model {
 
     def denormalizePrice(value: Price, amountAssetDecimals: Int, priceAssetDecimals: Int): BigDecimal =
       BigDecimal(value) / BigDecimal(10).pow(8 + priceAssetDecimals - amountAssetDecimals)
+
+    def denormalizeWavesAmount(value: Amount): BigDecimal = denormalizeAmountAndFee(value, 8)
   }
 }


### PR DESCRIPTION
Main:

  * Order fee settings now can be changed at some offset
  * Dynamic fee settings in application.conf now have 2 base fee instead of 1: base-maker-fee/base-taker-fee
  * Orders are validated by actual (current offset + 1) fee settings, fee is charged according to the current fee settings. Note, it can lead to matcher loses!
  * Method `getMakerTakerFee` in Matcher introduced. In case of dynamic fee settings matcher charges signed fee proportional to executed amount and _maker/taker ratio_
  * OrderBook accepts `getMakerTakerFee` lambda in `add` method and creates OrderExecuted event by fee settings associated with offset of the submitted order

Miscellaneous:

  * RateCacheSpecification introduced