### PR TITLE
DEX-606 Graceful stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,8 @@ waves.dex.rest-api.api-key-hash = "7L6GpLHhA5KyJTAVc8WFHwEcyTY8fC8rRbyMCiFnM4i"
 5. IDE can't find Waves Node's classes in `waves-ext`. Download required artifacts manually: `sbt waves-ext/downloadWavesNodeArtifacts` and 
    then reload SBT configuration in IDE.
 
+6. If you want to run integration tests with Kafka, run the command in sbt before: `set `dex-it`/Test/envVars := Map("KAFKA_SERVER" -> "kafka-host:9092")`
+
 ## 10. Production recommendations
 
 ### Kafka's queue

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/docker/BaseContainer.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/docker/BaseContainer.scala
@@ -6,7 +6,7 @@ import java.nio.file._
 
 import cats.Id
 import com.dimafeng.testcontainers.GenericContainer
-import com.github.dockerjava.api.exception.NotFoundException
+import com.github.dockerjava.api.exception.{NotFoundException, NotModifiedException}
 import com.github.dockerjava.api.model.{ContainerNetwork, ExposedPort, Ports}
 import com.github.dockerjava.core.command.ExecStartResultCallback
 import com.typesafe.config.Config
@@ -96,15 +96,20 @@ abstract class BaseContainer(protected val baseContainerPath: String, private va
     printState()
     log.debug(s"$prefix Stopping...")
 
-    dockerClient.stopContainerCmd(underlying.containerId).withTimeout(20).exec()
-    Iterator
-      .continually {
-        Thread.sleep(1000)
-        dockerClient.inspectContainerCmd(underlying.containerId).exec().getState
-      }
-      .zipWithIndex
-      .find { case (state, attempt) => !state.getRunning || attempt == 20 }
-      .fold(log.warn(s"Can't stop ${underlying.containerId}"))(_ => ())
+    try {
+      dockerClient.stopContainerCmd(underlying.containerId).withTimeout(20).exec()
+      Iterator
+        .continually {
+          Thread.sleep(1000)
+          dockerClient.inspectContainerCmd(underlying.containerId).exec().getState
+        }
+        .zipWithIndex
+        .find { case (state, attempt) => !state.getRunning || attempt == 20 }
+        .fold(log.warn(s"Can't stop ${underlying.containerId}"))(_ => ())
+    } catch {
+      case e: NotModifiedException => log.warn(s"$prefix Can't stop", e)
+      case e: Throwable            => throw e
+    }
   }
 
   private def sendStartCmd(): Unit = dockerClient.startContainerCmd(underlying.containerId).exec()

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/test/InformativeTestStart.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/test/InformativeTestStart.scala
@@ -15,7 +15,7 @@ trait InformativeTestStart extends Suite { self: BaseContainersKit =>
     def print(text: String): Unit = {
       val formatted = s"---------- [${LocalDateTime.now(ZoneId.of("UTC"))}] $text ----------"
       log.debug(formatted)
-      knownContainers.forEach { _.printDebugMessage(formatted) }
+      knownContainers.get().foreach { _.printDebugMessage(formatted) }
     }
 
     print(s"Test '$testName' started")

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/networking/DexClientFaultToleranceTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/networking/DexClientFaultToleranceTestSuite.scala
@@ -102,7 +102,6 @@ class DexClientFaultToleranceTestSuite extends MatcherSuiteBase with HasToxiProx
 
     markup(s"Stop node 2 and perform USD transfer from Bob to Alice")
     wavesNode2.stopWithoutRemove()
-    forgetContainer(wavesNode2)
 
     broadcastAndAwait(wavesNode1.api, bob2AliceTransferTx)
     usdBalancesShouldBe(wavesNode1.api, defaultAssetQuantity, 0)

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/networking/DexClientFaultToleranceTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/networking/DexClientFaultToleranceTestSuite.scala
@@ -78,6 +78,7 @@ class DexClientFaultToleranceTestSuite extends MatcherSuiteBase with HasToxiProx
     wavesNode2.api.connect(wavesNode1.networkAddress)
     wavesNode2.api.waitForConnectedPeer(wavesNode1.networkAddress)
 
+    wavesNode2.api.waitForHeight(wavesNode1.api.currentHeight)
     wavesNode2.api.waitForTransaction(IssueUsdTx)
 
     markup(s"Stop node 1 and perform USD transfer from Alice to Bob")

--- a/dex/src/main/scala/com/wavesplatform/dex/AddressActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/AddressActor.scala
@@ -377,7 +377,7 @@ class AddressActor(owner: Address,
       }
       .onComplete {
         case Success(Some(error)) => self ! Event.StoreFailed(orderId, error)
-        case Success(None)        => log.trace(s"Order $orderId saved")
+        case Success(None)        => log.trace(s"$event saved")
         case _                    => throw new IllegalStateException("Impossibru")
       }
 

--- a/dex/src/main/scala/com/wavesplatform/dex/Matcher.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/Matcher.scala
@@ -340,6 +340,10 @@ class Matcher(settings: MatcherSettings)(implicit val actorSystem: ActorSystem) 
         Option(matcherServerBinding).fold[Future[HttpTerminated]](Future.successful(HttpServerTerminated))(_.terminate(1.second))
       }
       _ <- {
+        log.info("Shutting down actors...")
+        gracefulStop(matcherActor, 3.seconds, MatcherActor.Shutdown)
+      }
+      _ <- {
         log.info("Shutting down gRPC client...")
         wavesBlockchainAsyncClient.close()
       }
