### PR TITLE
DEX-594 Average weighed price

### DIFF
--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/responses/dex/OrderBookHistoryItem.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/responses/dex/OrderBookHistoryItem.scala
@@ -16,7 +16,8 @@ case class OrderBookHistoryItem(id: Order.Id,
                                 feeAsset: Asset,
                                 timestamp: Long,
                                 status: OrderStatus,
-                                assetPair: AssetPair)
+                                assetPair: AssetPair,
+                                avgWeighedPrice: Long)
 
 object OrderBookHistoryItem {
   implicit val orderbookHistory: Format[OrderBookHistoryItem] = Json.format

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/api/MatcherWebSocketsTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/api/MatcherWebSocketsTestSuite.scala
@@ -191,7 +191,7 @@ class MatcherWebSocketsTestSuite extends MatcherSuiteBase with HasWebSockets {
               .copy(
                 filledAmount = 6.0.some,
                 filledFee = 0.00000017.some,
-                avgFilledPrice = 3.0.some
+                avgWeighedPrice = 3.0.some
               ),
             WsOrder(buyOrder.id(), status = OrderStatus.Cancelled.name.some)
           )

--- a/dex/src/main/scala/com/wavesplatform/dex/AddressActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/AddressActor.scala
@@ -358,7 +358,7 @@ class AddressActor(owner: Address,
       case status: OrderStatus.Final =>
         expiration.remove(remaining.id).foreach(_.cancel())
         activeOrders.remove(remaining.id).foreach(ao => openVolume = openVolume |-| ao.reservableBalance)
-        orderDB.saveOrderInfo(remaining.id, owner, OrderInfo.v3(remaining, status))
+        orderDB.saveOrderInfo(remaining.id, owner, OrderInfo.v4(remaining, status))
 
       case _ =>
         activeOrders.put(remaining.id, remaining)

--- a/dex/src/main/scala/com/wavesplatform/dex/AddressWsMutableState.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/AddressWsMutableState.scala
@@ -61,7 +61,7 @@ case class AddressWsMutableState(activeWsConnections: Queue[ActorRef],
           status = newStatus.name.some,
           filledAmount = ao.fillingInfo.filledAmount.some.map(denormalizeAmountAndFee(_, ad).toDouble),
           filledFee = ao.fillingInfo.filledFee.some.map(denormalizeAmountAndFee(_, ad).toDouble),
-          avgFilledPrice = ao.fillingInfo.avgFilledPrice.some.map(denormalizePrice(_, ad, pd).toDouble)
+          avgWeighedPrice = ao.fillingInfo.avgWeighedPrice.some.map(denormalizePrice(_, ad, pd).toDouble)
         )
     )
   }

--- a/dex/src/main/scala/com/wavesplatform/dex/api/MatcherApiRoute.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/MatcherApiRoute.scala
@@ -554,18 +554,19 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
       StatusCodes.OK -> reply.xs.map {
         case (id, oi) =>
           Json.obj(
-            "id"        -> id.toString,
-            "type"      -> oi.side.toString,
-            "orderType" -> oi.orderType,
-            "amount"    -> oi.amount,
-            "fee"       -> oi.matcherFee,
-            "price"     -> oi.price,
-            "timestamp" -> oi.timestamp,
-            "filled"    -> oi.status.filledAmount,
-            "filledFee" -> oi.status.filledFee,
-            "feeAsset"  -> oi.feeAsset,
-            "status"    -> oi.status.name,
-            "assetPair" -> oi.assetPair.json
+            "id"              -> id.toString,
+            "type"            -> oi.side.toString,
+            "orderType"       -> oi.orderType,
+            "amount"          -> oi.amount,
+            "fee"             -> oi.matcherFee,
+            "price"           -> oi.price,
+            "timestamp"       -> oi.timestamp,
+            "filled"          -> oi.status.filledAmount,
+            "filledFee"       -> oi.status.filledFee,
+            "feeAsset"        -> oi.feeAsset,
+            "status"          -> oi.status.name,
+            "assetPair"       -> oi.assetPair.json,
+            "avgWeighedPrice" -> oi.avgWeighedPrice
           )
       }
     }

--- a/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsOrder.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/websockets/WsOrder.scala
@@ -22,7 +22,7 @@ case class WsOrder(id: Order.Id,
                    status: Option[String] = None,
                    filledAmount: Option[Double] = None,
                    filledFee: Option[Double] = None,
-                   avgFilledPrice: Option[Double] = None)
+                   avgWeighedPrice: Option[Double] = None)
 
 object WsOrder {
 
@@ -48,7 +48,7 @@ object WsOrder {
       status.name.some,
       ao.fillingInfo.filledAmount.some.map(denormalizeAmountAndFee),
       ao.fillingInfo.filledFee.some.map(denormalizeAmountAndFee),
-      ao.fillingInfo.avgFilledPrice.some.map(denormalizePrice)
+      ao.fillingInfo.avgWeighedPrice.some.map(denormalizePrice)
     )
   }
 
