### PR TITLE
DEX-647 Refactor events generated by OrderBook

### DIFF
--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/MatchingRulesTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/MatchingRulesTestSuite.scala
@@ -236,8 +236,8 @@ class MatchingRulesTestSuite extends MatcherSuiteBase {
       dex1.api.reservedBalance(alice)(Waves) shouldBe matcherFee / 2
       dex1.api.reservedBalance(alice)(usd) shouldBe 20 * price * amount / PriceConstant
       dex1.api.cancel(alice, buyOrder)
-      dex1.api.reservedBalance(alice) shouldBe Map()
-      dex1.api.orderBook(wctUsdPair).bids shouldBe List()
+      dex1.api.reservedBalance(alice) shouldBe empty
+      dex1.api.orderBook(wctUsdPair).bids shouldBe empty
     }
   }
 

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/api/MatcherWebSocketsTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/api/MatcherWebSocketsTestSuite.scala
@@ -54,9 +54,11 @@ class MatcherWebSocketsTestSuite extends MatcherSuiteBase with HasWebSockets {
       connection.getOrderChanges.size shouldEqual ordersChangesCount
     }
 
-    Thread.sleep(200)
+    Thread.sleep(200) // Wait an additional time for extra events
 
-    connection.getBalancesChanges.size should be <= balancesChangesCountBorders._2
+    withClue(s"Order changes are ${expectedOrdersChanges.mkString(", ")}: ") {
+      connection.getBalancesChanges.size should be <= balancesChangesCountBorders._2
+    }
 
     squashBalanceChanges(connection.getBalancesChanges) should matchTo(expectedBalanceChanges)
     connection.getOrderChanges should matchTo(expectedOrdersChanges)
@@ -74,7 +76,9 @@ class MatcherWebSocketsTestSuite extends MatcherSuiteBase with HasWebSockets {
   }
 
   private def receiveAtLeastN[T](wsc: WebSocketConnection[T], n: Int): Seq[T] = {
-    eventually { wsc.getMessagesBuffer.size should be >= n }
+    withClue(s"Messages buffer is ${wsc.getMessagesBuffer.mkString(", ")}: ") {
+      eventually(wsc.getMessagesBuffer.size should be >= n)
+    }
     Thread.sleep(200) // Waiting for additional messages
     wsc.getMessagesBuffer
   }

--- a/dex-test-common/src/main/scala/com/wavesplatform/dex/test/matchers/DiffMatcherWithImplicits.scala
+++ b/dex-test-common/src/main/scala/com/wavesplatform/dex/test/matchers/DiffMatcherWithImplicits.scala
@@ -18,8 +18,10 @@ object DiffMatcherWithImplicits {
 
   case class DiffForMatcher[A: Diff](right: A) extends Matcher[A] {
     override def apply(left: A): MatchResult = Diff[A].apply(left, right) match {
-      case c: DiffResultDifferent => MatchResult(matches = false, s"Matching error:\n${Console.RESET}${c.show}${Console.RESET}", "")
-      case _                      => MatchResult(matches = true, "", "")
+      case c: DiffResultDifferent =>
+        val diff = c.show.split('\n').mkString(Console.RESET, s"${Console.RESET}\n${Console.RESET}", Console.RESET)
+        MatchResult(matches = false, s"Matching error:\n$diff", "")
+      case _ => MatchResult(matches = true, "", "")
     }
   }
 

--- a/dex/src/main/scala/com/wavesplatform/dex/AddressWsMutableState.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/AddressWsMutableState.scala
@@ -11,6 +11,7 @@ import com.wavesplatform.dex.model.{AcceptedOrder, OrderStatus}
 
 import scala.collection.immutable.Queue
 
+// TODO remove trackedOrders
 case class AddressWsMutableState(activeWsConnections: Queue[ActorRef],
                                  pendingWsConnections: Queue[ActorRef],
                                  changedSpendableAssets: Set[Asset],

--- a/dex/src/main/scala/com/wavesplatform/dex/history/HistoryRouter.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/history/HistoryRouter.scala
@@ -103,7 +103,7 @@ object HistoryRouter {
               totalFilled = denormalizeAmountAndFee(submitted.order.amount - submitted.amount, assetPair.amountAsset),
               feeFilled = 0,
               feeTotalFilled = denormalizeAmountAndFee(submitted.order.matcherFee - submitted.fee, submitted.order.feeAsset),
-              status = OrderStatus.finalStatus(submitted, isSystemCancel) match { case _: Filled => statusFilled; case _ => statusCancelled }
+              status = OrderStatus.finalCancelStatus(submitted, isSystemCancel) match { case _: Filled => statusFilled; case _ => statusCancelled }
             )
           )
       }