@@ -350,10 +354,6 @@ class Matcher(settings: MatcherSettings)(implicit val actorSystem: ActorSystem) 
       _ <- {
         log.info("Shutting down caches...")
         Future.successful(orderBooksSnapshotCache.close())
-      }
-      _ <- {
-        log.info("Shutting down actors...")
-        gracefulStop(matcherActor, 3.seconds, MatcherActor.Shutdown)
       }
       _ <- {
         log.info("Shutting down materializer...")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -44,10 +44,9 @@ object Dependencies {
 
     val sttp = "1.7.2"
 
-    val testContainers         = "0.34.3"
-    val testContainersPostgres = "1.12.4"
-
-    val toxiProxy = "1.12.4"
+    val testContainers          = "0.35.2"
+    val testContainersPostgres  = "1.12.5"
+    val testContainersToxiProxy = "1.12.5"
 
     val jackson  = "2.10.0"
     val playJson = "2.8.1"
@@ -108,7 +107,7 @@ object Dependencies {
     ExclusionRule(organization = "io.grpc"),
     ExclusionRule("com.wavesplatform", "protobuf-schemas")
   )
-  private val toxiProxy     = "org.testcontainers" % "toxiproxy" % Version.toxiProxy
+  private val toxiProxy     = "org.testcontainers" % "toxiproxy" % Version.testContainersToxiProxy
   private val googleGuava   = "com.google.guava" % "guava" % Version.googleGuava
   private val kafka         = "org.apache.kafka" % "kafka-clients" % Version.kafka
   private val grpcNetty     = "io.grpc" % "grpc-netty" % scalapb.compiler.Version.grpcJavaVersion

--- a/waves-ext/src/main/resources/application.conf
+++ b/waves-ext/src/main/resources/application.conf
@@ -12,3 +12,9 @@ waves.dex {
     balance-changes-batch-linger = 300ms
   }
 }
+
+akka.actor.waves-dex-grpc-scheduler {
+  type = "Dispatcher"
+  thread-pool-executor.fixed-pool-size = 4
+  throughput = 10
+}

--- a/waves-ext/src/main/resources/application.conf
+++ b/waves-ext/src/main/resources/application.conf
@@ -15,6 +15,7 @@ waves.dex {
 
 akka.actor.waves-dex-grpc-scheduler {
   type = "Dispatcher"
-  thread-pool-executor.fixed-pool-size = 4
+  executor = "thread-pool-executor"
+  thread-pool-executor.fixed-pool-size = 8
   throughput = 10
 }

--- a/waves-ext/src/main/scala/com/wavesplatform/dex/grpc/integration/DEXExtension.scala
+++ b/waves-ext/src/main/scala/com/wavesplatform/dex/grpc/integration/DEXExtension.scala
@@ -46,10 +46,9 @@ class DEXExtension(context: ExtensionContext) extends Extension with ScorexLoggi
     log.info("Shutting down gRPC DEX extension")
     if (server != null) {
       apiService.close()
-      server.shutdown()
+      server.shutdownNow()
     }
 
-    server.awaitTermination(10, TimeUnit.SECONDS) // TODO
     Future.successful(())
   }
 }