@@ -96,6 +96,6 @@ object WsOrder {
         (__ \ "s").formatNullable[String](orderStatusFormat) and    // status: ACCEPTED or FILLED or PARTIALLY_FILLED or CANCELLED
         (__ \ "q").formatNullable[Double](doubleAsStringFormat) and // filled amount
         (__ \ "Q").formatNullable[Double](doubleAsStringFormat) and // filled fee
-        (__ \ "r").formatNullable[Double](doubleAsStringFormat)     // average filled price among all trades
+        (__ \ "r").formatNullable[Double](doubleAsStringFormat)     // average weighed price among all trades
     )(WsOrder.apply, unlift(WsOrder.unapply))
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/model/AcceptedOrderType.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/AcceptedOrderType.scala
@@ -6,7 +6,8 @@ import play.api.libs.json._
 sealed trait AcceptedOrderType
 
 object AcceptedOrderType {
-  case object Limit extends AcceptedOrderType
+
+  case object Limit  extends AcceptedOrderType
   case object Market extends AcceptedOrderType
 
   implicit val acceptedOrderTypeFormat: Format[AcceptedOrderType] = Format(

--- a/dex/src/main/scala/com/wavesplatform/dex/model/OrderBookSnapshot.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/OrderBookSnapshot.scala
@@ -10,8 +10,8 @@ object OrderBookSnapshot {
   val empty: OrderBookSnapshot = OrderBookSnapshot(bids = Map.empty, asks = Map.empty, None)
 
   def serialize(dest: mutable.ArrayBuilder[Byte], x: OrderBookSnapshot): Unit = {
-    OrderBookSideSnapshot.serialize(dest, x.bids)
-    OrderBookSideSnapshot.serialize(dest, x.asks)
+    OrderBookSideSnapshot.encode(dest, x.bids)
+    OrderBookSideSnapshot.encode(dest, x.asks)
     x.lastTrade match {
       case None => dest += 0
       case Some(lastTrade) =>
@@ -22,8 +22,8 @@ object OrderBookSnapshot {
 
   def fromBytes(bb: ByteBuffer): OrderBookSnapshot =
     OrderBookSnapshot(
-      OrderBookSideSnapshot.fromBytes(bb),
-      OrderBookSideSnapshot.fromBytes(bb),
+      OrderBookSideSnapshot.decode(bb),
+      OrderBookSideSnapshot.decode(bb),
       bb.get match {
         case 0 => None
         case 1 => Some(LastTrade.fromBytes(bb))

--- a/dex/src/main/scala/com/wavesplatform/dex/model/OrderInfo.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/OrderInfo.scala
@@ -2,6 +2,7 @@ package com.wavesplatform.dex.model
 
 import java.nio.ByteBuffer
 
+import com.google.common.primitives.Longs
 import com.wavesplatform.dex.domain.asset.Asset.Waves
 import com.wavesplatform.dex.domain.asset.{Asset, AssetPair}
 import com.wavesplatform.dex.domain.order.{Order, OrderType}
@@ -18,13 +19,14 @@ trait OrderInfo[+S <: OrderStatus] {
   def status: S
   def assetPair: AssetPair
   def orderType: AcceptedOrderType
+  def avgWeighedPrice: Long
 }
 
 object OrderInfo {
   type FinalOrderInfo = OrderInfo[OrderStatus.Final]
 
   def v1[S <: OrderStatus](side: OrderType, amount: Long, price: Long, timestamp: Long, status: S, assetPair: AssetPair): OrderInfo[S] =
-    Impl(1, side, amount, price, 300000L, Waves, timestamp, status, assetPair, AcceptedOrderType.Limit)
+    Impl(1, side, amount, price, 300000L, Waves, timestamp, status, assetPair, AcceptedOrderType.Limit, price)
 
   def v2[S <: OrderStatus](order: Order, status: S): OrderInfo[S] =
     v2(order.orderType, order.amount, order.price, order.matcherFee, order.feeAsset, order.timestamp, status, order.assetPair)
@@ -37,20 +39,12 @@ object OrderInfo {
                            timestamp: Long,
                            status: S,
                            assetPair: AssetPair): OrderInfo[S] =
-    Impl(2, side, amount, price, matcherFee, matcherFeeAssetId, timestamp, status, assetPair, AcceptedOrderType.Limit)
+    Impl(2, side, amount, price, matcherFee, matcherFeeAssetId, timestamp, status, assetPair, AcceptedOrderType.Limit, price)
 
   def v3[S <: OrderStatus](ao: AcceptedOrder, status: S): OrderInfo[S] = {
     import ao.order
     val acceptedOrderType = if (ao.isLimit) AcceptedOrderType.Limit else AcceptedOrderType.Market
-    v3(order.orderType,
-       order.amount,
-       order.price,
-       order.matcherFee,
-       order.feeAsset,
-       order.timestamp,
-       status,
-       order.assetPair,
-       acceptedOrderType)
+    v3(order.orderType, order.amount, order.price, order.matcherFee, order.feeAsset, order.timestamp, status, order.assetPair, acceptedOrderType)
   }
 
   def v3[S <: OrderStatus](order: Order, status: S, orderType: AcceptedOrderType): OrderInfo[S] =
@@ -65,7 +59,36 @@ object OrderInfo {
                            status: S,
                            assetPair: AssetPair,
                            orderType: AcceptedOrderType): OrderInfo[S] =
-    Impl(3, side, amount, price, matcherFee, matcherFeeAssetId, timestamp, status, assetPair, orderType)
+    Impl(3, side, amount, price, matcherFee, matcherFeeAssetId, timestamp, status, assetPair, orderType, price)
+
+  def v4[S <: OrderStatus](side: OrderType,
+                           amount: Long,
+                           price: Long,
+                           matcherFee: Long,
+                           matcherFeeAssetId: Asset,
+                           timestamp: Long,
+                           status: S,
+                           assetPair: AssetPair,
+                           orderType: AcceptedOrderType,
+                           avgWeighedPrice: Long): OrderInfo[S] =
+    Impl(4, side, amount, price, matcherFee, matcherFeeAssetId, timestamp, status, assetPair, orderType, avgWeighedPrice)
+
+  def v4[S <: OrderStatus](ao: AcceptedOrder, status: S): OrderInfo[S] = {
+    import ao.order
+    val acceptedOrderType = if (ao.isLimit) AcceptedOrderType.Limit else AcceptedOrderType.Market
+    v4(
+      order.orderType,
+      order.amount,
+      order.price,
+      order.matcherFee,
+      order.feeAsset,
+      order.timestamp,
+      status,
+      order.assetPair,
+      acceptedOrderType,
+      ao.fillingInfo.avgWeighedPrice
+    )
+  }
 
   private case class Impl[+S <: OrderStatus](version: Byte,
                                              side: OrderType,
@@ -76,13 +99,15 @@ object OrderInfo {
                                              timestamp: Long,
                                              status: S,
                                              assetPair: AssetPair,
-                                             orderType: AcceptedOrderType)
+                                             orderType: AcceptedOrderType,
+                                             avgWeighedPrice: Long)
       extends OrderInfo[S]
 
   def encode(oi: FinalOrderInfo): Array[Byte] = oi.version match {
     case x if x <= 1 => encodeV1(oi)
     case 2           => encodeV2(oi)
     case 3           => encodeV3(oi)
+    case 4           => encodeV4(oi)
     case x           => throw new IllegalArgumentException(s"An unknown order version: $x")
   }
 
@@ -92,6 +117,7 @@ object OrderInfo {
       case side @ (0 | 1) => decodeV1(side, buf)
       case 2              => decodeV2(buf)
       case 3              => decodeV3(buf)
+      case 4              => decodeV4(buf)
       case x              => throw new IllegalStateException(s"An unknown version of order info: $x")
     }
   }
@@ -111,6 +137,7 @@ object OrderInfo {
   }
 
   private def decodeV1(side: Byte, buf: ByteBuffer): FinalOrderInfo = {
+
     val version: Byte = 1
     val totalAmount   = buf.getLong()
     val totalFee      = 300000L
@@ -148,6 +175,7 @@ object OrderInfo {
     ).array()
 
   private def decodeV2(buf: ByteBuffer): FinalOrderInfo = {
+
     val side        = OrderType(buf.get)
     val totalAmount = buf.getLong
     val price       = buf.getLong
@@ -174,6 +202,7 @@ object OrderInfo {
       .array()
 
   private def decodeV3(buf: ByteBuffer): FinalOrderInfo = {
+
     val side        = OrderType(buf.get)
     val totalAmount = buf.getLong
     val price       = buf.getLong
@@ -189,6 +218,35 @@ object OrderInfo {
       status = buf.getFinalOrderStatus(3, totalAmount, totalFee),
       assetPair = AssetPair(buf.getAssetId, buf.getAssetId),
       orderType = buf.getAcceptedOrderType
+    )
+  }
+
+  private def encodeV4(oi: OrderInfo.FinalOrderInfo): Array[Byte] = {
+    val size: Int = 52 + oi.feeAsset.byteRepr.length + oi.assetPair.bytes.length + 8
+    encodeVersioned(4, size, oi)
+      .putAcceptedOrderType(oi.orderType)
+      .put(Longs.toByteArray(oi.avgWeighedPrice))
+      .array()
+  }
+
+  private def decodeV4(buf: ByteBuffer): FinalOrderInfo = {
+
+    val side        = OrderType(buf.get)
+    val totalAmount = buf.getLong
+    val price       = buf.getLong
+    val totalFee    = buf.getLong
+
+    OrderInfo.v4(
+      side = side,
+      amount = totalAmount,
+      price = price,
+      matcherFee = totalFee,
+      matcherFeeAssetId = buf.getAssetId,
+      timestamp = buf.getLong,
+      status = buf.getFinalOrderStatus(3, totalAmount, totalFee),
+      assetPair = AssetPair(buf.getAssetId, buf.getAssetId),
+      orderType = buf.getAcceptedOrderType,
+      avgWeighedPrice = buf.getLong
     )
   }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/util/Codecs.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/util/Codecs.scala
@@ -2,7 +2,6 @@ package com.wavesplatform.dex.util
 
 import java.nio.ByteBuffer
 
-import com.google.common.primitives.Ints
 import com.wavesplatform.dex.domain.asset.Asset
 import com.wavesplatform.dex.domain.asset.Asset.{IssuedAsset, Waves}
 import com.wavesplatform.dex.domain.bytes.ByteStr
@@ -11,11 +10,6 @@ import com.wavesplatform.dex.model.{AcceptedOrderType, OrderStatus}
 object Codecs {
 
   implicit class ByteBufferExt(val b: ByteBuffer) extends AnyVal {
-
-    def putBytes(array: Array[Byte]): ByteBuffer = {
-      b.put(Ints.toByteArray(array.length))
-      b.put(array)
-    }
 
     def getBytes: Array[Byte] = {
       val len = b.getInt

--- a/dex/src/main/scala/com/wavesplatform/dex/util/Codecs.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/util/Codecs.scala
@@ -2,6 +2,7 @@ package com.wavesplatform.dex.util
 
 import java.nio.ByteBuffer
 
+import com.google.common.primitives.Ints
 import com.wavesplatform.dex.domain.asset.Asset
 import com.wavesplatform.dex.domain.asset.Asset.{IssuedAsset, Waves}
 import com.wavesplatform.dex.domain.bytes.ByteStr
@@ -10,6 +11,11 @@ import com.wavesplatform.dex.model.{AcceptedOrderType, OrderStatus}
 object Codecs {
 
   implicit class ByteBufferExt(val b: ByteBuffer) extends AnyVal {
+
+    def putBytes(array: Array[Byte]): ByteBuffer = {
+      b.put(Ints.toByteArray(array.length))
+      b.put(array)
+    }
 
     def getBytes: Array[Byte] = {
       val len = b.getInt

--- a/dex/src/test/scala/com/wavesplatform/dex/ActorsWebSocketInteractionsSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/ActorsWebSocketInteractionsSpecification.scala
@@ -219,7 +219,7 @@ class ActorsWebSocketInteractionsSpecification
                   status = OrderStatus.PartiallyFilled.name.some,
                   filledAmount = 5.0.some,
                   filledFee = 0.0015.some,
-                  avgFilledPrice = 3.0.some
+                  avgWeighedPrice = 3.0.some
                 )
               )
             )
@@ -281,7 +281,7 @@ class ActorsWebSocketInteractionsSpecification
                   status = OrderStatus.PartiallyFilled.name.some,
                   filledAmount = 10.0.some,
                   filledFee = 0.00000340.some,
-                  avgFilledPrice = 3.0.some
+                  avgWeighedPrice = 3.0.some
                 )
               )
             )
@@ -297,7 +297,7 @@ class ActorsWebSocketInteractionsSpecification
                   status = OrderStatus.PartiallyFilled.name.some,
                   filledAmount = 25.0.some,
                   filledFee = 0.00000850.some,
-                  avgFilledPrice = 3.0.some
+                  avgWeighedPrice = 3.0.some
                 )
               )
             )
@@ -313,7 +313,7 @@ class ActorsWebSocketInteractionsSpecification
                   status = OrderStatus.PartiallyFilled.name.some,
                   filledAmount = 30.0.some,
                   filledFee = 0.00001020.some,
-                  avgFilledPrice = 3.0.some
+                  avgWeighedPrice = 3.0.some
                 )
               )
             )
@@ -475,7 +475,7 @@ class ActorsWebSocketInteractionsSpecification
                       status = OrderStatus.Filled.name.some,
                       filledAmount = 5.0.some,
                       filledFee = 0.003.some,
-                      avgFilledPrice = 3.0.some)
+                      avgWeighedPrice = 3.0.some)
             )
           )
 
@@ -487,7 +487,7 @@ class ActorsWebSocketInteractionsSpecification
                       status = OrderStatus.Filled.name.some,
                       filledAmount = 5.0.some,
                       filledFee = 0.003.some,
-                      avgFilledPrice = 3.1.some)
+                      avgWeighedPrice = 3.1.some)
             )
           )
 
