### PR TITLE
DEX-661 REST API improvements

### DIFF
--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/BaseContainersKit.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/BaseContainersKit.scala
@@ -78,6 +78,16 @@ trait BaseContainersKit extends ScorexLogging {
 
   protected implicit val tryHttpBackend: LoggingSttpBackend[Try, Nothing] = new LoggingSttpBackend[Try, Nothing](
     TryHttpURLConnectionBackend(customizeConnection = conn => {
+      conn.setConnectTimeout(10000)
+      conn.setReadTimeout(10000)
+
+      conn.setDefaultUseCaches(false)
+      conn.setUseCaches(false)
+      conn.setRequestProperty("Cache-Control", "no-store")
+      conn.setRequestProperty("Pragma", "no-cache")
+      conn.setRequestProperty("If-Modified-Since", "Sat, 1 Jan 2000 00:00:00 GMT")
+      conn.setRequestProperty("Expired", "0")
+
       if (conn.getRequestMethod == "POST" && conn.getDoOutput) conn.setChunkedStreamingMode(0)
     })
   )

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/BaseContainersKit.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/BaseContainersKit.scala
@@ -78,8 +78,9 @@ trait BaseContainersKit extends ScorexLogging {
 
   protected implicit val tryHttpBackend: LoggingSttpBackend[Try, Nothing] = new LoggingSttpBackend[Try, Nothing](
     TryHttpURLConnectionBackend(customizeConnection = conn => {
-      conn.setConnectTimeout(10000)
-      conn.setReadTimeout(10000)
+      // For tests with a high latency
+      conn.setConnectTimeout(30000)
+      conn.setReadTimeout(30000)
 
       conn.setDefaultUseCaches(false)
       conn.setUseCaches(false)

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/BaseContainersKit.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/BaseContainersKit.scala
@@ -82,6 +82,7 @@ trait BaseContainersKit extends ScorexLogging {
       conn.setConnectTimeout(30000)
       conn.setReadTimeout(30000)
 
+      // This block of code to figh caches. It seems this doesn't help on macOS, but works on CI
       conn.setDefaultUseCaches(false)
       conn.setUseCaches(false)
       conn.setRequestProperty("Cache-Control", "no-store")

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/dex/DexApi.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/dex/DexApi.scala
@@ -43,10 +43,12 @@ trait DexApi[F[_]] extends HasWaitReady[F] {
 
   def tryCancel(owner: KeyPair, order: Order): F[Either[MatcherError, MatcherStatusResponse]] = tryCancel(owner, order.assetPair, order.id())
   def tryCancel(owner: KeyPair, assetPair: AssetPair, id: Order.Id): F[Either[MatcherError, MatcherStatusResponse]]
-
   def tryCancelWithApiKey(id: Order.Id): F[Either[MatcherError, MatcherStatusResponse]]
-  def tryCancelAll(owner: KeyPair, timestamp: Long = System.currentTimeMillis): F[Either[MatcherError, Unit]]                             // TODO
-  def tryCancelAllByPair(owner: KeyPair, assetPair: AssetPair, timestamp: Long = System.currentTimeMillis): F[Either[MatcherError, Unit]] // TODO
+
+  // TODO Response type in DEX-548
+  def tryCancelAll(owner: KeyPair, timestamp: Long = System.currentTimeMillis): F[Either[MatcherError, Unit]]
+  def tryCancelAllByPair(owner: KeyPair, assetPair: AssetPair, timestamp: Long = System.currentTimeMillis): F[Either[MatcherError, Unit]]
+  def tryCancelAllByIdsWithApiKey(owner: PublicKey): F[Either[MatcherError, Unit]]
 
   def tryOrderStatus(order: Order): F[Either[MatcherError, OrderStatusResponse]] = tryOrderStatus(order.assetPair, order.id())
   def tryOrderStatus(assetPair: AssetPair, id: Order.Id): F[Either[MatcherError, OrderStatusResponse]]
@@ -54,20 +56,20 @@ trait DexApi[F[_]] extends HasWaitReady[F] {
   def tryTransactionsByOrder(id: Order.Id): F[Either[MatcherError, List[ExchangeTransaction]]]
 
   /**
-   * param @activeOnly Server treats this parameter as false if it wasn't specified
-   */
+    * param @activeOnly Server treats this parameter as false if it wasn't specified
+    */
   def tryOrderHistory(owner: KeyPair,
                       activeOnly: Option[Boolean] = None,
                       timestamp: Long = System.currentTimeMillis): F[Either[MatcherError, List[OrderBookHistoryItem]]]
 
   /**
-   * param @activeOnly Server treats this parameter as true if it wasn't specified
-   */
+    * param @activeOnly Server treats this parameter as true if it wasn't specified
+    */
   def tryOrderHistoryWithApiKey(owner: Address, activeOnly: Option[Boolean] = None): F[Either[MatcherError, List[OrderBookHistoryItem]]]
 
   /**
-   * param @activeOnly Server treats this parameter as false if it wasn't specified
-   */
+    * param @activeOnly Server treats this parameter as false if it wasn't specified
+    */
   def tryOrderHistoryByPair(owner: KeyPair,
                             assetPair: AssetPair,
                             activeOnly: Option[Boolean] = None,
@@ -203,6 +205,14 @@ object DexApi {
         sttp
           .post(uri"$apiUri/orderbook/${assetPair.amountAssetStr}/${assetPair.priceAssetStr}/cancel")
           .body(body)
+          .contentType("application/json", "UTF-8")
+      }
+
+      override def tryCancelAllByIdsWithApiKey(owner: PublicKey): F[Either[MatcherError, Unit]] = tryUnit {
+        sttp
+          .post(uri"$apiUri/orders/cancel")
+          .headers(apiKeyHeaders)
+          .headers(userPublicKeyHeaders(owner))
           .contentType("application/json", "UTF-8")
       }
 
@@ -401,6 +411,7 @@ object DexApi {
         "Signature" -> Base58.encode(crypto.sign(owner, owner.publicKey ++ Longs.toByteArray(timestamp)))
       )
 
-      private val apiKeyHeaders: Map[String, String] = Map("X-API-Key" -> apiKey)
+      private val apiKeyHeaders: Map[String, String]                      = Map("X-API-Key"         -> apiKey)
+      private def userPublicKeyHeaders(x: PublicKey): Map[String, String] = Map("X-User-Public-Key" -> x.base58)
     }
 }

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/dex/DexApi.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/dex/DexApi.scala
@@ -48,7 +48,7 @@ trait DexApi[F[_]] extends HasWaitReady[F] {
   // TODO Response type in DEX-548
   def tryCancelAll(owner: KeyPair, timestamp: Long = System.currentTimeMillis): F[Either[MatcherError, Unit]]
   def tryCancelAllByPair(owner: KeyPair, assetPair: AssetPair, timestamp: Long = System.currentTimeMillis): F[Either[MatcherError, Unit]]
-  def tryCancelAllByIdsWithApiKey(owner: PublicKey, orderIds: Set[Order.Id]): F[Either[MatcherError, Unit]]
+  def tryCancelAllByIdsWithApiKey(owner: Address, orderIds: Set[Order.Id]): F[Either[MatcherError, Unit]]
 
   def tryOrderStatus(order: Order): F[Either[MatcherError, OrderStatusResponse]] = tryOrderStatus(order.assetPair, order.id())
   def tryOrderStatus(assetPair: AssetPair, id: Order.Id): F[Either[MatcherError, OrderStatusResponse]]
@@ -208,11 +208,10 @@ object DexApi {
           .contentType("application/json", "UTF-8")
       }
 
-      override def tryCancelAllByIdsWithApiKey(owner: PublicKey, orderIds: Set[Order.Id]): F[Either[MatcherError, Unit]] = tryUnit {
+      override def tryCancelAllByIdsWithApiKey(owner: Address, orderIds: Set[Order.Id]): F[Either[MatcherError, Unit]] = tryUnit {
         sttp
-          .post(uri"$apiUri/orders/cancel")
+          .post(uri"$apiUri/orders/$owner/cancel")
           .headers(apiKeyHeaders)
-          .headers(userPublicKeyHeaders(owner))
           .body(Json.stringify(Json.toJson(orderIds)))
           .contentType("application/json", "UTF-8")
       }

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/dex/DexApiOps.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/dex/DexApiOps.scala
@@ -42,7 +42,7 @@ object DexApiOps {
       explicitGet(self.tryCancelAllByPair(owner, assetPair, timestamp))
     }
 
-    def cancelAllByIdsWithApiKey(owner: PublicKey, orderIds: Set[Order.Id]): F[Unit] = explicitGet(self.tryCancelAllByIdsWithApiKey(owner, orderIds))
+    def cancelAllByIdsWithApiKey(owner: Address, orderIds: Set[Order.Id]): F[Unit] = explicitGet(self.tryCancelAllByIdsWithApiKey(owner, orderIds))
 
     def orderStatus(order: Order): F[OrderStatusResponse]                       = orderStatus(order.assetPair, order.id())
     def orderStatus(assetPair: AssetPair, id: Order.Id): F[OrderStatusResponse] = explicitGet(self.tryOrderStatus(assetPair, id))

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/dex/DexApiOps.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/dex/DexApiOps.scala
@@ -32,15 +32,17 @@ object DexApiOps {
     def cancel(owner: KeyPair, order: Order): F[MatcherStatusResponse]                       = cancel(owner, order.assetPair, order.id())
     def cancel(owner: KeyPair, assetPair: AssetPair, id: Order.Id): F[MatcherStatusResponse] = explicitGet(self.tryCancel(owner, assetPair, id))
 
-    def cancelWithApiKey(order: Order): F[MatcherStatusResponse] = cancelWithApiKey(order.id())
-    def cancelWithApiKey(id: Order.Id): F[MatcherStatusResponse] = explicitGet(self.tryCancelWithApiKey(id))
+    def cancelWithApiKey(order: Order, xUserPublicKey: Option[PublicKey] = None): F[MatcherStatusResponse] =
+      cancelWithApiKey(order.id(), xUserPublicKey)
+    def cancelWithApiKey(id: Order.Id, xUserPublicKey: Option[PublicKey]): F[MatcherStatusResponse] =
+      explicitGet(self.tryCancelWithApiKey(id, xUserPublicKey))
 
     def cancelAll(owner: KeyPair, timestamp: Long = System.currentTimeMillis()): F[Unit] = explicitGet(self.tryCancelAll(owner, timestamp))
     def cancelAllByPair(owner: KeyPair, assetPair: AssetPair, timestamp: Long = System.currentTimeMillis()): F[Unit] = {
       explicitGet(self.tryCancelAllByPair(owner, assetPair, timestamp))
     }
 
-    def cancelAllByIdsWithApiKey(owner: PublicKey): F[Unit] = explicitGet(self.tryCancelAllByIdsWithApiKey(owner))
+    def cancelAllByIdsWithApiKey(owner: PublicKey, orderIds: Set[Order.Id]): F[Unit] = explicitGet(self.tryCancelAllByIdsWithApiKey(owner, orderIds))
 
     def orderStatus(order: Order): F[OrderStatusResponse]                       = orderStatus(order.assetPair, order.id())
     def orderStatus(assetPair: AssetPair, id: Order.Id): F[OrderStatusResponse] = explicitGet(self.tryOrderStatus(assetPair, id))

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/dex/DexApiOps.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/dex/DexApiOps.scala
@@ -40,6 +40,8 @@ object DexApiOps {
       explicitGet(self.tryCancelAllByPair(owner, assetPair, timestamp))
     }
 
+    def cancelAllByIdsWithApiKey(owner: PublicKey): F[Unit] = explicitGet(self.tryCancelAllByIdsWithApiKey(owner))
+
     def orderStatus(order: Order): F[OrderStatusResponse]                       = orderStatus(order.assetPair, order.id())
     def orderStatus(assetPair: AssetPair, id: Order.Id): F[OrderStatusResponse] = explicitGet(self.tryOrderStatus(assetPair, id))
 

--- a/dex-it/src/test/resources/dex-servers/dex-base.conf
+++ b/dex-it/src/test/resources/dex-servers/dex-base.conf
@@ -24,9 +24,7 @@ waves.dex {
     caches.default-expiration = 10ms
   }
 
-  order-book-snapshot-http-cache {
-    cache-timeout = 1ms
-  }
+  order-book-snapshot-http-cache.cache-timeout = 1ms
 
   rest-order-limit = 10
 

--- a/dex-it/src/test/resources/dex-servers/dex-base.conf
+++ b/dex-it/src/test/resources/dex-servers/dex-base.conf
@@ -24,6 +24,10 @@ waves.dex {
     caches.default-expiration = 10ms
   }
 
+  order-book-snapshot-http-cache {
+    cache-timeout = 1ms
+  }
+
   rest-order-limit = 10
 
   events-queue {

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/CancelOrderTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/CancelOrderTestSuite.scala
@@ -124,7 +124,7 @@ class CancelOrderTestSuite extends MatcherSuiteBase {
         val order = mkBobOrder
         placeAndAwaitAtDex(order)
 
-        dex1.api.tryCancelWithApiKey(order.id(), Some(alice.publicKey)) should failWith(9437193)
+        dex1.api.tryCancelWithApiKey(order.id(), Some(alice.publicKey)) should failWith(9437193) // OrderNotFound
         dex1.api.cancelWithApiKey(order)
         dex1.api.waitForOrderStatus(order, OrderStatus.Cancelled)
       }

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/CancelOrderTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/CancelOrderTestSuite.scala
@@ -190,7 +190,7 @@ class CancelOrderTestSuite extends MatcherSuiteBase {
     }
 
     // DEX-548
-    "returns a rejected orders if an owner is invalid" in {
+    "returns a rejected orders if an owner is invalid" ignore {
       val orders = mkBobOrders(wavesUsdPair)
       orders.foreach(dex1.api.place)
       orders.foreach(dex1.api.waitForOrderStatus(_, OrderStatus.Accepted))

--- a/dex/src/main/scala/com/wavesplatform/dex/AddressActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/AddressActor.scala
@@ -122,7 +122,7 @@ class AddressActor(owner: Address,
       val allActiveOrderIds = getActiveLimitOrders(None).map(_.order.id()).toSet
       val toCancelIds       = allActiveOrderIds.intersect(command.orderIds)
       val unknownIds        = command.orderIds -- allActiveOrderIds
-      log.debug(s"Got $command, to cancel: ${toCancelIds.mkString(", ")}, unknownIds: ${unknownIds.mkString(", ")}")
+      log.debug(s"Got $command, to cancel: ${toCancelIds.mkString(", ")}, unknown ids: ${unknownIds.mkString(", ")}")
 
       val initResponse = unknownIds.map(id => id -> api.OrderCancelRejected(error.OrderNotFound(id))).toMap
       if (toCancelIds.isEmpty) sender ! api.BatchCancelCompleted(initResponse)
@@ -221,7 +221,7 @@ class AddressActor(owner: Address,
         }
       }
       val isActive = activeOrders.contains(id)
-      log.trace(s"OrderCanceled($id, system=$isSystemCancel, isActive=$isActive)")
+      log.trace(s"Got OrderCanceled($id, system=$isSystemCancel, isActive=$isActive)")
       if (isActive) handleOrderTerminated(ao, OrderStatus.finalStatus(ao, isSystemCancel))
 
     case CancelExpiredOrder(id) =>

--- a/dex/src/main/scala/com/wavesplatform/dex/AddressActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/AddressActor.scala
@@ -120,7 +120,7 @@ class AddressActor(owner: Address,
 
     case command: Command.CancelOrders =>
       val allActiveOrderIds = getActiveLimitOrders(None).map(_.order.id()).toSet
-      val toCancelIds       = allActiveOrderIds -- command.orderIds
+      val toCancelIds       = allActiveOrderIds.intersect(command.orderIds)
       val unknownIds        = command.orderIds -- allActiveOrderIds
       log.debug(s"Got $command, to cancel: ${toCancelIds.mkString(", ")}, unknownIds: ${unknownIds.mkString(", ")}")
 

--- a/dex/src/main/scala/com/wavesplatform/dex/api/MatcherApiRoute.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/MatcherApiRoute.scala
@@ -26,14 +26,7 @@ import com.wavesplatform.dex.domain.utils.ScorexLogging
 import com.wavesplatform.dex.effect.FutureResult
 import com.wavesplatform.dex.error.MatcherError
 import com.wavesplatform.dex.grpc.integration.exceptions.WavesNodeConnectionLostException
-import com.wavesplatform.dex.market.MatcherActor.{
-  ForceSaveSnapshots,
-  ForceStartOrderBook,
-  GetMarkets,
-  GetSnapshotOffsets,
-  MarketData,
-  SnapshotOffsetsResponse
-}
+import com.wavesplatform.dex.market.MatcherActor.{ForceSaveSnapshots, ForceStartOrderBook, GetMarkets, GetSnapshotOffsets, MarketData, SnapshotOffsetsResponse}
 import com.wavesplatform.dex.market.OrderBookActor._
 import com.wavesplatform.dex.metrics.TimerExt
 import com.wavesplatform.dex.model._
@@ -708,9 +701,9 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
   def forceCancelOrder: Route = (path("orders" / "cancel" / ByteStrPM) & post & withAuth & withUserPublicKeyOpt) { (orderId, userPublicKey) =>
     def reject = complete(OrderCancelRejected(error.OrderNotFound(orderId)))
     (DBUtils.order(db, orderId), userPublicKey) match {
-      case (None, _)                                               => reject
-      case (Some(order), Some(pk)) if pk.toAddress != order.sender => reject
-      case (Some(order), _)                                        => handleCancelRequest(None, order.sender, Some(orderId), None)
+      case (None, _)                                                         => reject
+      case (Some(order), Some(pk)) if pk.toAddress != order.sender.toAddress => reject
+      case (Some(order), _)                                                  => handleCancelRequest(None, order.sender, Some(orderId), None)
     }
   }
 

--- a/dex/src/main/scala/com/wavesplatform/dex/api/MatcherApiRoute.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/MatcherApiRoute.scala
@@ -517,7 +517,7 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
     handleCancelRequest(None)
   }
 
-  @Path("/orderbook/{address}/cancel")
+  @Path("/orders/{address}/cancel")
   @ApiOperation(
     value = "Cancel active orders by IDs",
     httpMethod = "POST",
@@ -528,13 +528,13 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
   )
   @ApiImplicitParams(
     Array(
+      new ApiImplicitParam(name = "address", value = "Address", dataType = "string", paramType = "path"),
       new ApiImplicitParam(
         name = "body",
         value = "Json array with order ids",
         required = true,
         paramType = "body",
-        dataTypeClass = classOf[Set[String]],
-        defaultValue = "[]"
+        dataTypeClass = classOf[Array[String]]
       ),
     )
   )

--- a/dex/src/main/scala/com/wavesplatform/dex/api/MatcherApiRoute.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/MatcherApiRoute.scala
@@ -541,7 +541,7 @@ case class MatcherApiRoute(assetPairBuilder: AssetPairBuilder,
   def cancelAllById: Route = (path("orders" / AddressPM / "cancel") & post & withAuth) { address =>
     entity(as[Set[ByteStr]]) { xs =>
       complete { askAddressActor(address, AddressActor.Command.CancelOrders(xs)) }
-    } ~ complete(StatusCodes.BadRequest)
+    }
   }
 
   @Path("/orderbook/{amountAsset}/{priceAsset}/delete")

--- a/dex/src/main/scala/com/wavesplatform/dex/api/http/AuthRoute.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/http/AuthRoute.scala
@@ -34,10 +34,4 @@ trait AuthRoute { this: ApiRoute =>
           case Right(x) => provide[Option[PublicKey]](Some(PublicKey(x)))
         }
     }
-
-  def withUserPublicKey(implicit trm: ToResponseMarshaller[MatcherResponse]): Directive1[PublicKey] =
-    withUserPublicKeyOpt.flatMap {
-      case None    => complete(SimpleErrorResponse(StatusCodes.BadRequest, UserPublicKeyIsNotValid))
-      case Some(x) => provide(x)
-    }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/api/http/AuthRoute.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/http/AuthRoute.scala
@@ -2,10 +2,11 @@ package com.wavesplatform.dex.api.http
 
 import akka.http.scaladsl.marshalling.ToResponseMarshaller
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.server.Directive0
+import akka.http.scaladsl.server.{Directive0, Directive1}
 import com.wavesplatform.dex.api.{MatcherResponse, SimpleErrorResponse}
+import com.wavesplatform.dex.domain.account.PublicKey
 import com.wavesplatform.dex.domain.crypto
-import com.wavesplatform.dex.error.{ApiKeyIsNotProvided, ApiKeyIsNotValid}
+import com.wavesplatform.dex.error.{ApiKeyIsNotProvided, ApiKeyIsNotValid, UserPublicKeyIsNotValid}
 
 trait AuthRoute { this: ApiRoute =>
 
@@ -23,4 +24,20 @@ trait AuthRoute { this: ApiRoute =>
       }
     }
   }
+
+  def withUserPublicKeyOpt(implicit trm: ToResponseMarshaller[MatcherResponse]): Directive1[Option[PublicKey]] =
+    optionalHeaderValueByType[`X-User-Public-Key`](()).flatMap {
+      case None => provide(None)
+      case Some(rawPublicKey) =>
+        PublicKey.fromBase58String(rawPublicKey.value) match {
+          case Left(_)  => complete(SimpleErrorResponse(StatusCodes.BadRequest, UserPublicKeyIsNotValid))
+          case Right(x) => provide[Option[PublicKey]](Some(PublicKey(x)))
+        }
+    }
+
+  def withUserPublicKey(implicit trm: ToResponseMarshaller[MatcherResponse]): Directive1[PublicKey] =
+    withUserPublicKeyOpt.flatMap {
+      case None    => complete(SimpleErrorResponse(StatusCodes.BadRequest, UserPublicKeyIsNotValid))
+      case Some(x) => provide(x)
+    }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/api/http/`X-Api-Key`.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/http/`X-Api-Key`.scala
@@ -5,10 +5,10 @@ import akka.http.scaladsl.model.headers._
 import scala.util.Try
 
 object `X-Api-Key` extends ModeledCustomHeaderCompanion[`X-Api-Key`] {
-  override final val name: String                     = headerName
-  override def parse(value: String): Try[`X-Api-Key`] = Try(new `X-Api-Key`(value))
+  final val headerName            = "X-API-Key" // Constant that compatible with annotations
+  override final val name: String = headerName
 
-  final val headerName = "X-API-Key" // Constant that compatible with annotations
+  override def parse(value: String): Try[`X-Api-Key`] = Try(new `X-Api-Key`(value))
 }
 
 final class `X-Api-Key`(val value: String) extends ModeledCustomHeader[`X-Api-Key`] {

--- a/dex/src/main/scala/com/wavesplatform/dex/api/http/`X-User-Public-Key`.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/http/`X-User-Public-Key`.scala
@@ -1,0 +1,18 @@
+package com.wavesplatform.dex.api.http
+
+import akka.http.scaladsl.model.headers._
+
+import scala.util.Try
+
+object `X-User-Public-Key` extends ModeledCustomHeaderCompanion[`X-User-Public-Key`] {
+  final val headerName = "X-User-Public-Key"
+  override final val name: String = headerName
+
+  override def parse(value: String): Try[`X-User-Public-Key`] = Try(new `X-User-Public-Key`(value))
+}
+
+final class `X-User-Public-Key`(val value: String) extends ModeledCustomHeader[`X-User-Public-Key`] {
+  override def companion: `X-User-Public-Key`.type = `X-User-Public-Key`
+  override def renderInRequests: Boolean           = true
+  override def renderInResponses: Boolean          = false
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/error/MatcherError.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/error/MatcherError.scala
@@ -456,6 +456,8 @@ case object ApiKeyIsNotProvided
 
 case object ApiKeyIsNotValid extends MatcherError(auth, commonEntity, commonClass, e"Provided API key is not correct")
 
+case object UserPublicKeyIsNotValid extends MatcherError(account, pubKey, broken, e"Provided user public key is not correct")
+
 sealed abstract class Entity(val code: Int)
 object Entity {
   object common  extends Entity(0)

--- a/dex/src/main/scala/com/wavesplatform/dex/market/BatchOrderCancelActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/market/BatchOrderCancelActor.scala
@@ -32,7 +32,7 @@ class BatchOrderCancelActor private (
       val updatedRestOrderIds = restOrderIds - id
       val updatedResponse     = response.updated(id, x)
 
-      if (updatedRestOrderIds.isEmpty) stop(api.BatchCancelCompleted(response), timer)
+      if (updatedRestOrderIds.isEmpty) stop(api.BatchCancelCompleted(updatedResponse), timer)
       else context.become(state(restOrderIds - id, updatedResponse, timer))
 
     // case Terminated(ref) => // Can't terminate before processorActor, because processorActor is a parent

--- a/dex/src/test/scala/com/wavesplatform/dex/api/MatcherApiRouteSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/api/MatcherApiRouteSpec.scala
@@ -287,33 +287,24 @@ class MatcherApiRouteSpec extends RouteSpec("/matcher") with MatcherSpecBase wit
   }
 
   // cancelAllById
-  routePath("/orders/cancel") - {
+  routePath("/orders/{address}/cancel") - {
     val orderId = orderToCancel.id()
 
     "X-Api-Key is required" in test { route =>
-      Post(routePath("/orders/cancel"), HttpEntity(ContentTypes.`application/json`, Json.toJson(Set(orderId)).toString())) ~> route ~> check {
+      Post(
+        routePath(s"/orders/${orderToCancel.sender.toAddress}/cancel"),
+        HttpEntity(ContentTypes.`application/json`, Json.toJson(Set(orderId)).toString())
+      ) ~> route ~> check {
         status shouldEqual StatusCodes.Forbidden
       }
     }
 
-    "X-User-Public-Key is required" in test(
-      { route =>
-        Post(
-          routePath("/orders/cancel"),
-          HttpEntity(ContentTypes.`application/json`, Json.toJson(Set(orderId)).toString())
-        ).withHeaders(RawHeader("X-API-KEY", apiKey)) ~> route ~> check {
-          status shouldEqual StatusCodes.BadRequest
-        }
-      },
-      apiKey
-    )
-
     "sunny day" in test(
       { route =>
         Post(
-          routePath("/orders/cancel"),
+          routePath(s"/orders/${orderToCancel.sender.toAddress}/cancel"),
           HttpEntity(ContentTypes.`application/json`, Json.toJson(Set(orderId)).toString())
-        ).withHeaders(RawHeader("X-API-KEY", apiKey), RawHeader("X-User-Public-Key", orderToCancel.senderPublicKey.base58)) ~> route ~> check {
+        ).withHeaders(RawHeader("X-API-KEY", apiKey)) ~> route ~> check {
           status shouldEqual StatusCodes.OK
         }
       },
@@ -322,7 +313,7 @@ class MatcherApiRouteSpec extends RouteSpec("/matcher") with MatcherSpecBase wit
   }
 
   // forceCancelOrder
-  routePath("/orders/cancel/[orderId]") - {
+  routePath("/orders/cancel/{orderId}") - {
     val orderId = orderToCancel.id()
 
     "X-Api-Key is required" in test { route =>

--- a/dex/src/test/scala/com/wavesplatform/dex/api/MatcherApiRouteSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/api/MatcherApiRouteSpec.scala
@@ -60,6 +60,15 @@ class MatcherApiRouteSpec extends RouteSpec("/matcher") with MatcherSpecBase wit
       }
     }
 
+    "works with an API key too" in test(
+      { route =>
+        Get(routePath(s"/balance/reserved/${Base58.encode(publicKey)}")).withHeaders(RawHeader("X-API-KEY", apiKey)) ~> route ~> check {
+          status shouldBe StatusCodes.OK
+        }
+      },
+      apiKey
+    )
+
     "returns HTTP 400 when provided a wrong base58-encoded" - {
       "signature" in test { route =>
         mkGet(route)(Base58.encode(publicKey), ts, ";;") ~> check {

--- a/dex/src/test/scala/com/wavesplatform/dex/api/MatcherApiRouteSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/api/MatcherApiRouteSpec.scala
@@ -10,7 +10,7 @@ import com.typesafe.config.ConfigFactory
 import com.wavesplatform.dex._
 import com.wavesplatform.dex.api.http.ApiMarshallers._
 import com.wavesplatform.dex.caches.RateCache
-import com.wavesplatform.dex.db.WithDB
+import com.wavesplatform.dex.db.{OrderDB, WithDB}
 import com.wavesplatform.dex.domain.account.KeyPair
 import com.wavesplatform.dex.domain.bytes.codec.Base58
 import com.wavesplatform.dex.domain.crypto
@@ -20,7 +20,7 @@ import com.wavesplatform.dex.settings.MatcherSettings
 import com.wavesplatform.dex.settings.OrderFeeSettings.DynamicSettings
 import org.scalamock.scalatest.PathMockFactory
 import org.scalatest.concurrent.Eventually
-import play.api.libs.json.{JsString, JsValue}
+import play.api.libs.json.{JsString, JsValue, Json}
 
 import scala.concurrent.Future
 import scala.util.Random
@@ -28,9 +28,13 @@ import scala.util.Random
 class MatcherApiRouteSpec extends RouteSpec("/matcher") with MatcherSpecBase with PathMockFactory with Eventually with WithDB {
 
   private val settings       = MatcherSettings.valueReader.read(ConfigFactory.load(), "waves.dex")
+  private val apiKey         = "apiKey"
   private val matcherKeyPair = KeyPair("matcher".getBytes("utf-8"))
   private val smartAsset     = arbitraryAssetGen.sample.get
   private val smartAssetId   = smartAsset.id
+
+  // Will be refactored in DEX-548
+  private val orderToCancel = orderV3Generator.sample.get
 
   private val smartAssetDesc = BriefAssetDescription(
     name = "smart asset",
@@ -75,7 +79,6 @@ class MatcherApiRouteSpec extends RouteSpec("/matcher") with MatcherSpecBase wit
 
   routePath("/settings/rates/{assetId}") - {
 
-    val apiKey    = "apiKey"
     val rateCache = RateCache.inMem
 
     val rate        = 0.0055
@@ -283,6 +286,81 @@ class MatcherApiRouteSpec extends RouteSpec("/matcher") with MatcherSpecBase wit
     }
   }
 
+  // cancelAllById
+  routePath("/orders/cancel") - {
+    val orderId = orderToCancel.id()
+
+    "X-Api-Key is required" in test { route =>
+      Post(routePath("/orders/cancel"), HttpEntity(ContentTypes.`application/json`, Json.toJson(Set(orderId)).toString())) ~> route ~> check {
+        status shouldEqual StatusCodes.Forbidden
+      }
+    }
+
+    "X-User-Public-Key is required" in test(
+      { route =>
+        Post(
+          routePath("/orders/cancel"),
+          HttpEntity(ContentTypes.`application/json`, Json.toJson(Set(orderId)).toString())
+        ).withHeaders(RawHeader("X-API-KEY", apiKey)) ~> route ~> check {
+          status shouldEqual StatusCodes.BadRequest
+        }
+      },
+      apiKey
+    )
+
+    "sunny day" in test(
+      { route =>
+        Post(
+          routePath("/orders/cancel"),
+          HttpEntity(ContentTypes.`application/json`, Json.toJson(Set(orderId)).toString())
+        ).withHeaders(RawHeader("X-API-KEY", apiKey), RawHeader("X-User-Public-Key", orderToCancel.senderPublicKey.base58)) ~> route ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+      },
+      apiKey
+    )
+  }
+
+  // forceCancelOrder
+  routePath("/orders/cancel/[orderId]") - {
+    val orderId = orderToCancel.id()
+
+    "X-Api-Key is required" in test { route =>
+      Post(routePath(s"/orders/cancel/$orderId")) ~> route ~> check {
+        status shouldEqual StatusCodes.Forbidden
+      }
+    }
+
+    "X-User-Public-Key is not required" in test(
+      { route =>
+        Post(routePath(s"/orders/cancel/$orderId")).withHeaders(RawHeader("X-API-KEY", apiKey)) ~> route ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+      },
+      apiKey
+    )
+
+    "X-User-Public-Key is specified, but wrong" in test(
+      { route =>
+        Post(routePath(s"/orders/cancel/$orderId"))
+          .withHeaders(RawHeader("X-API-KEY", apiKey), RawHeader("X-User-Public-Key", matcherKeyPair.publicKey.base58)) ~> route ~> check {
+          status shouldEqual StatusCodes.BadRequest
+        }
+      },
+      apiKey
+    )
+
+    "sunny day" in test(
+      { route =>
+        Post(routePath(s"/orders/cancel/$orderId"))
+          .withHeaders(RawHeader("X-API-KEY", apiKey), RawHeader("X-User-Public-Key", orderToCancel.senderPublicKey.base58)) ~> route ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+      },
+      apiKey
+    )
+  }
+
   private def test[U](f: Route => U, apiKey: String = "", rateCache: RateCache = RateCache.inMem): U = {
 
     val addressActor = TestProbe("address")
@@ -290,11 +368,18 @@ class MatcherApiRouteSpec extends RouteSpec("/matcher") with MatcherSpecBase wit
     addressActor.setAutoPilot { (sender: ActorRef, msg: Any) =>
       msg match {
         case AddressDirectory.Envelope(_, AddressActor.Query.GetReservedBalance) => sender ! AddressActor.Reply.Balance(Map.empty)
-        case _                                                                   =>
+        case AddressDirectory.Envelope(address, command: AddressActor.Command.CancelOrders) if address == orderToCancel.sender.toAddress =>
+          sender ! api.BatchCancelCompleted { command.orderIds.map(id => id -> api.OrderCanceled(id)).toMap }
+        case AddressDirectory.Envelope(address, command: AddressActor.Command.CancelOrder) if address == orderToCancel.sender.toAddress =>
+          sender ! api.OrderCanceled(command.orderId)
+        case _ =>
       }
 
       TestActor.NoAutoPilot
     }
+
+    val odb = OrderDB(settings.orderDb, db)
+    odb.saveOrder(orderToCancel)
 
     val route: Route = MatcherApiRoute(
       assetPairBuilder = new AssetPairBuilder(

--- a/dex/src/test/scala/com/wavesplatform/dex/api/MatcherApiRouteSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/api/MatcherApiRouteSpec.scala
@@ -308,6 +308,18 @@ class MatcherApiRouteSpec extends RouteSpec("/matcher") with MatcherSpecBase wit
       }
     }
 
+    "an invalid body" in test(
+      { route =>
+        Post(
+          routePath(s"/orders/${orderToCancel.sender.toAddress}/cancel"),
+          HttpEntity(ContentTypes.`application/json`, Json.toJson(orderId).toString())
+        ).withHeaders(RawHeader("X-API-KEY", apiKey)) ~> route ~> check {
+          status shouldEqual StatusCodes.BadRequest
+        }
+      },
+      apiKey
+    )
+
     "sunny day" in test(
       { route =>
         Post(


### PR DESCRIPTION
Bug fixes:
* Batch cancels don't return the latest order status;

MatcherApiRoute:
* Added cancelAllById to cancel orders by a list of order ids;
* forceCancelOrder - additional check by X-User-Public-Key if it present;
* reservedBalance - also works by X-Api-Key;

AddressActor: supports CancelOrders;
BatchOrderCancelActor: the final response could be prepared with some initial value (e.g. some orders aren't found among users orders);

Other:
* Added a new error: UserPublicKeyIsNotValid;
* Added X-User-Public-Key to additionally verify some admin requests;

Tests:
* DexApi: added tryCancelAllByIdsWithApiKey;
* Disable caches for sync API;