### PR TITLE
DEX-603 Logging and configuration issues

### DIFF
--- a/dex/build.sbt
+++ b/dex/build.sbt
@@ -99,9 +99,11 @@ inConfig(Universal)(
   ))
 
 // DEB package
-Linux / name := s"waves-dex" // A staging directory name
-Linux / normalizedName := (Linux / name).value // An archive file name
-Linux / packageName := (Linux / name).value    // In a control file
+inConfig(Linux)(Seq(
+  name := "waves-dex", // A staging directory name
+  normalizedName := name.value, // An archive file name
+  packageName := name.value // In a control file
+))
 
 inConfig(Debian)(
   Seq(

--- a/dex/build.sbt
+++ b/dex/build.sbt
@@ -90,6 +90,12 @@ executableScriptName := "waves-dex"
 inConfig(Universal)(
   Seq(
     packageName := s"waves-dex-${version.value}", // An archive file name
+    // Common JVM parameters
+    // -J prefix is required by a parser
+    javaOptions ++= Seq(
+      "-Xmx2g",
+      "-Xms128m",
+    ).map(x => s"-J$x"),
     mappings ++= sbt.IO
       .listFiles((Compile / packageSource).value / "doc")
       .map { file =>

--- a/dex/src/main/resources/application.conf
+++ b/dex/src/main/resources/application.conf
@@ -489,7 +489,7 @@ akka {
   jvm-shutdown-hooks = off
 
   loggers = ["akka.event.slf4j.Slf4jLogger"]
-  loglevel = "TRACE"
+  loglevel = "DEBUG" # | OFF | ERROR | WARNING | INFO
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
 
   actor {

--- a/dex/src/main/scala/com/wavesplatform/dex/Application.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/Application.scala
@@ -110,6 +110,11 @@ object Application {
   private[this] def startDEX(configFile: Option[String]): Unit = {
 
     val (config, settings) = loadApplicationConfig { configFile.map(new File(_)) }
+
+    // This option is used in logback.xml by default
+    if (Option(System.getProperty("waves.dex.root-directory")).isEmpty)
+      System.setProperty("waves.dex.root-directory", config.getString("waves.dex.root-directory"))
+
     val log                = LoggerFacade(LoggerFactory getLogger getClass)
 
     log.info("Starting...")

--- a/dex/src/package/debian/postinst
+++ b/dex/src/package/debian/postinst
@@ -2,11 +2,11 @@ ${{header}}
 ${{loader-functions}}
 ${{detect-loader}}
 
-config_dir=/etc/${{app_name}}
+install_dir=/usr/share/${{app_name}}
+
+config_dir=$install_dir/conf
 config_file=$config_dir/main.conf
 logback_file=$config_dir/logback.xml
-
-install_dir=/usr/share/${{app_name}}
 
 if [ "$1" = configure ]; then
     # make sure the user exists

--- a/dex/src/package/doc/logback.xml
+++ b/dex/src/package/doc/logback.xml
@@ -13,7 +13,7 @@
     <property name="logback.file.enabled" value="${logback.file.enabled:-false}"/>
     <property name="logback.file.pattern" value="${logback.file.pattern:-${logback.common.pattern}}"/>
     <property name="logback.file.level" value="${logback.file.level:-DEBUG}"/>
-    <property name="logback.file.directory" value="${logback.file.directory:-${waves.directory}/log}"/>
+    <property name="logback.file.directory" value="${logback.file.directory:-${waves.dex.root-directory}/log}"/>
 
     <!-- JRE -->
     <logger name="sun.rmi" level="INFO"/>

--- a/project/RewriteSwaggerConfigPlugin.scala
+++ b/project/RewriteSwaggerConfigPlugin.scala
@@ -54,7 +54,13 @@ const ui = SwaggerUIBundle({
   layout: "StandaloneLayout",
   operationsSorter: "alpha"
 });
-window.ui = ui;"""
+window.ui = ui;
+
+/* Select HTTPS if you are on HTTPS. "Тот, кто использовал Swagger UI, в цирке не смеется" */
+if ("https" === window.location.protocol.replace(":", "")) {
+  document.querySelector('option[value="https"]').selected = true;
+}
+"""
                   // Careful! ^ will be inserted as one-liner
                   el.text(update)
               }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.4
+sbt.version=1.3.8

--- a/waves-ext/build.sbt
+++ b/waves-ext/build.sbt
@@ -79,9 +79,11 @@ inConfig(Universal)(
 )
 
 // DEB package
-Linux / name := s"waves-dex-extension${network.value.packageSuffix}" // A staging directory name
-Linux / normalizedName := (Linux / name).value // An archive file name
-Linux / packageName := (Linux / name).value    // In a control file
+inConfig(Linux)(Seq(
+  name := s"waves-dex-extension${network.value.packageSuffix}", // A staging directory name
+  normalizedName := name.value, // An archive file name
+  packageName := name.value // In a control file
+))
 
 Debian / debianPackageConflicts := Seq(
   "grpc-server",

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/domain/asset/Asset.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/domain/asset/Asset.scala
@@ -40,7 +40,7 @@ object Asset {
     case _              => JsError("Expected base58-encoded assetId or null")
   }
   implicit val assetIdWrites: Writes[Asset] = Writes {
-    case Waves           => JsNull
+    case Waves           => JsString(WavesName)
     case IssuedAsset(id) => JsString(id.base58)
   }
 

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/domain/asset/Asset.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/domain/asset/Asset.scala
@@ -35,7 +35,7 @@ object Asset {
   }
 
   implicit val assetIdReads: Reads[Asset] = Reads {
-    case json: JsString => assetReads.reads(json)
+    case json: JsString => if (json.value == WavesName) JsSuccess(Waves) else assetReads.reads(json)
     case JsNull         => JsSuccess(Waves)
     case _              => JsError("Expected base58-encoded assetId or null")
   }


### PR DESCRIPTION
* Application: sets waves.dex.root-directory from the config, if it wasn't set up;
* RewriteSwaggerConfigPlugin: selects HTTPS if we on the HTTPS page;
* logback.xml: waves.directory is not used, replaced by waves.dex.root-directory instead;
* application.conf: changed the default loglevel;
* null instead of WAVES in /matcher/settings;
* Added default memory limits;