@@ -499,7 +499,7 @@ class ActorsWebSocketInteractionsSpecification
                       status = OrderStatus.PartiallyFilled.name.some,
                       filledAmount = 2.0.some,
                       filledFee = 0.0012.some,
-                      avgFilledPrice = 3.2.some)
+                      avgWeighedPrice = 3.2.some)
             )
           )
 
@@ -550,10 +550,10 @@ class ActorsWebSocketInteractionsSpecification
             Seq(
               WsOrder(
                 id = mo.id,
-                avgFilledPrice = 3.0.some,
+                status = OrderStatus.PartiallyFilled.name.some,
                 filledAmount = 5.0.some,
                 filledFee = 0.00125.some,
-                status = OrderStatus.PartiallyFilled.name.some
+                avgWeighedPrice = 3.0.some
               )
             )
           )
@@ -566,7 +566,7 @@ class ActorsWebSocketInteractionsSpecification
                       status = OrderStatus.PartiallyFilled.name.some,
                       filledAmount = 10.0.some,
                       filledFee = 0.0025.some,
-                      avgFilledPrice = 3.0.some)
+                      avgWeighedPrice = 3.05.some)
             )
           )
 
@@ -579,7 +579,7 @@ class ActorsWebSocketInteractionsSpecification
                 status = OrderStatus.Filled.name.some,
                 filledAmount = 12.0.some,
                 filledFee = 0.003.some,