--- a/waves-ext/src/main/scala/com/wavesplatform/dex/grpc/integration/services/WavesBlockchainApiGrpcService.scala
+++ b/waves-ext/src/main/scala/com/wavesplatform/dex/grpc/integration/services/WavesBlockchainApiGrpcService.scala
@@ -50,11 +50,13 @@ class WavesBlockchainApiGrpcService(context: ExtensionContext, balanceChangesBat
       .map(BalanceChangesResponse.apply)
       .doOnSubscriptionCancel(Task {
         // https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
+        log.info("==> onCancel")
         val shutdownError = new StatusRuntimeException(Status.UNAVAILABLE) // Because it should try to connect to other DEX Extension
-        balanceChangesSubscribers.forEach(_.onError(shutdownError))
+//        balanceChangesSubscribers.forEach(_.onError(shutdownError))
         balanceChangesSubscribers.clear()
       })
       .doOnComplete(Task {
+        log.info("==> onCompleted")
         // For consistency
         balanceChangesSubscribers.forEach(_.onCompleted())
         balanceChangesSubscribers.clear()

--- a/waves-ext/src/main/scala/com/wavesplatform/dex/grpc/integration/services/WavesBlockchainApiGrpcService.scala
+++ b/waves-ext/src/main/scala/com/wavesplatform/dex/grpc/integration/services/WavesBlockchainApiGrpcService.scala
@@ -49,7 +49,8 @@ class WavesBlockchainApiGrpcService(context: ExtensionContext, balanceChangesBat
       .filter(_.nonEmpty)
       .map(BalanceChangesResponse.apply)
       .doOnSubscriptionCancel(Task {
-        val shutdownError = new StatusRuntimeException(Status.ABORTED)
+        // https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
+        val shutdownError = new StatusRuntimeException(Status.UNAVAILABLE) // Because it should try to connect to other DEX Extension
         balanceChangesSubscribers.forEach(_.onError(shutdownError))
         balanceChangesSubscribers.clear()
       })

--- a/waves-ext/src/main/scala/com/wavesplatform/dex/grpc/integration/services/WavesBlockchainApiGrpcService.scala
+++ b/waves-ext/src/main/scala/com/wavesplatform/dex/grpc/integration/services/WavesBlockchainApiGrpcService.scala
@@ -186,5 +186,5 @@ class WavesBlockchainApiGrpcService(context: ExtensionContext, balanceChangesBat
     NodeAddressResponse(InetAddress.getLocalHost.getHostAddress)
   }
 
-  override def close(): Unit = balanceChanges().cancel()
+  override def close(): Unit = balanceChanges.foreachL(_.cancel())
 }

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/WavesBlockchainGrpcAsyncClient.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/WavesBlockchainGrpcAsyncClient.scala
@@ -87,7 +87,7 @@ class WavesBlockchainGrpcAsyncClient(eventLoopGroup: EventLoopGroup, channel: Ma
   }
 
   /** Performs new gRPC call for receiving of the spendable balance changes stream */
-  private def requestBalanceChanges(): Unit = blockchainService.getBalanceChanges(Empty(), balanceChangesObserver)
+  private def requestBalanceChanges(): Unit = blockchainService.getBalanceChanges(Empty(), balanceChangesObserver) // TODO
 
   private def parse(input: RunScriptResponse): RunScriptResult = input.result match {
     case Result.WrongInput(message)   => throw new IllegalArgumentException(message)
@@ -153,7 +153,9 @@ class WavesBlockchainGrpcAsyncClient(eventLoopGroup: EventLoopGroup, channel: Ma
   }
 
   override def close(): Future[Unit] = {
-    channel.shutdownNow()
+    balanceChangesObserver.onCompleted() // TODO
+    channel.shutdown()
+    channel.awaitTermination(10, TimeUnit.SECONDS)
     // See NettyChannelBuilder.eventLoopGroup
     eventLoopGroup.shutdownGracefully(0, 500, TimeUnit.MILLISECONDS).asScala.map(_ => ())
   }

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/WavesBlockchainGrpcAsyncClient.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/grpc/integration/clients/WavesBlockchainGrpcAsyncClient.scala
@@ -2,6 +2,7 @@ package com.wavesplatform.dex.grpc.integration.clients
 
 import java.net.InetAddress
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 import com.google.protobuf.ByteString
 import com.google.protobuf.empty.Empty
@@ -19,11 +20,10 @@ import com.wavesplatform.dex.grpc.integration.protobuf.DexToPbConversions._
 import com.wavesplatform.dex.grpc.integration.protobuf.PbToDexConversions._
 import com.wavesplatform.dex.grpc.integration.services.RunScriptResponse.Result
 import com.wavesplatform.dex.grpc.integration.services._
-import io.grpc.ManagedChannel
-import io.grpc.stub.StreamObserver
+import io.grpc.stub.{ClientCallStreamObserver, ClientResponseObserver}
+import io.grpc.{ManagedChannel, Status, StatusRuntimeException}
 import io.netty.channel.EventLoopGroup
 import monix.execution.Scheduler
-import monix.execution.atomic.AtomicBoolean
 import monix.reactive.Observable
 import monix.reactive.subjects.ConcurrentSubject
 
@@ -45,6 +45,7 @@ class WavesBlockchainGrpcAsyncClient(eventLoopGroup: EventLoopGroup, channel: Ma
 
   private def handlingErrors[A](f: => Future[A]): Future[A] = { f transform (identity, gRPCErrorsHandler) }
 
+  private val shuttingDown      = new AtomicBoolean(false)
   private val blockchainService = WavesBlockchainApiGrpc.stub(channel)
 
   private val spendableBalanceChangesSubject = ConcurrentSubject.publish[SpendableBalanceChanges](monixScheduler)
@@ -64,30 +65,10 @@ class WavesBlockchainGrpcAsyncClient(eventLoopGroup: EventLoopGroup, channel: Ma
       .mapValues { _.map { case (_, asset, balance) => asset -> balance }.toMap.withDefaultValue(0) }
   }
 
-  private val isConnectionEstablished: AtomicBoolean = AtomicBoolean(true)
-
-  private val balanceChangesObserver: StreamObserver[BalanceChangesResponse] = new StreamObserver[BalanceChangesResponse] {
-
-    override def onCompleted(): Unit = log.info("Balance changes stream completed!")
-
-    override def onNext(value: BalanceChangesResponse): Unit = {
-      if (isConnectionEstablished.compareAndSet(false, true)) {
-        blockchainService.getNodeAddress { Empty() } foreach { response =>
-          log.info(s"gRPC connection restored! DEX server now is connected to Node with an address: ${response.address}")
-        }
-      }
-      spendableBalanceChangesSubject.onNext(groupByAddress(value))
-    }
-
-    override def onError(t: Throwable): Unit = {
-      if (isConnectionEstablished.compareAndSet(true, false)) log.error("Connection with Node lost!", t)
-      channel.resetConnectBackoff()
-      requestBalanceChanges()
-    }
-  }
+  private val balanceChangesObserver = new BalanceChangesObserver
 
   /** Performs new gRPC call for receiving of the spendable balance changes stream */
-  private def requestBalanceChanges(): Unit = blockchainService.getBalanceChanges(Empty(), balanceChangesObserver) // TODO
+  private def requestBalanceChanges(): Unit = blockchainService.getBalanceChanges(Empty(), balanceChangesObserver) // TODO ClientResponseObserver
 
   private def parse(input: RunScriptResponse): RunScriptResult = input.result match {
     case Result.WrongInput(message)   => throw new IllegalArgumentException(message)
@@ -153,7 +134,8 @@ class WavesBlockchainGrpcAsyncClient(eventLoopGroup: EventLoopGroup, channel: Ma
   }
 
   override def close(): Future[Unit] = {
-    balanceChangesObserver.onCompleted() // TODO
+    shuttingDown.set(true)
+    balanceChangesObserver.close()
     channel.shutdown()
     channel.awaitTermination(10, TimeUnit.SECONDS)
     // See NettyChannelBuilder.eventLoopGroup
@@ -164,5 +146,32 @@ class WavesBlockchainGrpcAsyncClient(eventLoopGroup: EventLoopGroup, channel: Ma
     blockchainService.getNodeAddress { Empty() } map { r =>
       InetAddress.getByName(r.address)
     }
+  }
+
+  private final class BalanceChangesObserver extends ClientResponseObserver[Empty, BalanceChangesResponse] with AutoCloseable {
+
+    private val isConnectionEstablished: AtomicBoolean         = new AtomicBoolean(true)
+    private var requestStream: ClientCallStreamObserver[Empty] = _
+
+    override def onCompleted(): Unit = log.info("Balance changes stream completed!")
+
+    override def onNext(value: BalanceChangesResponse): Unit = {
+      if (isConnectionEstablished.compareAndSet(false, true)) {
+        blockchainService.getNodeAddress { Empty() } foreach { response =>
+          log.info(s"gRPC connection restored! DEX server now is connected to Node with an address: ${response.address}")
+        }
+      }
+      spendableBalanceChangesSubject.onNext(groupByAddress(value))
+    }
+
+    override def onError(e: Throwable): Unit = if (!shuttingDown.get()) {
+      if (isConnectionEstablished.compareAndSet(true, false)) log.error("Connection with Node lost!", e)
+      channel.resetConnectBackoff()
+      requestBalanceChanges()
+    }
+
+    override def close(): Unit = if (requestStream != null) requestStream.cancel("Shutting down", new StatusRuntimeException(Status.ABORTED))
+
+    override def beforeStart(requestStream: ClientCallStreamObserver[Empty]): Unit = this.requestStream = requestStream
   }
 }


### PR DESCRIPTION
* Better error handling and stop procedure for gRPC;
* Fixed the shutdown including Kafka errors;
* A separate thread pool for gRPC service on DEX extension;

Integration tests:
* Containers in tests are shut down in a reversed to initialization order;
* Fixed NotModifiedException if a container already stopped;