--- a/dex/src/main/scala/com/wavesplatform/dex/model/MatcherModel.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/MatcherModel.scala
@@ -394,7 +394,7 @@ object Events {
     def submittedRemaining: AcceptedOrder = submitted.fold[AcceptedOrder] { submittedLimitRemaining } { submittedMarketRemaining }
   }
 
-  case class OrderAdded(order: LimitOrder, timestamp: Long) extends Event
+  case class OrderAdded(order: AcceptedOrder, timestamp: Long) extends Event
 
   case class OrderCanceled(acceptedOrder: AcceptedOrder, isSystemCancel: Boolean, timestamp: Long) extends Event
 

--- a/dex/src/main/scala/com/wavesplatform/dex/model/MatcherModel.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/MatcherModel.scala
@@ -345,7 +345,7 @@ object OrderStatus {
     val name = "Cancelled"
   }
 
-  def finalStatus(ao: AcceptedOrder, isSystemCancel: Boolean): Final = {
+  def finalCancelStatus(ao: AcceptedOrder, isSystemCancel: Boolean): Final = {
     val filledAmount     = ao.order.amount - ao.amount
     val filledMatcherFee = ao.order.matcherFee - ao.fee
     if (isSystemCancel && (filledAmount > 0 || ao.isMarket)) Filled(filledAmount, filledMatcherFee) else Cancelled(filledAmount, filledMatcherFee)
@@ -369,7 +369,7 @@ object Events {
     def counterRemainingAmount: Long = math.max(counter.amount - executedAmount, 0)
     def counterExecutedFee: Long     = AcceptedOrder.partialFee(maxCounterFee, counter.order.amount, executedAmount)
     def counterRemainingFee: Long    = math.max(counter.fee - counterExecutedFee, 0)
-    def counterRemaining: LimitOrder = counter.partial(amount = counterRemainingAmount, fee = counterRemainingFee)
+    lazy val counterRemaining: LimitOrder = counter.partial(amount = counterRemainingAmount, fee = counterRemainingFee)
 
     def submittedRemainingAmount: Long = math.max(submitted.amount - executedAmount, 0)
     def submittedExecutedFee: Long     = AcceptedOrder.partialFee(maxSubmittedFee, submitted.order.amount, executedAmount)
@@ -391,7 +391,7 @@ object Events {
       submittedLimitOrder.partial(amount = submittedRemainingAmount, fee = submittedRemainingFee)
     }
 
-    def submittedRemaining: AcceptedOrder = submitted.fold[AcceptedOrder] { submittedLimitRemaining } { submittedMarketRemaining }
+    lazy val submittedRemaining: AcceptedOrder = submitted.fold[AcceptedOrder] { submittedLimitRemaining } { submittedMarketRemaining }
   }
 
   case class OrderAdded(order: AcceptedOrder, timestamp: Long) extends Event

--- a/dex/src/main/scala/com/wavesplatform/dex/model/OrderBook.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/OrderBook.scala
@@ -44,11 +44,7 @@ case class OrderBook private (bids: Side, asks: Side, lastTrade: Option[LastTrad
           eventTs: Long,
           getMakerTakerFee: (AcceptedOrder, LimitOrder) => (Long, Long),
           tickSize: Long = MatchingRule.DefaultRule.tickSize): (OrderBook, Queue[Event], LevelAmounts) = {
-    val events = submitted match {
-      case submitted: LimitOrder => Queue(OrderAdded(submitted, eventTs))
-      case _: MarketOrder        => Queue.empty[Event]
-    }
-
+    val events = Queue(OrderAdded(submitted, eventTs))
     if (submitted.order.isValid(eventTs)) doMatch(eventTs, tickSize, getMakerTakerFee, submitted, events, this)
     else (this, events.enqueue(OrderCanceled(submitted, isSystemCancel = false, eventTs)), LevelAmounts.empty)
   }

--- a/dex/src/main/scala/com/wavesplatform/dex/model/OrderBook.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/OrderBook.scala
@@ -43,9 +43,15 @@ case class OrderBook private (bids: Side, asks: Side, lastTrade: Option[LastTrad
   def add(submitted: AcceptedOrder,
           eventTs: Long,
           getMakerTakerFee: (AcceptedOrder, LimitOrder) => (Long, Long),
-          tickSize: Long = MatchingRule.DefaultRule.tickSize): (OrderBook, Queue[Event], LevelAmounts) =
-    if (submitted.order.isValid(eventTs)) doMatch(eventTs, tickSize, getMakerTakerFee, submitted, this)
-    else (this, Queue(OrderCanceled(submitted, isSystemCancel = false, eventTs)), LevelAmounts.empty)
+          tickSize: Long = MatchingRule.DefaultRule.tickSize): (OrderBook, Queue[Event], LevelAmounts) = {
+    val events = submitted match {
+      case submitted: LimitOrder => Queue(OrderAdded(submitted, eventTs))
+      case _: MarketOrder        => Queue.empty[Event]
+    }
+
+    if (submitted.order.isValid(eventTs)) doMatch(eventTs, tickSize, getMakerTakerFee, submitted, events, this)
+    else (this, events.enqueue(OrderCanceled(submitted, isSystemCancel = false, eventTs)), LevelAmounts.empty)
+  }
 
   def snapshot: OrderBookSnapshot                     = OrderBookSnapshot(bids, asks, lastTrade)
   def aggregatedSnapshot: OrderBookAggregatedSnapshot = OrderBookAggregatedSnapshot(bids.aggregated.toSeq, asks.aggregated.toSeq)
@@ -108,6 +114,7 @@ object OrderBook {
                       tickSize: Long,
                       getMakerTakerMaxFee: (AcceptedOrder, LimitOrder) => (Long, Long),
                       submitted: AcceptedOrder,
+                      events: Queue[Event],
                       orderBook: OrderBook): (OrderBook, Queue[Event], LevelAmounts) = {
     @scala.annotation.tailrec
     def loop(orderBook: OrderBook,
@@ -161,18 +168,18 @@ object OrderBook {
         case _ =>
           submitted match {
             case submitted: LimitOrder =>
-              val levelPrice = correctPriceByTickSize(submitted.price, submitted.order.orderType, tickSize)
+              val levelPrice       = correctPriceByTickSize(submitted.price, submitted.order.orderType, tickSize)
               val updatedOrderBook = orderBook.insert(levelPrice, submitted)
               // TODO replace by levelChanges.add(levelPrice, submitted) during optimization
               val updatedLevelChanges = levelChanges.put(updatedOrderBook.levelAmountsAt(submitted.order.orderType, levelPrice))
-              (updatedOrderBook, events.enqueue(OrderAdded(submitted, eventTs)), updatedLevelChanges)
+              (updatedOrderBook, events, updatedLevelChanges)
             case submitted: MarketOrder =>
               // Cancel market order in the absence of counters
               (orderBook, events.enqueue(OrderCanceled(submitted, isSystemCancel = true, eventTs)), levelChanges)
           }
       }
 
-    loop(orderBook, submitted, Queue.empty, LevelAmounts.empty)
+    loop(orderBook, submitted, events, LevelAmounts.empty)
   }
 
   private def formatSide(side: Side): String =

--- a/dex/src/test/scala/com/wavesplatform/dex/ActorsWebSocketInteractionsSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/ActorsWebSocketInteractionsSpecification.scala
@@ -90,13 +90,8 @@ class ActorsWebSocketInteractionsSpecification
 
     def placeOrder(ao: AcceptedOrder): Unit = {
       addressDir ! AddressDirectory.Envelope(address, AddressActor.Command.PlaceOrder(ao.order, ao.isMarket))
-      ao.fold { lo =>
-        eventsProbe.expectMsg(QueueEvent.Placed(lo))
-        addressDir ! OrderAdded(lo, System.currentTimeMillis)
-      } { mo =>
-        eventsProbe.expectMsg(QueueEvent.PlacedMarket(mo))
-        addressDir ! OrderAdded(mo, System.currentTimeMillis)
-      }
+      eventsProbe.expectMsg(ao.fold[QueueEvent](QueueEvent.Placed)(QueueEvent.PlacedMarket))
+      addressDir ! OrderAdded(ao, System.currentTimeMillis)
     }
 
     def cancelOrder(ao: AcceptedOrder, isSystemCancel: Boolean): Unit = {

--- a/dex/src/test/scala/com/wavesplatform/dex/ActorsWebSocketInteractionsSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/ActorsWebSocketInteractionsSpecification.scala
@@ -88,7 +88,6 @@ class ActorsWebSocketInteractionsSpecification
       addressDir.tell(AddressDirectory.Envelope(address, AddressActor.AddWsSubscription), eventsProbe.ref)
     }
 
-    // TODO
     def placeOrder(ao: AcceptedOrder): Unit = {
       addressDir ! AddressDirectory.Envelope(address, AddressActor.Command.PlaceOrder(ao.order, ao.isMarket))
       ao.fold { lo =>
@@ -96,6 +95,7 @@ class ActorsWebSocketInteractionsSpecification
         addressDir ! OrderAdded(lo, System.currentTimeMillis)
       } { mo =>
         eventsProbe.expectMsg(QueueEvent.PlacedMarket(mo))
+        addressDir ! OrderAdded(mo, System.currentTimeMillis)
       }
     }
 
@@ -272,7 +272,7 @@ class ActorsWebSocketInteractionsSpecification
             placeOrder(mo)
             expectWsBalancesAndOrders(
               Map(usd -> WsBalances(150, 150), eth -> WsBalances(1.99998297, 0.00001703)),
-              Seq.empty // since market order cannot be added in order book
+              Seq(WsOrder.fromDomain(mo, OrderStatus.Accepted))
             )
           }
 
@@ -547,7 +547,7 @@ class ActorsWebSocketInteractionsSpecification
           placeOrder(mo)
           expectWsBalancesAndOrders(
             Map(Waves -> WsBalances(87.997, 12.003)),
-            Seq.empty
+            Seq(WsOrder.fromDomain(mo, OrderStatus.Accepted))
           )
 
           mo = matchOrders(mo, counter1)

--- a/dex/src/test/scala/com/wavesplatform/dex/ActorsWebSocketInteractionsSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/ActorsWebSocketInteractionsSpecification.scala
@@ -430,7 +430,6 @@ class ActorsWebSocketInteractionsSpecification
           ad ! AddressDirectory.Envelope(address, AddressActor.Command.PlaceOrder(submitted.order, submitted.isMarket))
           ep.expectMsg(QueueEvent.Placed(submitted))
 
-          // TODO check other tests: OrderAdded should be after place
           ad ! OrderAdded(submitted, now)
           val oe = OrderExecuted(submitted, counter, System.currentTimeMillis, submitted.matcherFee, counter.matcherFee)
           ad ! oe

--- a/dex/src/test/scala/com/wavesplatform/dex/market/OrderBookActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/market/OrderBookActorSpecification.scala
@@ -431,7 +431,7 @@ class OrderBookActorSpecification
         }
 
         orderBook ! wrapMarketOrder(marketOrder)
-
+        tp.expectMsgType[OrderAdded]
         val oe1 = tp.expectMsgType[OrderExecuted]
         oe1.submitted shouldBe marketOrder
         oe1.counter shouldBe LimitOrder(counterOrder1)
@@ -491,6 +491,7 @@ class OrderBookActorSpecification
 
         withClue("Stop condition - no counter orders:") {
           orderBook ! wrapMarketOrder(marketOrder)
+          tp.expectMsgType[OrderAdded]
           val oc = tp.expectMsgType[OrderCanceled]
 
           oc.acceptedOrder shouldBe marketOrder
@@ -505,7 +506,7 @@ class OrderBookActorSpecification
           tp.expectMsgType[OrderAdded]
 
           orderBook ! wrapMarketOrder(marketOrder)
-
+          tp.expectMsgType[OrderAdded]
           val oe = tp.expectMsgType[OrderExecuted]
           oe.submitted shouldBe marketOrder
           oe.counter shouldBe LimitOrder(counterOrder)
@@ -565,6 +566,7 @@ class OrderBookActorSpecification
 
           orderBook ! wrapMarketOrder(marketOrder)
 
+          tp.expectMsgType[OrderAdded]
           val oe = tp.expectMsgType[OrderExecuted]
           oe.submitted shouldBe marketOrder
           oe.counter shouldBe LimitOrder(counterOrder)

--- a/dex/src/test/scala/com/wavesplatform/dex/market/OrderBookActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/market/OrderBookActorSpecification.scala
@@ -140,9 +140,11 @@ class OrderBookActorSpecification
       val ord2 = sell(pair, 15 * Order.PriceConstant, 100)
 
       actor ! wrapLimitOrder(ord1)
-      actor ! wrapLimitOrder(ord2)
+      tp.expectMsgType[OrderAdded]
 
-      tp.receiveN(3)
+      actor ! wrapLimitOrder(ord2)
+      tp.expectMsgType[OrderAdded]
+      tp.expectMsgType[OrderExecuted]
 
       actor ! SaveSnapshot(Long.MaxValue)
       tp.expectMsgType[OrderBookSnapshotUpdateCompleted]
@@ -167,7 +169,7 @@ class OrderBookActorSpecification
       actor ! wrapLimitOrder(ord1)
       actor ! wrapLimitOrder(ord2)
       actor ! wrapLimitOrder(ord3)
-      tp.receiveN(4)
+      tp.receiveN(5)
 
       actor ! SaveSnapshot(Long.MaxValue)
       tp.expectMsgType[OrderBookSnapshotUpdateCompleted]
@@ -195,7 +197,7 @@ class OrderBookActorSpecification
       actor ! wrapLimitOrder(ord2)
       actor ! wrapLimitOrder(ord3)
       actor ! wrapLimitOrder(ord4)
-      tp.receiveN(6)
+      tp.receiveN(7)
 
       actor ! SaveSnapshot(Long.MaxValue)
       tp.expectMsgType[OrderBookSnapshotUpdateCompleted]

--- a/dex/src/test/scala/com/wavesplatform/dex/matching/ReservedBalanceSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/matching/ReservedBalanceSpecification.scala
@@ -277,7 +277,7 @@ class ReservedBalanceSpecification extends AnyPropSpecLike with MatcherSpecLike 
       withClue(s"Counter sender should have reserved asset:") {
         val (expectedAmountReserve, expectedPriceReserve) = if (counterType == BUY) (0, 1) else (minAmountFor(counterPrice), 0)
         openVolume(counter.senderPublicKey, pair.amountAsset) shouldBe expectedAmountReserve
-        openVolume(counter.senderPublicKey, pair.priceAsset) shouldBe expectedPriceReserve // <--
+        openVolume(counter.senderPublicKey, pair.priceAsset) shouldBe expectedPriceReserve
       }
 
       withClue(s"Submitted sender should not have reserves:") {

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderBookSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderBookSpec.scala
@@ -216,9 +216,9 @@ ${updatedOb.aggregatedSnapshot}
         // tickSize == 1
         val eventPrices = events
           .collect {
-            case evt: OrderAdded                          => evt.order.price
-            case evt: OrderExecuted                       => evt.counter.price
-            case evt @ OrderCanceled(_: LimitOrder, _, _) => evt.acceptedOrder.price // Ignore market orders, because the are canceled at end
+            case evt: OrderAdded    => evt.order.price
+            case evt: OrderExecuted => evt.counter.price
+            case evt: OrderCanceled => evt.acceptedOrder.price // Ignore market orders, because the are canceled at end
           }
           .filter(p => ob.hasPrice(p) || updatedOb.hasPrice(p))
           .toSet


### PR DESCRIPTION
Fixed:
* Send the full market order on place;
* Send only changes for MarketOrder, when it is filled;

Domain:
* OrderBook: always generate OrderAdded;
* OrderStatus.finalStatus is renamed to finalCancelStatus, because it used only for OrderCanceled;

Now we know clearly when an order appears first time, thus:
* AddressActor - simplified events processing;
* AddressDirectory - simplified message forwarding to order history;
* AddressWsMutableState.trackedOrders is removed;

Tests:
* Fixed coloring in DiffMatcherWithImplicits;

Other:
* AddressActor uses a regular group for Map (code is less difficult to interpret);