-                avgFilledPrice = 3.0.some
+                avgWeighedPrice = 3.07.some
               )
             )
           )

--- a/dex/src/test/scala/com/wavesplatform/dex/ActorsWebSocketInteractionsSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/ActorsWebSocketInteractionsSpecification.scala
@@ -90,7 +90,7 @@ class ActorsWebSocketInteractionsSpecification
 
     def placeOrder(ao: AcceptedOrder): Unit = {
       addressDir ! AddressDirectory.Envelope(address, AddressActor.Command.PlaceOrder(ao.order, ao.isMarket))
-      eventsProbe.expectMsg(ao.fold[QueueEvent](QueueEvent.Placed)(QueueEvent.PlacedMarket))
+      eventsProbe.expectMsg(ao match { case lo: LimitOrder => QueueEvent.Placed(lo); case mo: MarketOrder => QueueEvent.PlacedMarket(mo) })
       addressDir ! OrderAdded(ao, System.currentTimeMillis)
     }
 

--- a/dex/src/test/scala/com/wavesplatform/dex/MatcherSpecBase.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/MatcherSpecBase.scala
@@ -1,5 +1,6 @@
 package com.wavesplatform.dex
 
+import java.math.BigInteger
 import java.security.SecureRandom
 import java.util.concurrent.atomic.AtomicLong
 
