### PR TITLE
DEX-524 Creation of the orders with denormalized price in it-tests

### DIFF
--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/config/PredefinedAssets.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/config/PredefinedAssets.scala
@@ -1,7 +1,7 @@
 package com.wavesplatform.dex.it.config
 
 import com.wavesplatform.dex.domain.asset.Asset.{IssuedAsset, Waves}
-import com.wavesplatform.dex.domain.asset.AssetPair
+import com.wavesplatform.dex.domain.asset.{Asset, AssetPair}
 import com.wavesplatform.dex.domain.bytes.ByteStr
 import com.wavesplatform.dex.it.config.PredefinedAccounts._
 import com.wavesplatform.dex.it.waves.Implicits._
@@ -42,4 +42,6 @@ trait PredefinedAssets {
 
   val ForbiddenAssetId: ByteStr   = ByteStr.decodeBase58("FdbnAsset").get
   val ForbiddenAsset: IssuedAsset = IssuedAsset(ForbiddenAssetId)
+
+  implicit val assetDecimalsMap: Map[Asset, Int] = Map(Waves -> 8, usd -> 2, wct -> 2, eth -> 8, btc -> 8)
 }

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/waves/MkWavesEntities.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/waves/MkWavesEntities.scala
@@ -6,6 +6,7 @@ import com.wavesplatform.dex.domain.account.{Address, AddressScheme, KeyPair, Pu
 import com.wavesplatform.dex.domain.asset.Asset.{IssuedAsset, Waves}
 import com.wavesplatform.dex.domain.asset.{Asset, AssetPair}
 import com.wavesplatform.dex.domain.bytes.ByteStr
+import com.wavesplatform.dex.domain.model.Normalization
 import com.wavesplatform.dex.domain.order.{Order, OrderType}
 import com.wavesplatform.dex.domain.transaction.{ExchangeTransaction, ExchangeTransactionV2}
 import com.wavesplatform.dex.domain.utils.EitherExt2
@@ -67,6 +68,22 @@ trait MkWavesEntities {
         version = 3,
         feeAsset = feeAsset
       )
+
+  /** Creates order with denormalized price */
+  def mkOrderDP(owner: KeyPair,
+                pair: AssetPair,
+                orderType: OrderType,
+                amount: Long,
+                price: Double,
+                matcherFee: Long = matcherFee,
+                feeAsset: Asset = Waves,
+                ts: Long = System.currentTimeMillis,
+                ttl: Duration = 30.days - 1.seconds,
+                version: Byte = orderVersion,
+                matcher: PublicKey = matcher)(implicit assetDecimalsMap: Map[Asset, Int]): Order = {
+    val normalizedPrice = Normalization.normalizePrice(price, assetDecimalsMap(pair.amountAsset), assetDecimalsMap(pair.priceAsset))
+    mkOrder(owner, pair, orderType, amount, normalizedPrice, matcherFee, feeAsset, ts, ttl, version, matcher)
+  }
 
   def mkTransfer(sender: KeyPair,
                  recipient: Address,

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/MarketOrderTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/MarketOrderTestSuite.scala
@@ -8,7 +8,6 @@ import com.wavesplatform.dex.domain.account.KeyPair
 import com.wavesplatform.dex.domain.asset.Asset.Waves
 import com.wavesplatform.dex.domain.asset.{Asset, AssetPair}
 import com.wavesplatform.dex.domain.bytes.ByteStr
-import com.wavesplatform.dex.domain.model.Normalization
 import com.wavesplatform.dex.domain.order.OrderType.{BUY, SELL}
 import com.wavesplatform.dex.domain.order.{Order, OrderType}
 import com.wavesplatform.dex.it.api.responses.dex.{OrderBookHistoryItem, OrderStatus, OrderStatusResponse}
@@ -22,11 +21,6 @@ class MarketOrderTestSuite extends MatcherSuiteBase {
 
   val fixedFee: Long  = 0.003.waves
   val percentFee: Int = 14
-
-  implicit class DoubleOps(value: Double) {
-    val waves, eth: Long = Normalization.normalizeAmountAndFee(value, 8)
-    val usd: Long        = Normalization.normalizePrice(value, 8, 2)
-  }
 
   def tooLowPrice(orderType: String, price: String): String = {
     s"Price of the $orderType market order ($price) is too low for its full execution with the current market state"

--- a/dex-test-common/src/main/scala/com/wavesplatform/dex/asset/DoubleOps.scala
+++ b/dex-test-common/src/main/scala/com/wavesplatform/dex/asset/DoubleOps.scala
@@ -5,7 +5,7 @@ import com.wavesplatform.dex.domain.model.Normalization
 trait DoubleOps {
   implicit final class DoubleOpsImplicits(val value: Double) {
     val waves, eth, btc: Long = Normalization.normalizeAmountAndFee(value, 8)
-    val usd: Long             = Normalization.normalizeAmountAndFee(value, 2)
+    val usd, wct: Long        = Normalization.normalizeAmountAndFee(value, 2)
   }
 }
 

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/domain/order/OrderV1.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/domain/order/OrderV1.scala
@@ -72,9 +72,6 @@ case class OrderV1(@ApiModelProperty(
       Longs.toByteArray(matcherFee)
   )
 
-//  @ApiModelProperty(hidden = true)
-//  val signatureValid = Coeval.evalOnce(crypto.verify(signature, bodyBytes(), senderPublicKey))
-
   @ApiModelProperty(hidden = true)
   override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(bodyBytes() ++ signature)
 }

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/domain/transaction/ExchangeTransactionV1.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/domain/transaction/ExchangeTransactionV1.scala
@@ -50,9 +50,6 @@ case class ExchangeTransactionV1(buyOrder: OrderV1,
 
   override val bytes: Coeval[Array[Byte]] = Coeval.evalOnce(bodyBytes() ++ signature.arr)
 
-//  val signatureValid: Coeval[Boolean] = Coeval.evalOnce(crypto.verify(signature.arr, bodyBytes(), sender))
-
-//  override val signedDescendants: Coeval[Seq[Signed]] = Coeval.evalOnce(Seq(buyOrder, sellOrder))
 }
 
 object ExchangeTransactionV1 extends ExchangeTransactionParser[ExchangeTransactionV1] {
@@ -103,8 +100,8 @@ object ExchangeTransactionV1 extends ExchangeTransactionParser[ExchangeTransacti
 
   override def statefulParse: Stateful[ExchangeTransactionV1] = {
     for {
-      _              <- read[Int] // legacy buy order length
-      _              <- read[Int] // legacy sell order length
+      _              <- read[Int]
+      _              <- read[Int]
       buyOrder       <- OrderV1.statefulParse
       sellOrder      <- OrderV1.statefulParse
       price          <- read[Long]


### PR DESCRIPTION
 * mkOrderDP introduced (accepts prices of type double)
 * PostgresHistoryDatabaseTestSuite is rewritten in mkOrderDP style