### PR TITLE
DEX-643 Max active orders

### DIFF
--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/dex/DexApi.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/dex/DexApi.scala
@@ -53,10 +53,21 @@ trait DexApi[F[_]] extends HasWaitReady[F] {
 
   def tryTransactionsByOrder(id: Order.Id): F[Either[MatcherError, List[ExchangeTransaction]]]
 
+  /**
+   * param @activeOnly Server treats this parameter as false if it wasn't specified
+   */
   def tryOrderHistory(owner: KeyPair,
                       activeOnly: Option[Boolean] = None,
                       timestamp: Long = System.currentTimeMillis): F[Either[MatcherError, List[OrderBookHistoryItem]]]
+
+  /**
+   * param @activeOnly Server treats this parameter as true if it wasn't specified
+   */
   def tryOrderHistoryWithApiKey(owner: Address, activeOnly: Option[Boolean] = None): F[Either[MatcherError, List[OrderBookHistoryItem]]]
+
+  /**
+   * param @activeOnly Server treats this parameter as false if it wasn't specified
+   */
   def tryOrderHistoryByPair(owner: KeyPair,
                             assetPair: AssetPair,
                             activeOnly: Option[Boolean] = None,

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/MatcherTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/MatcherTestSuite.scala
@@ -356,7 +356,7 @@ class MatcherTestSuite extends MatcherSuiteBase with TableDrivenPropertyChecks {
 
     def mkAliceOrder(i: Int, tpe: OrderType) = mkOrder(alice, pair, tpe, 100L + i, Order.PriceConstant)
 
-    val orders = (1 to (OrderDB.OldestOrderIndexOffset + 5)).flatMap { i =>
+    val orders = (1 to (OrderDB.maxOrders + 5)).flatMap { i =>
       List(
         mkAliceOrder(i, OrderType.BUY),
         mkAliceOrder(i, OrderType.SELL)

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/MatcherTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/MatcherTestSuite.scala
@@ -1,6 +1,7 @@
 package com.wavesplatform.it.sync
 
 import com.softwaremill.sttp._
+import com.typesafe.config.{Config, ConfigFactory}
 import com.wavesplatform.dex.db.OrderDB
 import com.wavesplatform.dex.domain.asset.Asset.Waves
 import com.wavesplatform.dex.domain.asset.AssetPair
@@ -31,6 +32,14 @@ class MatcherTestSuite extends MatcherSuiteBase with TableDrivenPropertyChecks {
   private val bob2WavesPair                                 = AssetPair(bobAsset2, Waves)
 
   private val order1 = mkOrder(alice, aliceWavesPair, SELL, aliceSellAmount, 2000.waves, ttl = 10.minutes) // TTL?
+
+  private val maxOrders = 99
+
+  override protected def dexInitialSuiteConfig: Config = ConfigFactory.parseString(
+    s"""waves.dex {
+       |  order-db.max-orders = $maxOrders
+       |}""".stripMargin
+  )
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
@@ -356,7 +365,7 @@ class MatcherTestSuite extends MatcherSuiteBase with TableDrivenPropertyChecks {
 
     def mkAliceOrder(i: Int, tpe: OrderType) = mkOrder(alice, pair, tpe, 100L + i, Order.PriceConstant)
 
-    val orders = (1 to (OrderDB.maxOrders + 5)).flatMap { i =>
+    val orders = (1 to (maxOrders + 5)).flatMap { i =>
       List(
         mkAliceOrder(i, OrderType.BUY),
         mkAliceOrder(i, OrderType.SELL)

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/MatcherTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/MatcherTestSuite.scala
@@ -2,7 +2,6 @@ package com.wavesplatform.it.sync
 
 import com.softwaremill.sttp._
 import com.typesafe.config.{Config, ConfigFactory}
-import com.wavesplatform.dex.db.OrderDB
 import com.wavesplatform.dex.domain.asset.Asset.Waves
 import com.wavesplatform.dex.domain.asset.AssetPair
 import com.wavesplatform.dex.domain.order.OrderType._

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/RestOrderLimitTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/RestOrderLimitTestSuite.scala
@@ -12,17 +12,25 @@ import com.wavesplatform.it.MatcherSuiteBase
 
 class RestOrderLimitTestSuite extends MatcherSuiteBase {
 
-  override protected val dexInitialSuiteConfig: Config = ConfigFactory.parseString("waves.dex.rest-order-limit = 8".stripMargin)
+  private val maxActiveOrders    = 50
+  private val maxFinalizedOrders = 3
+
+  override protected val dexInitialSuiteConfig: Config = ConfigFactory.parseString(
+    s"""waves.dex {
+       |  max-active-orders = $maxActiveOrders
+       |  order-db.max-orders = $maxFinalizedOrders
+       |}""".stripMargin
+  )
 
   private def activeOrders: List[Order.Id] = {
     val activeOrders = dex1.api.orderHistory(alice, activeOnly = Some(true)).map(_.id)
-    dex1.api.orderHistoryWithApiKey(alice, activeOnly = Some(true)).map(_.id) should equal(activeOrders)
+    dex1.api.orderHistoryWithApiKey(alice, activeOnly = Some(true)).map(_.id) should matchTo(activeOrders)
     activeOrders
   }
 
   private def allOrders: List[Order.Id] = {
     val allOrders = dex1.api.orderHistory(alice).map(_.id)
-    dex1.api.orderHistoryWithApiKey(alice, activeOnly = Some(false)).map(_.id) should equal(allOrders)
+    dex1.api.orderHistoryWithApiKey(alice, activeOnly = Some(false)).map(_.id) should matchTo(allOrders)
     allOrders
   }
 
@@ -70,15 +78,15 @@ class RestOrderLimitTestSuite extends MatcherSuiteBase {
     dex1.api.cancel(alice, cancelled2)
     dex1.api.waitForOrderStatus(cancelled2, OrderStatus.Cancelled)
 
-    val activeOrdersAllFive       = Seq(partial2, active2, partial1, active1, active0).map(_.id())
+    val activeOrdersAllFive       = List(partial2, active2, partial1, active1, active0).map(_.id())
     val allOrdersExceptTheFilled1 = activeOrdersAllFive ++ Seq(cancelled2, filled2, cancelled1).map(_.id())
-    val activeOrdersByPair        = Seq(partial1, active1, active0).map(_.id())
+    val activeOrdersByPair        = List(partial1, active1, active0).map(_.id())
     val allOrdersByPair           = activeOrdersByPair ++ Seq(cancelled1, filled1).map(_.id())
 
-    activeOrders should equal(activeOrdersAllFive)
-    allOrders should equal(allOrdersExceptTheFilled1)
-    activeOrdersBy(alicePair) should equal(activeOrdersByPair)
-    allOrdersBy(alicePair) should equal(allOrdersByPair)
+    activeOrders should matchTo(activeOrdersAllFive)
+    allOrders should matchTo(allOrdersExceptTheFilled1)
+    activeOrdersBy(alicePair) should matchTo(activeOrdersByPair)
+    allOrdersBy(alicePair) should matchTo(allOrdersByPair)
 
     info("'fullOrderHistory' and 'ordersByAddress' must return all active orders, even if they are more than the limit")
 
@@ -90,18 +98,18 @@ class RestOrderLimitTestSuite extends MatcherSuiteBase {
 
     dex1.api.waitForOrderStatus(active6, OrderStatus.Accepted)
 
-    val activeOrdersAllNine          = Seq(active6, active5, active4, active3).map(_.id()) ++ activeOrdersAllFive
-    val activeOrdersByPairWithTwoNew = Seq(active4, active3).map(_.id()) ++ activeOrdersByPair
-    val allOrdersByPairWithTwoNew    = Seq(active4, active3).map(_.id()) ++ allOrdersByPair
+    val activeOrdersAllNine          = List(active6, active5, active4, active3).map(_.id()) ++ activeOrdersAllFive
+    val activeOrdersByPairWithTwoNew = List(active4, active3).map(_.id()) ++ activeOrdersByPair
+    val allOrdersByPairWithTwoNew    = List(active4, active3).map(_.id()) ++ allOrdersByPair
 
     {
       val xs = activeOrders
-      xs should equal(allOrders)
-      xs should equal(activeOrdersAllNine)
+      xs should matchTo(allOrders.take(xs.size)) // rest were finalized
+      xs should matchTo(activeOrdersAllNine)
     }
 
-    activeOrdersBy(alicePair) should equal(activeOrdersByPairWithTwoNew)
-    allOrdersBy(alicePair) should equal(allOrdersByPairWithTwoNew)
+    activeOrdersBy(alicePair) should matchTo(activeOrdersByPairWithTwoNew)
+    allOrdersBy(alicePair) should matchTo(allOrdersByPairWithTwoNew)
 
     info("'orderHistoryByPair' must return no more 'rest-order-limit' orders")
 
@@ -113,18 +121,18 @@ class RestOrderLimitTestSuite extends MatcherSuiteBase {
 
     dex1.api.waitForOrderStatus(active10, OrderStatus.Accepted)
 
-    val activeOrdersAllThirteen               = Seq(active10, active9, active8, active7).map(_.id()) ++ activeOrdersAllNine
-    val activeOrdersByPairWithTwoMoreNew      = Seq(active8, active7).map(_.id()) ++ activeOrdersByPairWithTwoNew
-    val allOrdersByPairWithTwoNewExceptOneOld = Seq(active8, active7).map(_.id()) ++ allOrdersByPairWithTwoNew.dropRight(1)
+    val activeOrdersAllThirteen               = List(active10, active9, active8, active7).map(_.id()) ++ activeOrdersAllNine
+    val activeOrdersByPairWithTwoMoreNew      = List(active8, active7).map(_.id()) ++ activeOrdersByPairWithTwoNew
+    val allOrdersByPairWithTwoNewExceptOneOld = List(active8, active7).map(_.id()) ++ allOrdersByPairWithTwoNew
 
     {
       val xs = activeOrders
-      xs should equal(allOrders)
-      xs should equal(activeOrdersAllThirteen)
+      xs should matchTo(allOrders.take(xs.size)) // rest were finalized
+      xs should matchTo(activeOrdersAllThirteen)
     }
 
-    activeOrdersBy(alicePair) should equal(activeOrdersByPairWithTwoMoreNew)
-    allOrdersBy(alicePair) should equal(allOrdersByPairWithTwoNewExceptOneOld)
+    activeOrdersBy(alicePair) should matchTo(activeOrdersByPairWithTwoMoreNew)
+    allOrdersBy(alicePair) should matchTo(allOrdersByPairWithTwoNewExceptOneOld)
 
     info("all the methods move active orders that were filled")
 
@@ -133,19 +141,19 @@ class RestOrderLimitTestSuite extends MatcherSuiteBase {
       mkOrder(bob, bobPair, SELL, 2, 2.waves, ts = now + 22), // fill active2, active5
       mkOrder(bob, alicePair, BUY, 2, 9.waves, ts = now + 23), // fill partial1, active7
       mkOrder(bob, alicePair, BUY, 1, 10.waves, ts = now + 24) // fill active1
-    ).foreach(dex1.api.place)
+    ).foreach(placeAndAwaitAtDex(_, OrderStatus.Filled))
 
-    dex1.api.waitForOrderStatus(active1, OrderStatus.Filled)
+    val activeOrdersAllSeven = List(active10, active9, active8, active6, active4, active3, active0).map(_.id())
 
-    val activeOrdersAllSeven            = Seq(active10, active9, active8, active6, active4, active3, active0).map(_.id())
-    val allOrdersWithOneFilled          = activeOrdersAllSeven ++ Seq(active1).map(_.id())
-    val activeOrdersByPairWithTwoFilled = Seq(active8, active4, active3, active0).map(_.id())
-    val allOrdersByPairWithTwoFilled    = activeOrdersByPairWithTwoFilled ++ Seq(active7, cancelled1, partial1, active1).map(_.id())
+    // Because sorted by timestamp in descending order
+    val allOrdersWithOneFilled          = activeOrdersAllSeven ++ Seq(active7, partial1, active1).map(_.id())
+    val activeOrdersByPairWithTwoFilled = List(active8, active4, active3, active0).map(_.id())
+    val allOrdersByPairWithTwoFilled    = activeOrdersByPairWithTwoFilled ++ Seq(active7, partial1, active1).map(_.id())
 
-    activeOrders should equal(activeOrdersAllSeven)
-    allOrders should equal(allOrdersWithOneFilled)
-    activeOrdersBy(alicePair) should equal(activeOrdersByPairWithTwoFilled)
-    allOrdersBy(alicePair) should equal(allOrdersByPairWithTwoFilled)
+    activeOrders should matchTo(activeOrdersAllSeven)
+    allOrders should matchTo(allOrdersWithOneFilled)
+    activeOrdersBy(alicePair) should matchTo(activeOrdersByPairWithTwoFilled)
+    allOrdersBy(alicePair) should matchTo(allOrdersByPairWithTwoFilled)
 
     info("'orderHistoryByPair' must return all active orders, even if they are more than the limit")
 
@@ -158,16 +166,19 @@ class RestOrderLimitTestSuite extends MatcherSuiteBase {
 
     dex1.api.waitForOrderStatus(active15, OrderStatus.Accepted)
 
-    val activeOrdersAllTwelve     = Seq(active15, active14, active13, active12, active11).map(_.id()) ++ activeOrdersAllSeven
-    val activeOrdersByPairAllNine = Seq(active15, active14, active13, active12, active11).map(_.id()) ++ allOrdersByPairWithTwoFilled.take(4)
+    val activeOrdersAllTwelve     = List(active15, active14, active13, active12, active11).map(_.id()) ++ activeOrdersAllSeven
+    val activeOrdersByPairAllNine = List(active15, active14, active13, active12, active11).map(_.id()) ++ allOrdersByPairWithTwoFilled
 
-    activeOrders should equal(allOrders)
-    activeOrders should equal(activeOrdersAllTwelve)
+    {
+      val xs = activeOrders
+      xs should matchTo(allOrders.take(xs.size))
+      xs should matchTo(activeOrdersAllTwelve.take(xs.size))
+    }
 
     {
       val xs = activeOrdersBy(alicePair)
-      xs should equal(allOrdersBy(alicePair))
-      xs should equal(activeOrdersByPairAllNine)
+      xs should matchTo(allOrdersBy(alicePair).take(xs.size)) // rest were finalized
+      xs should matchTo(activeOrdersByPairAllNine.take(xs.size))
     }
   }
 

--- a/dex/src/main/resources/application.conf
+++ b/dex/src/main/resources/application.conf
@@ -42,6 +42,14 @@ waves.dex {
     api-key-different-host = no
   }
 
+  # Maximum number of active orders
+  max-active-orders = 400
+
+  order-db {
+    # Maximum number of finalized orders in the order db. Older orders are removed
+    max-orders = 100
+  }
+
   # Client to Waves DEX extension
   waves-blockchain-client {
 
@@ -287,9 +295,6 @@ waves.dex {
 
   # Maximum time to process recovered events by order books
   order-books-recovering-timeout = 10m
-
-  # Maximum allowed amount of orders retrieved via REST
-  rest-order-limit = 100
 
   # Base assets used as price assets
   price-assets: []

--- a/dex/src/main/scala/com/wavesplatform/dex/Matcher.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/Matcher.scala
@@ -242,7 +242,7 @@ class Matcher(settings: MatcherSettings)(implicit val actorSystem: ActorSystem) 
   private lazy val db                  = openDB(settings.dataDir)
   private lazy val assetPairsDB        = AssetPairsDB(db)
   private lazy val orderBookSnapshotDB = OrderBookSnapshotDB(db)
-  private lazy val orderDB             = OrderDB(settings, db)
+  private lazy val orderDB             = OrderDB(settings.orderDb, db)
 
   lazy val orderBookSnapshotStore: ActorRef = actorSystem.actorOf(
     OrderBookSnapshotStoreActor.props(orderBookSnapshotDB),
@@ -321,6 +321,7 @@ class Matcher(settings: MatcherSettings)(implicit val actorSystem: ActorSystem) 
                 matcherQueue.storeEvent,
                 orderBookCache.getOrDefault(_, OrderBook.AggregatedSnapshot()),
                 startSchedules,
+                settings.maxActiveOrders,
                 settings.actorResponseTimeout - settings.actorResponseTimeout / 10 // Should be enough
               )
           ),

--- a/dex/src/main/scala/com/wavesplatform/dex/db/OrderDB.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/db/OrderDB.scala
@@ -52,7 +52,7 @@ object OrderDB {
 
           val newPairSeqNr = rw.inc(MatcherKeys.finalizedPairSeqNr(sender, oi.assetPair))
           rw.put(MatcherKeys.finalizedPair(sender, oi.assetPair, newPairSeqNr), Some(id))
-          if (newPairSeqNr > settings.maxOrders) // Indexes start with 1, so if newPairSeqNr=101, we delete 1 (the first)
+          if (newPairSeqNr > settings.maxOrders) // Indexes start with 1, so if maxOrders=100 and newPairSeqNr=101, we delete 1 (the first)
             rw.get(MatcherKeys.finalizedPair(sender, oi.assetPair, newPairSeqNr - settings.maxOrders))
               .map(MatcherKeys.order)
               .foreach(x => rw.delete(x))

--- a/dex/src/main/scala/com/wavesplatform/dex/db/OrderDB.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/db/OrderDB.scala
@@ -9,7 +9,6 @@ import com.wavesplatform.dex.domain.order.Order
 import com.wavesplatform.dex.domain.utils.ScorexLogging
 import com.wavesplatform.dex.model.OrderInfo.FinalOrderInfo
 import com.wavesplatform.dex.model.{OrderInfo, OrderStatus}
-import com.wavesplatform.dex.settings.MatcherSettings
 import org.iq80.leveldb.DB
 
 trait OrderDB {
@@ -18,15 +17,13 @@ trait OrderDB {
   def saveOrderInfo(id: Order.Id, sender: Address, oi: OrderInfo[OrderStatus.Final]): Unit
   def saveOrder(o: Order): Unit
   def get(id: Order.Id): Option[Order]
-  def loadRemainingOrders(owner: Address,
-                          maybePair: Option[AssetPair],
-                          activeOrders: Seq[(Order.Id, OrderInfo[OrderStatus])]): Seq[(Order.Id, OrderInfo[OrderStatus])]
+  def getFinalizedOrders(owner: Address, maybePair: Option[AssetPair]): Seq[(Order.Id, OrderInfo[OrderStatus])]
 }
 
 object OrderDB {
-  val OldestOrderIndexOffset = 100
+  case class Settings(maxOrders: Int)
 
-  def apply(settings: MatcherSettings, db: DB): OrderDB = new OrderDB with ScorexLogging {
+  def apply(settings: Settings, db: DB): OrderDB = new OrderDB with ScorexLogging {
     override def containsInfo(id: Order.Id): Boolean = db.readOnly(_.has(MatcherKeys.orderInfo(id)))
 
     override def status(id: Order.Id): OrderStatus.Final = db.readOnly { ro =>
@@ -52,8 +49,8 @@ object OrderDB {
 
           val newPairSeqNr = rw.inc(MatcherKeys.finalizedPairSeqNr(sender, oi.assetPair))
           rw.put(MatcherKeys.finalizedPair(sender, oi.assetPair, newPairSeqNr), Some(id))
-          if (newPairSeqNr > OldestOrderIndexOffset) // Indexes start with 1, so if newPairSeqNr=101, we delete 1 (the first)
-            rw.get(MatcherKeys.finalizedPair(sender, oi.assetPair, newPairSeqNr - OldestOrderIndexOffset))
+          if (newPairSeqNr > settings.maxOrders) // Indexes start with 1, so if newPairSeqNr=101, we delete 1 (the first)
+            rw.get(MatcherKeys.finalizedPair(sender, oi.assetPair, newPairSeqNr - settings.maxOrders))
               .map(MatcherKeys.order)
               .foreach(x => rw.delete(x))
 
@@ -62,10 +59,8 @@ object OrderDB {
       }
     }
 
-    override def loadRemainingOrders(owner: Address,
-                                     maybePair: Option[AssetPair],
-                                     activeOrders: Seq[(Order.Id, OrderInfo[OrderStatus])]): Seq[(Order.Id, OrderInfo[OrderStatus])] = db.readOnly {
-      ro =>
+    override def getFinalizedOrders(owner: Address, maybePair: Option[AssetPair]): Seq[(Order.Id, OrderInfo[OrderStatus])] =
+      db.readOnly { ro =>
         val (seqNr, key) = maybePair match {
           case Some(p) =>
             (ro.get(MatcherKeys.finalizedPairSeqNr(owner, p)), MatcherKeys.finalizedPair(owner, p, _: Int))
@@ -73,12 +68,12 @@ object OrderDB {
             (ro.get(MatcherKeys.finalizedCommonSeqNr(owner)), MatcherKeys.finalizedCommon(owner, _: Int))
         }
 
-        activeOrders ++ (for {
-          offset <- 0 until (settings.maxOrdersPerRequest - activeOrders.length)
+        (for {
+          offset <- 0 until math.min(seqNr, settings.maxOrders)
           id     <- db.get(key(seqNr - offset))
           oi     <- db.get(MatcherKeys.orderInfo(id))
         } yield id -> oi).sorted
-    }
+      }
   }
 
   implicit def orderInfoOrdering[S <: OrderStatus]: Ordering[(ByteStr, OrderInfo[S])] = Ordering.by { case (id, oi) => (-oi.timestamp, id) }

--- a/dex/src/main/scala/com/wavesplatform/dex/db/OrderDB.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/db/OrderDB.scala
@@ -11,6 +11,9 @@ import com.wavesplatform.dex.model.OrderInfo.FinalOrderInfo
 import com.wavesplatform.dex.model.{OrderInfo, OrderStatus}
 import org.iq80.leveldb.DB
 
+/**
+ * Contains only finalized orders
+ */
 trait OrderDB {
   def containsInfo(id: Order.Id): Boolean
   def status(id: Order.Id): OrderStatus.Final

--- a/dex/src/main/scala/com/wavesplatform/dex/model/OrderValidator.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/OrderValidator.scala
@@ -46,7 +46,6 @@ object OrderValidator extends ScorexLogging {
   private val timer = Kamon.timer("matcher.validation").refine("type" -> "blockchain")
 
   val MinExpiration: Long  = 60 * 1000L
-  val MaxActiveOrders: Int = 200
 
   val exchangeTransactionCreationFee: Long = 30000L
   val ScriptExtraFee                       = 400000L

--- a/dex/src/test/scala/com/wavesplatform/dex/AddressActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/AddressActorSpecification.scala
@@ -229,7 +229,8 @@ class AddressActorSpecification
               Future.successful { Some(QueueEventWithMeta(0, 0, event)) }
             },
             _ => OrderBook.AggregatedSnapshot(),
-            false
+            false,
+            100
           )
         )
       )

--- a/dex/src/test/scala/com/wavesplatform/dex/db/EmptyOrderDB.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/db/EmptyOrderDB.scala
@@ -12,8 +12,6 @@ object EmptyOrderDB extends OrderDB {
   override def get(id: Order.Id): Option[Order]                                                     = None
   override def saveOrderInfo(id: Order.Id, sender: Address, oi: OrderInfo[OrderStatus.Final]): Unit = {}
   override def saveOrder(o: Order): Unit                                                            = {}
-  override def loadRemainingOrders(owner: Address,
-                                   maybePair: Option[AssetPair],
-                                   activeOrders: Seq[(Order.Id, OrderInfo[OrderStatus])]): Seq[(Order.Id, OrderInfo[OrderStatus])] =
+  override def getFinalizedOrders(owner: Address, maybePair: Option[AssetPair]): Seq[(Order.Id, OrderInfo[OrderStatus])] =
     Seq.empty
 }

--- a/dex/src/test/scala/com/wavesplatform/dex/db/TestOrderDB.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/db/TestOrderDB.scala
@@ -26,13 +26,10 @@ class TestOrderDB(maxOrdersPerRequest: Int) extends OrderDB {
 
   override def saveOrder(o: Order): Unit = knownOrders += o.id() -> o
 
-  override def loadRemainingOrders(owner: Address,
-                                   maybePair: Option[AssetPair],
-                                   activeOrders: Seq[(Order.Id, OrderInfo[OrderStatus])]): Seq[(Order.Id, OrderInfo[OrderStatus])] =
-    activeOrders ++ (for {
+  override def getFinalizedOrders(owner: Address, maybePair: Option[AssetPair]): Seq[(Order.Id, OrderInfo[OrderStatus])] =
+    (for {
       id   <- maybePair.fold(idsForAddress(owner))(p => idsForPair(owner -> p))
       info <- orderInfo.get(id)
     } yield id -> info)
       .sortBy { case (_, oi) => -oi.timestamp }
-      .take(maxOrdersPerRequest - activeOrders.length)
 }

--- a/dex/src/test/scala/com/wavesplatform/dex/db/TestOrderDB.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/db/TestOrderDB.scala
@@ -5,7 +5,7 @@ import com.wavesplatform.dex.domain.asset.AssetPair
 import com.wavesplatform.dex.domain.order.Order
 import com.wavesplatform.dex.model.{OrderInfo, OrderStatus}
 
-class TestOrderDB(maxOrdersPerRequest: Int) extends OrderDB {
+class TestOrderDB(maxFinalizedOrders: Int) extends OrderDB {
 
   private var knownOrders   = Map.empty[Order.Id, Order]
   private var orderInfo     = Map.empty[Order.Id, OrderInfo[OrderStatus.Final]]
@@ -20,8 +20,8 @@ class TestOrderDB(maxOrdersPerRequest: Int) extends OrderDB {
 
   override def saveOrderInfo(id: Order.Id, sender: Address, oi: OrderInfo[OrderStatus.Final]): Unit = if (!containsInfo(id)) {
     orderInfo += id                      -> oi
-    idsForAddress += sender              -> (id +: idsForAddress(sender))
-    idsForPair += (sender, oi.assetPair) -> (id +: idsForPair(sender -> oi.assetPair))
+    idsForAddress += sender              -> (id +: idsForAddress(sender)).take(maxFinalizedOrders)
+    idsForPair += (sender, oi.assetPair) -> (id +: idsForPair(sender -> oi.assetPair)).take(maxFinalizedOrders)
   }
 
   override def saveOrder(o: Order): Unit = knownOrders += o.id() -> o

--- a/dex/src/test/scala/com/wavesplatform/dex/matching/ReservedBalanceSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/matching/ReservedBalanceSpecification.scala
@@ -112,7 +112,8 @@ class ReservedBalanceSpecification
               _ => Future.successful(false),
               _ => Future.failed(new IllegalStateException("Should not be used in the test")),
               orderBookCache = _ => AggregatedSnapshot(),
-              enableSchedules
+              enableSchedules,
+              100
             )
         ),
         None
@@ -500,7 +501,8 @@ class ReservedBalanceSpecification
                   Future.successful { Some(QueueEventWithMeta(0, System.currentTimeMillis, event)) }
                 },
                 orderBookCache = orderBookCache,
-                enableSchedules
+                enableSchedules,
+                100
               )
           ),
           None

--- a/dex/src/test/scala/com/wavesplatform/dex/matching/ReservedBalanceSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/matching/ReservedBalanceSpecification.scala
@@ -94,7 +94,9 @@ class ReservedBalanceSpecification
   private val ignoreSpendableBalanceChanges: Subject[SpendableBalanceChanges, SpendableBalanceChanges] = Subject.empty[SpendableBalanceChanges]
 
   private val pair: AssetPair      = AssetPair(mkAssetId("WAVES"), mkAssetId("USD"))
-  private var oh: OrderHistoryStub = new OrderHistoryStub(system, ntpTime)
+
+  private def mkOrderHistory = new OrderHistoryStub(system, ntpTime, 100, 70)
+  private var oh: OrderHistoryStub = mkOrderHistory
 
   private val addressDir = system.actorOf(
     Props(
@@ -147,7 +149,7 @@ class ReservedBalanceSpecification
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    oh = new OrderHistoryStub(system, ntpTime)
+    oh = mkOrderHistory
   }
 
   forAll(

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderHistoryBalanceSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderHistoryBalanceSpecification.scala
@@ -10,6 +10,7 @@ import com.wavesplatform.dex.domain.asset.{Asset, AssetPair}
 import com.wavesplatform.dex.domain.bytes.ByteStr
 import com.wavesplatform.dex.domain.order.Order
 import com.wavesplatform.dex.model.Events.{OrderAdded, OrderCanceled, OrderExecuted}
+import com.wavesplatform.dex.test.matchers.DiffMatcherWithImplicits
 import com.wavesplatform.dex.time.NTPTime
 import com.wavesplatform.dex.{AddressActor, MatcherSpecBase}
 import org.scalatest._
@@ -26,6 +27,7 @@ class OrderHistoryBalanceSpecification
     with Matchers
     with MatcherSpecBase
     with BeforeAndAfterEach
+    with DiffMatcherWithImplicits
     with NTPTime {
 
   import OrderHistoryBalanceSpecification._
@@ -33,19 +35,20 @@ class OrderHistoryBalanceSpecification
   private val WctBtc   = AssetPair(mkAssetId("WCT"), mkAssetId("BTC"))
   private val WavesBtc = AssetPair(Waves, mkAssetId("BTC"))
 
-  private var oh = new OrderHistoryStub(system, ntpTime)
+  private def mkOrderHistory = new OrderHistoryStub(system, ntpTime, MaxActiveOrders, MaxFinalizedOrders)
+  private var oh             = mkOrderHistory
   override def beforeEach(): Unit = {
     super.beforeEach()
-    oh = new OrderHistoryStub(system, ntpTime)
+    oh = mkOrderHistory
   }
 
   def openVolume(address: Address, asset: Asset): Long = oh.ref(address).openVolume(asset)
 
-  def activeOrderIds(sender: Address): Seq[ByteStr]                        = oh.ref(sender).activeOrderIds
-  def allOrderIds(sender: Address): Seq[ByteStr]                           = oh.ref(sender).allOrderIds
-  def activeOrderIdsByPair(sender: Address, pair: AssetPair): Seq[ByteStr] = oh.ref(sender).activeOrderIdsByPair(pair)
-  def allOrderIdsByPair(sender: Address, pair: AssetPair): Seq[ByteStr]    = oh.ref(sender).allOrderIdsByPair(pair)
-  def orderStatus(orderId: ByteStr)                                        = oh.ref(orderId).orderStatus(orderId)
+  def activeOrderIds(sender: Address)                        = oh.ref(sender).activeOrderIds
+  def allOrderIds(sender: Address)                           = oh.ref(sender).allOrderIds
+  def activeOrderIdsByPair(sender: Address, pair: AssetPair) = oh.ref(sender).activeOrderIdsByPair(pair)
+  def allOrderIdsByPair(sender: Address, pair: AssetPair)    = oh.ref(sender).allOrderIdsByPair(pair)
+  def orderStatus(orderId: ByteStr)                          = oh.ref(orderId).orderStatus(orderId)
 
   property("New buy order added") {
     val ord = buy(WctBtc, 10000, 0.0007)
@@ -602,10 +605,10 @@ class OrderHistoryBalanceSpecification
       o
     }.toVector
 
-    oh.process(OrderCanceled(LimitOrder(origOrders.last), isSystemCancel = false, ntpTime.getTimestamp()))
+    val canceledOrder = origOrders.last
+    oh.process(OrderCanceled(LimitOrder(canceledOrder), isSystemCancel = false, ntpTime.getTimestamp()))
 
     val newOrder = buy(WavesBtc, 100000000, 0.001, Some(pk), Some(300000L), Some(1L))
-
     oh.process(OrderAdded(LimitOrder(newOrder), ntpTime.getTimestamp()))
 
     withClue("orders list") {
@@ -613,11 +616,10 @@ class OrderHistoryBalanceSpecification
       val expectedActiveOrders = origOrders.init.reverse :+ newOrder
       activeOrderIds(pk) shouldBe expectedActiveOrders.map(_.id())
 
-      // 'last' is canceled. It should be moved to the end of all orders' list, but it doesn't fit. So we remove it
-      val expectedAllOrders = origOrders.init.reverse :+ newOrder
+      // 'last' is canceled. It should be moved to the end of all orders' list
+      val expectedAllOrders = origOrders.init.reverse :+ newOrder :+ canceledOrder
       val actualAllOrders   = allOrderIds(pk)
-      actualAllOrders should have length matcherSettings.orderDb.maxOrders
-      actualAllOrders shouldBe expectedAllOrders.map(_.id())
+      actualAllOrders should matchTo(expectedAllOrders.map(_.id()))
     }
   }
 
@@ -629,24 +631,24 @@ class OrderHistoryBalanceSpecification
       o
     }.toVector
 
-    oh.process(OrderCanceled(LimitOrder(origOrders.last), isSystemCancel = false, ntpTime.getTimestamp()))
+    val canceledOrder = origOrders.last
+    oh.process(OrderCanceled(LimitOrder(canceledOrder), isSystemCancel = false, ntpTime.getTimestamp()))
 
     withClue("orders list") {
       // 'last' is canceled, remove it
-      activeOrderIds(pk) shouldBe origOrders.init.reverse.map(_.id())
+      val expectedActiveOrders = origOrders.init.reverse
+      activeOrderIds(pk) shouldBe expectedActiveOrders.map(_.id())
 
-      // 'last' is removed, because it doesn't fit in 'matcherSettings.maxOrdersPerRequest'
-      val expectedAllOrders = origOrders.init.reverse
+      val expectedAllOrders = expectedActiveOrders :+ canceledOrder
       val actualAllOrders   = allOrderIds(pk)
-      actualAllOrders should have length matcherSettings.orderDb.maxOrders
-      allOrderIds(pk) shouldBe expectedAllOrders.map(_.id())
+      actualAllOrders should matchTo(expectedAllOrders.map(_.id()))
     }
   }
 
   property("History by pair - added orders more than history by pair limit (200 active)") {
     val pk = KeyPair("private".getBytes("utf-8"))
 
-    val orders = (1 to MaxElements).map { i =>
+    val orders = (1 to MaxActiveOrders).map { i =>
       val o = buy(WavesBtc, 100000000, 0.0008 + 0.00001 * i, Some(pk), Some(300000L), Some(100L + i))
       oh.process(OrderAdded(LimitOrder(o), ntpTime.getTimestamp()))
       o
@@ -667,31 +669,32 @@ class OrderHistoryBalanceSpecification
     }
   }
 
-  property("History by pair - added and canceled orders both more than history by pair limit (200 active, 10 canceled)") {
+  property("History by pair - added and canceled orders both more than history by pair limit (maxActive + maxFinalized + 1)") {
     val pk = KeyPair("private".getBytes("utf-8"))
 
-    val allOrders = (1 to MaxElements + 10).map { i =>
+    val ordersToFinalize = MaxFinalizedOrders + 1
+    val allOrders = (1 to MaxActiveOrders + ordersToFinalize).map { i =>
       val o = buy(WavesBtc, 100000000, 0.0008 + 0.00001 * i, Some(pk), Some(300000L), Some(100L + i))
       oh.processAll(OrderAdded(LimitOrder(o), ntpTime.getTimestamp()))
       o
     }.toVector
 
-    val (ordersToCancel, activeOrders) = allOrders.splitAt(MaxElements)
+    val (ordersToCancel, activeOrders) = allOrders.splitAt(ordersToFinalize)
     ordersToCancel.foreach(o => oh.process(OrderCanceled(LimitOrder(o), isSystemCancel = false, ntpTime.getTimestamp())))
     val expectedActiveOrderIds = activeOrders.map(_.id()).reverse
 
     withClue("common") {
-      val expectedIds = allOrders.takeRight(MaxElements).map(_.id()).reverse
-      val allIds      = allOrderIds(pk)
-      allIds shouldBe expectedIds
-      activeOrderIds(pk) shouldBe expectedActiveOrderIds
+      val expectedAllIds = allOrders.takeRight(MaxTotalOrders).map(_.id()).reverse
+      val allIds         = allOrderIds(pk)
+      allIds should matchTo(expectedAllIds)
+      activeOrderIds(pk) should matchTo(expectedActiveOrderIds)
     }
 
     withClue("pair") {
-      val expectedIds = allOrders.takeRight(MaxElements).map(_.id()).reverse
+      val expectedIds = allOrders.takeRight(MaxTotalOrders).map(_.id()).reverse
       val pair1Ids    = allOrderIdsByPair(pk, WavesBtc)
-      pair1Ids shouldBe expectedIds
-      activeOrderIdsByPair(pk, WavesBtc) shouldBe expectedActiveOrderIds
+      pair1Ids should matchTo(expectedIds)
+      activeOrderIdsByPair(pk, WavesBtc) should matchTo(expectedActiveOrderIds)
     }
   }
 
@@ -700,9 +703,9 @@ class OrderHistoryBalanceSpecification
     val pair1 = WavesBtc
     val pair2 = AssetPair(Waves, mkAssetId("ETH"))
 
-    // 1. Place and cancel active.MaxElements orders
+    // 1. Place and cancel MaxTotalOrders orders
 
-    val pair1Orders = (1 to MaxElements).map { i =>
+    val pair1Orders = (1 to MaxTotalOrders).map { i =>
       val o = buy(pair1, 100000000, 0.0008 + 0.00001 * i, Some(pk), Some(300000L), Some(100L + i))
       oh.process(OrderAdded(LimitOrder(o), ntpTime.getTimestamp()))
       o
@@ -718,11 +721,11 @@ class OrderHistoryBalanceSpecification
       val expectedIds = pair1Orders.map(_.id()).reverse
 
       withClue("common") {
-        allOrderIds(pk) shouldBe expectedIds.take(MaxElements)
+        allOrderIds(pk) should matchTo(expectedIds.take(MaxFinalizedOrders))
       }
 
       withClue("pair1") {
-        allOrderIdsByPair(pk, pair1) shouldBe expectedIds.take(MaxElements)
+        allOrderIdsByPair(pk, pair1) should matchTo(expectedIds.take(MaxFinalizedOrders))
       }
 
       withClue("pair2") {
@@ -748,18 +751,18 @@ class OrderHistoryBalanceSpecification
 
       withClue("common") {
         val allIds      = allOrderIds(pk)
-        val expectedIds = pair2Orders.map(_.id()).reverse ++ pair1Orders.map(_.id()).reverse.take(MaxElements - pair2Orders.size)
-        allIds shouldBe expectedIds
+        val expectedIds = (pair1Orders.map(_.id()) ++ pair2Orders.map(_.id())).reverse.take(MaxFinalizedOrders)
+        allIds should matchTo(expectedIds)
       }
 
       withClue("pair1") {
         val pair1Ids = allOrderIdsByPair(pk, pair1)
-        pair1Ids shouldBe pair1Orders.map(_.id()).reverse.take(MaxElements)
+        pair1Ids should matchTo(pair1Orders.map(_.id()).reverse.take(MaxFinalizedOrders))
       }
 
       withClue("pair2") {
         val pair2Ids = allOrderIdsByPair(pk, pair2)
-        pair2Ids shouldBe pair2Orders.map(_.id()).reverse
+        pair2Ids should matchTo(pair2Orders.map(_.id()).reverse.take(MaxFinalizedOrders))
       }
     }
   }
@@ -884,23 +887,26 @@ class OrderHistoryBalanceSpecification
 }
 
 private object OrderHistoryBalanceSpecification {
-  val MaxElements: Int             = 100
+  val MaxActiveOrders    = 100
+  val MaxFinalizedOrders = 70
+  val MaxTotalOrders     = MaxActiveOrders + MaxFinalizedOrders
+
   implicit val askTimeout: Timeout = 5.seconds
 
   private def askAddressActor[A: ClassTag](ref: ActorRef, msg: Any) =
     Await.result((ref ? msg).mapTo[A], 5.seconds)
 
   private implicit class AddressActorExt(val ref: ActorRef) extends AnyVal {
-    def orderIds(assetPair: Option[AssetPair], activeOnly: Boolean): Seq[Order.Id] =
-      askAddressActor[AddressActor.Reply.OrdersStatuses](ref, AddressActor.Query.GetOrdersStatuses(assetPair, activeOnly)).xs.map(_._1)
+    def orderIds(assetPair: Option[AssetPair], activeOnly: Boolean): Vector[Order.Id] =
+      askAddressActor[AddressActor.Reply.OrdersStatuses](ref, AddressActor.Query.GetOrdersStatuses(assetPair, activeOnly)).xs.map(_._1).toVector
 
-    def activeOrderIds: Seq[Order.Id] = orderIds(None, true)
+    def activeOrderIds: Vector[Order.Id] = orderIds(None, true)
 
-    def allOrderIds: Seq[Order.Id] = orderIds(None, false)
+    def allOrderIds: Vector[Order.Id] = orderIds(None, false)
 
-    def activeOrderIdsByPair(pair: AssetPair): Seq[Order.Id] = orderIds(Some(pair), true)
+    def activeOrderIdsByPair(pair: AssetPair): Vector[Order.Id] = orderIds(Some(pair), true)
 
-    def allOrderIdsByPair(pair: AssetPair): Seq[Order.Id] = orderIds(Some(pair), false)
+    def allOrderIdsByPair(pair: AssetPair): Vector[Order.Id] = orderIds(Some(pair), false)
 
     def openVolume(asset: Asset): Long =
       askAddressActor[AddressActor.Reply.Balance](ref, AddressActor.Query.GetReservedBalance).balance.getOrElse(asset, 0L)

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderHistoryBalanceSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderHistoryBalanceSpecification.scala
@@ -596,7 +596,7 @@ class OrderHistoryBalanceSpecification
 
   property("History with more than max limit") {
     val pk = KeyPair("private".getBytes("utf-8"))
-    val origOrders = (0 until matcherSettings.maxOrdersPerRequest).map { i =>
+    val origOrders = (0 until matcherSettings.orderDb.maxOrders).map { i =>
       val o = buy(WavesBtc, 100000000, 0.0008 + 0.00001 * i, Some(pk), Some(300000L), Some(100L + i))
       oh.process(OrderAdded(LimitOrder(o), ntpTime.getTimestamp()))
       o
@@ -616,14 +616,14 @@ class OrderHistoryBalanceSpecification
       // 'last' is canceled. It should be moved to the end of all orders' list, but it doesn't fit. So we remove it
       val expectedAllOrders = origOrders.init.reverse :+ newOrder
       val actualAllOrders   = allOrderIds(pk)
-      actualAllOrders should have length matcherSettings.maxOrdersPerRequest
+      actualAllOrders should have length matcherSettings.orderDb.maxOrders
       actualAllOrders shouldBe expectedAllOrders.map(_.id())
     }
   }
 
   property("History with canceled order and more than max limit") {
     val pk = KeyPair("private".getBytes("utf-8"))
-    val origOrders = (0 to matcherSettings.maxOrdersPerRequest).map { i =>
+    val origOrders = (0 to matcherSettings.orderDb.maxOrders).map { i =>
       val o = buy(WavesBtc, 100000000, 0.0008 + 0.00001 * i, Some(pk), Some(300000L), Some(100L + i))
       oh.process(OrderAdded(LimitOrder(o), ntpTime.getTimestamp()))
       o
@@ -638,7 +638,7 @@ class OrderHistoryBalanceSpecification
       // 'last' is removed, because it doesn't fit in 'matcherSettings.maxOrdersPerRequest'
       val expectedAllOrders = origOrders.init.reverse
       val actualAllOrders   = allOrderIds(pk)
-      actualAllOrders should have length matcherSettings.maxOrdersPerRequest
+      actualAllOrders should have length matcherSettings.orderDb.maxOrders
       allOrderIds(pk) shouldBe expectedAllOrders.map(_.id())
     }
   }

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderHistoryStub.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderHistoryStub.scala
@@ -13,7 +13,7 @@ import com.wavesplatform.dex.time.Time
 import scala.collection.mutable
 import scala.concurrent.Future
 
-class OrderHistoryStub(system: ActorSystem, time: Time) {
+class OrderHistoryStub(system: ActorSystem, time: Time, maxActiveOrders: Int, maxFinalizedOrders: Int) {
   private implicit val efc = new ErrorFormatterContext {
     override def assetDecimals(asset: Asset): Int = 8
   }
@@ -30,12 +30,12 @@ class OrderHistoryStub(system: ActorSystem, time: Time) {
             ao.order.sender,
             _ => Future.successful(0L),
             time,
-            new TestOrderDB(100),
+            new TestOrderDB(maxFinalizedOrders),
             _ => Future.successful(false),
             e => Future.successful { Some(QueueEventWithMeta(0, 0, e)) },
             _ => OrderBook.AggregatedSnapshot(),
             true,
-            100
+            maxActiveOrders
           )
         )
       )

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderHistoryStub.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderHistoryStub.scala
@@ -34,7 +34,8 @@ class OrderHistoryStub(system: ActorSystem, time: Time) {
             _ => Future.successful(false),
             e => Future.successful { Some(QueueEventWithMeta(0, 0, e)) },
             _ => OrderBook.AggregatedSnapshot(),
-            true
+            true,
+            100
           )
         )
       )

--- a/dex/src/test/scala/com/wavesplatform/dex/settings/BaseSettingsSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/settings/BaseSettingsSpecification.scala
@@ -71,6 +71,9 @@ class BaseSettingsSpecification extends AnyFlatSpec {
          |      type = "in-mem"
          |      in-mem.seed-in-base64 = "c3lrYWJsZXlhdA=="
          |    }
+         |    order-db {
+         |      max-orders = 199
+         |    }
          |    rest-api {
          |      address = 127.1.2.3
          |      port = 6880

--- a/dex/src/test/scala/com/wavesplatform/dex/settings/MatcherSettingsSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/settings/MatcherSettingsSpecification.scala
@@ -3,7 +3,7 @@ package com.wavesplatform.dex.settings
 import cats.data.NonEmptyList
 import com.typesafe.config.Config
 import com.wavesplatform.dex.api.OrderBookSnapshotHttpCache
-import com.wavesplatform.dex.db.AccountStorage
+import com.wavesplatform.dex.db.{AccountStorage, OrderDB}
 import com.wavesplatform.dex.domain.asset.Asset.{IssuedAsset, Waves}
 import com.wavesplatform.dex.domain.asset.AssetPair
 import com.wavesplatform.dex.domain.bytes.ByteStr
@@ -56,7 +56,7 @@ class MatcherSettingsSpecification extends BaseSettingsSpecification with Matche
     settings.snapshotsInterval should be(999)
     settings.snapshotsLoadingTimeout should be(423.seconds)
     settings.startEventsProcessingTimeout should be(543.seconds)
-    settings.maxOrdersPerRequest should be(100)
+    settings.orderDb should be(OrderDB.Settings(199))
     settings.priceAssets should be(
       Seq(
         Waves,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
     val scalaCheck         = "1.14.3"
     val scalaTestPlusCheck = "3.1.0.1"
     val scalaMock          = "4.4.0"
-    val diffx              = "0.3.16"
+    val diffx              = "0.3.19"
 
     val cats              = "2.0.0"
     val catsTaglessMacros = "0.11"


### PR DESCRIPTION
Simplified a logic for getting order history from REST API.

Was:
There was a setting: `rest-order-limit`.
DEX loaded active orders and tried to fill the resulting list with closed (filled, canceled) orders to fit rest-order-limit, if it is able.

Now:
There are new settings: `max-active-orders` and `order-db.max-orders`.
DEX loads all active orders (up to `max-active-orders`) and all closed orders (up to `order-db.max-orders`).