@@ -265,7 +266,11 @@ trait MatcherSpecBase extends SystemTime with DiffMatcherWithImplicits with Doub
     expiration: Long   <- maxTimeGen
     matcherFee: Long   <- maxWavesAmountGen
     orderVersion: Byte <- Gen.oneOf(1: Byte, 2: Byte)
-  } yield BuyLimitOrder(amount, matcherFee, Order.buy(sender, MatcherAccount, pair, amount, price, timestamp, expiration, matcherFee, orderVersion))
+  } yield
+    BuyLimitOrder(amount,
+                  matcherFee,
+                  Order.buy(sender, MatcherAccount, pair, amount, price, timestamp, expiration, matcherFee, orderVersion),
+                  BigInteger.ZERO)
 
   protected val sellLimitOrderGenerator: Gen[SellLimitOrder] = for {
     sender: KeyPair    <- accountGen
@@ -276,7 +281,11 @@ trait MatcherSpecBase extends SystemTime with DiffMatcherWithImplicits with Doub
     expiration: Long   <- maxTimeGen
     matcherFee: Long   <- maxWavesAmountGen
     orderVersion: Byte <- Gen.oneOf(1: Byte, 2: Byte)
-  } yield SellLimitOrder(amount, matcherFee, Order.sell(sender, MatcherAccount, pair, amount, price, timestamp, expiration, matcherFee, orderVersion))
+  } yield
+    SellLimitOrder(amount,
+                   matcherFee,
+                   Order.sell(sender, MatcherAccount, pair, amount, price, timestamp, expiration, matcherFee, orderVersion),
+                   BigInteger.ZERO)
 
   protected val limitOrderGenerator: Gen[LimitOrder] = Gen.oneOf(sellLimitOrderGenerator, buyLimitOrderGenerator)
 

--- a/dex/src/test/scala/com/wavesplatform/dex/api/websockets/WebSocketMessagesSerdeSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/api/websockets/WebSocketMessagesSerdeSpecification.scala
@@ -1,5 +1,7 @@
 package com.wavesplatform.dex.api.websockets
 
+import java.math.BigInteger
+
 import com.softwaremill.diffx.Diff
 import com.wavesplatform.dex.api.http.PlayJsonException
 import com.wavesplatform.dex.api.websockets.WsOrderBook.WsSide
@@ -39,8 +41,8 @@ class WebSocketMessagesSerdeSpecification extends AnyFreeSpec with ScalaCheckDri
     val ao = (isNew, isMarket) match {
       case (true, true)   => MarketOrder(order, _ => Long.MaxValue)
       case (true, false)  => LimitOrder(order)
-      case (false, true)  => MarketOrder(order, _ => Long.MaxValue).partial(partialAmount, partialFee, Long.MaxValue)
-      case (false, false) => LimitOrder(order).partial(partialAmount, partialFee)
+      case (false, true)  => MarketOrder(order, _ => Long.MaxValue).partial(partialAmount, partialFee, Long.MaxValue, BigInteger.valueOf(order.price))
+      case (false, false) => LimitOrder(order).partial(partialAmount, partialFee, BigInteger.valueOf(order.price))
     }
 
     val result = WsOrder.fromDomain(ao, AddressActor.activeStatus(ao))

--- a/dex/src/test/scala/com/wavesplatform/dex/gen/OrderBookGen.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/gen/OrderBookGen.scala
@@ -1,5 +1,6 @@
 package com.wavesplatform.dex.gen
 
+import java.math.BigInteger
 import java.nio.charset.StandardCharsets
 
 import com.wavesplatform.dex.domain.account.KeyPair
@@ -73,8 +74,8 @@ trait OrderBookGen {
     } yield {
       val restFee = AcceptedOrder.partialFee(order.matcherFee, order.amount, restAmount)
       order.orderType match {
-        case OrderType.SELL => SellLimitOrder(restAmount, restFee, order)
-        case OrderType.BUY  => BuyLimitOrder(restAmount, restFee, order)
+        case OrderType.SELL => SellLimitOrder(restAmount, restFee, order, BigInteger.valueOf(order.price))
+        case OrderType.BUY  => BuyLimitOrder(restAmount, restFee, order, BigInteger.valueOf(order.price))
       }
     }
 
@@ -84,8 +85,8 @@ trait OrderBookGen {
       availableForSpending <- Gen.choose(minAmount(order.price), order.amount)
     } yield {
       order.orderType match {
-        case OrderType.SELL => SellMarketOrder(order.amount, order.matcherFee, order, availableForSpending)
-        case OrderType.BUY  => BuyMarketOrder(order.amount, order.matcherFee, order, availableForSpending)
+        case OrderType.SELL => SellMarketOrder(order.amount, order.matcherFee, order, availableForSpending, BigInteger.valueOf(order.price))
+        case OrderType.BUY  => BuyMarketOrder(order.amount, order.matcherFee, order, availableForSpending, BigInteger.valueOf(order.price))
       }
     }
 

--- a/dex/src/test/scala/com/wavesplatform/dex/market/OrderBookActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/market/OrderBookActorSpecification.scala
@@ -151,12 +151,15 @@ class OrderBookActorSpecification
 
       actor ! RestartActor
       tp.expectMsg(
-        OrderAdded(SellLimitOrder(
-                     ord2.amount - ord1.amount,
-                     ord2.matcherFee - AcceptedOrder.partialFee(ord2.matcherFee, ord2.amount, ord1.amount),
-                     ord2
-                   ),
-                   ord2.timestamp)
+        OrderAdded(
+          SellLimitOrder(
+            ord2.amount - ord1.amount,
+            ord2.matcherFee - AcceptedOrder.partialFee(ord2.matcherFee, ord2.amount, ord1.amount),
+            ord2,
+            (BigInt(10) * Order.PriceConstant * 100 * Order.PriceConstant).bigInteger
+          ),
+          ord2.timestamp
+        )
       )
       tp.expectMsgType[OrderBookRecovered]
     }
@@ -177,12 +180,15 @@ class OrderBookActorSpecification
 
       val restAmount = ord1.amount + ord2.amount - ord3.amount
       tp.expectMsg(
-        OrderAdded(BuyLimitOrder(
-                     restAmount,
-                     ord2.matcherFee - AcceptedOrder.partialFee(ord2.matcherFee, ord2.amount, ord2.amount - restAmount),
-                     ord2
-                   ),
-                   ord2.timestamp)
+        OrderAdded(
+          BuyLimitOrder(
+            restAmount,
+            ord2.matcherFee - AcceptedOrder.partialFee(ord2.matcherFee, ord2.amount, ord2.amount - restAmount),
+            ord2,
+            (BigInt(2) * Order.PriceConstant * 100 * Order.PriceConstant).bigInteger
+          ),
+          ord2.timestamp
+        )
       )
       tp.expectMsgType[OrderBookRecovered]
     }
@@ -209,10 +215,12 @@ class OrderBookActorSpecification
           SellLimitOrder(
             restAmount,
             ord2.matcherFee - AcceptedOrder.partialFee(ord2.matcherFee, ord2.amount, ord2.amount - restAmount),
-            ord2
+            ord2,
+            (BigInt(4) * Order.PriceConstant * 100 * Order.PriceConstant).bigInteger
           ),
           ord2.timestamp
-        ))
+        )
+      )
       tp.expectMsgType[OrderBookRecovered]
     }
 

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderBookSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderBookSpec.scala
@@ -209,7 +209,7 @@ ${updatedOb.aggregatedSnapshot}
     "result.levelChanges.prices == all(event.executedPrice)" in forAll(coinsInvariantPropGen) {
       case (askOrders, bidOrders, newOrder) =>
         val ob                                = mkOrderBook(askOrders, bidOrders)
-        val (updatedOb, events, levelChanges) = ob.add(newOrder, ts, getMakerTakerFee = (o1, o2) => (o1.matcherFee, o2.matcherFee))
+        val (updatedOb, events, levelChanges) = ob.add(newOrder, ts, _.matcherFee -> _.matcherFee)
 
         val levelChangesPrices = levelChanges.asks.keySet ++ levelChanges.bids.keySet
 

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderHistoryBalanceSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderHistoryBalanceSpecification.scala
@@ -1,5 +1,7 @@
 package com.wavesplatform.dex.model
 
+import java.math.BigInteger
+
 import akka.actor.{ActorRef, ActorSystem}
 import akka.pattern.ask
 import akka.testkit.TestKit
@@ -532,7 +534,10 @@ class OrderHistoryBalanceSpecification
     val exec1 = OrderExecuted(LimitOrder(submitted), LimitOrder(counter))
     oh.processAll(
       exec1,
-      OrderCanceled(exec1.counter.partial(exec1.counterRemainingAmount, exec1.counterRemainingFee), isSystemCancel = false, time.getTimestamp()))
+      OrderCanceled(exec1.counter.partial(exec1.counterRemainingAmount, exec1.counterRemainingFee, BigInteger.ZERO),
+                    isSystemCancel = false,
+                    time.getTimestamp())
+    )
 
     orderStatus(counter.id()) shouldBe OrderStatus.Cancelled(1000000000, 142857)
     orderStatus(submitted.id()) shouldBe OrderStatus.Filled(1000000000, 300000)

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderInfoSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderInfoSpec.scala
@@ -9,31 +9,37 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.{ScalaCheckPropertyChecks => PropertyChecks}
 
 class OrderInfoSpec extends AnyFreeSpec with Matchers with MatcherSpecBase with PropertyChecks with NoShrink {
+
   private def finalizedOrderInfoGen(o: Order, orderInfoVersion: Byte): Gen[OrderInfo[OrderStatus.Final]] =
     for {
-      filledAmount <- Gen.choose(0, o.amount)
-      filledFee    <- if (orderInfoVersion == 1) Gen.const((BigInt(filledAmount) * 300000 / o.amount).toLong) else Gen.choose(0, o.matcherFee)
-      status       <- Gen.oneOf(OrderStatus.Filled(filledAmount, filledFee), OrderStatus.Cancelled(filledAmount, filledFee))
-    } yield o.toInfo(orderInfoVersion, status)
+      filledAmount    <- Gen.choose(0, o.amount)
+      filledFee       <- if (orderInfoVersion == 1) Gen.const((BigInt(filledAmount) * 300000 / o.amount).toLong) else Gen.choose(0, o.matcherFee)
+      status          <- Gen.oneOf(OrderStatus.Filled(filledAmount, filledFee), OrderStatus.Cancelled(filledAmount, filledFee))
+      aoType          <- if (orderInfoVersion <= 2) Gen.const(AcceptedOrderType.Limit) else Gen.oneOf(AcceptedOrderType.Limit, AcceptedOrderType.Market)
+      avgWeighedPrice <- if (orderInfoVersion <= 3) Gen.const(o.price) else Gen.choose(0, o.price)
+    } yield o.toInfo(orderInfoVersion, status, aoType, avgWeighedPrice)
 
   private val finalizedOrderInfoGen: Gen[OrderInfo[OrderStatus.Final]] = for {
     (o, _) <- orderGenerator
-    v      <- Gen.choose[Byte](1, 2)
+    v      <- Gen.choose[Byte](1, 4)
     result <- finalizedOrderInfoGen(o, v)
   } yield result
 
   "OrderInfo" - {
     "x == decode(encode(x))" in forAll(finalizedOrderInfoGen) { oi =>
-      OrderInfo.decode(OrderInfo.encode(oi)) == oi
+      OrderInfo.decode(OrderInfo encode oi) == oi
     }
   }
 }
 
 object OrderInfoSpec {
+
   implicit class OrderExt(val o: Order) extends AnyVal {
-    def toInfo[A <: OrderStatus](version: Byte, status: A) = version match {
+    def toInfo[A <: OrderStatus](version: Byte, status: A, aoType: AcceptedOrderType, avgWeighedPrice: Long): OrderInfo[A] = version match {
       case 1 => OrderInfo.v1[A](o.orderType, o.amount, o.price, o.timestamp, status, o.assetPair)
       case 2 => OrderInfo.v2[A](o.orderType, o.amount, o.price, o.matcherFee, o.feeAsset, o.timestamp, status, o.assetPair)
+      case 3 => OrderInfo.v3[A](o.orderType, o.amount, o.price, o.matcherFee, o.feeAsset, o.timestamp, status, o.assetPair, aoType)
+      case 4 => OrderInfo.v4[A](o.orderType, o.amount, o.price, o.matcherFee, o.feeAsset, o.timestamp, status, o.assetPair, aoType, avgWeighedPrice)
     }
   }
 }

--- a/waves-integration/src/main/scala/com/wavesplatform/dex/domain/order/Order.scala
+++ b/waves-integration/src/main/scala/com/wavesplatform/dex/domain/order/Order.scala
@@ -164,11 +164,11 @@ object Order extends EntityParser[Order] {
 
   type Id = ByteStr
 
-  val MaxLiveTime: Long     = 30L * 24L * 60L * 60L * 1000L
-  val PriceConstantExponent = 8
-  val PriceConstantDecimal  = java.math.BigDecimal.ONE.scaleByPowerOfTen(PriceConstantExponent)
-  val PriceConstant         = PriceConstantDecimal.longValue()
-  val MaxAmount: Long       = 100 * PriceConstant * PriceConstant
+  val MaxLiveTime: Long                          = 30L * 24L * 60L * 60L * 1000L
+  val PriceConstantExponent: Int                 = 8
+  val PriceConstantDecimal: java.math.BigDecimal = java.math.BigDecimal.ONE.scaleByPowerOfTen(PriceConstantExponent)
+  val PriceConstant: Long                        = PriceConstantDecimal.longValue()
+  val MaxAmount: Long                            = 100 * PriceConstant * PriceConstant
 
   def apply(senderPublicKey: PublicKey,
             matcherPublicKey: PublicKey,


### PR DESCRIPTION
 * AcceptedOrder has been enriched with avgWeighedPriceNominator. Dividing this by filledAmount we got avgWeighedPrice
 * OrderInfo v4 has been introduced (it has new field avgWeighedPrice). For old orders avgWeighedPrice will be equal to order price
 * AddressActor uses OrderInfo v4 and sends correct avgWeighedPrice via WebSockets
 * OrderBookSideSnapshot got new serialization of LimitOrder with backward compatibility
 * Unit and it-tests have been added

Miscellaneous

 * limitOrderFormat has been removed from OrderBook
 * AcceptedOrder.fold removed