### PR TITLE
DEX-666 API key in authenticated WS stream

### DIFF
--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/websockets/HasWebSockets.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/websockets/HasWebSockets.scala
@@ -21,6 +21,9 @@ trait HasWebSockets extends BeforeAndAfterAll { _: Suite =>
   implicit protected val system: ActorSystem        = ActorSystem()
   implicit protected val materializer: Materializer = Materializer.matFromSystem(system)
 
+  protected def getBaseBalancesStreamUri(dex: DexContainer): String   = s"127.0.0.1:${dex.restApiAddress.getPort}/ws/accountUpdates/"
+  protected def getBaseOrderBooksStreamUri(dex: DexContainer): String = s"127.0.0.1:${dex.restApiAddress.getPort}/ws/orderbook/"
+
   protected val knownWsConnections: ConcurrentHashMap.KeySetView[WebSocketConnection[_], lang.Boolean] =
     ConcurrentHashMap.newKeySet[WebSocketConnection[_]]()
 
@@ -38,13 +41,13 @@ trait HasWebSockets extends BeforeAndAfterAll { _: Suite =>
     val timestamp     = System.currentTimeMillis()
     val signedMessage = prefix.getBytes(StandardCharsets.UTF_8) ++ client.publicKey.arr ++ Longs.toByteArray(timestamp)
     val signature     = com.wavesplatform.dex.domain.crypto.sign(client, signedMessage)
-    val wsUri         = s"127.0.0.1:${dex.restApiAddress.getPort}/ws/accountUpdates/${client.publicKey}?Timestamp=$timestamp&Signature=$signature"
+    val wsUri         = s"${getBaseBalancesStreamUri(dex)}${client.publicKey}?t=$timestamp&s=$signature"
 
-    new WebSocketAuthenticatedConnection(wsUri)
+    new WebSocketAuthenticatedConnection(wsUri, None)
   }
 
   protected def mkWebSocketOrderBookConnection(assetPair: AssetPair, dex: DexContainer): WebSocketConnection[WsOrderBook] = {
-    val wsUri = s"127.0.0.1:${dex.restApiAddress.getPort}/ws/orderbook/${assetPair.amountAssetStr}/${assetPair.priceAssetStr}"
+    val wsUri = s"${getBaseOrderBooksStreamUri(dex)}${assetPair.amountAssetStr}/${assetPair.priceAssetStr}"
     mkWebSocketConnection(wsUri) { msg =>
       Json.parse(msg.asTextMessage.getStrictText).as[WsOrderBook]
     }

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/websockets/WebSocketAuthenticatedConnection.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/websockets/WebSocketAuthenticatedConnection.scala
@@ -6,8 +6,8 @@ import com.wavesplatform.dex.api.websockets.{WsAddressState, WsBalances, WsOrder
 import com.wavesplatform.dex.domain.asset.Asset
 import play.api.libs.json.Json
 
-class WebSocketAuthenticatedConnection(uri: String)(implicit system: ActorSystem, materializer: Materializer)
-    extends WebSocketConnection[WsAddressState](uri, msg => Json.parse(msg.asTextMessage.getStrictText).as[WsAddressState], true) {
+class WebSocketAuthenticatedConnection(uri: String, apiKey: Option[String])(implicit system: ActorSystem, materializer: Materializer)
+    extends WebSocketConnection[WsAddressState](uri, msg => Json.parse(msg.asTextMessage.getStrictText).as[WsAddressState], true, apiKey) {
 
   def getBalancesChanges: Seq[Map[Asset, WsBalances]] = getMessagesBuffer.map(_.balances).distinct
   def getOrderChanges: Seq[WsOrder]                   = getMessagesBuffer.flatMap(_.orders).distinct

--- a/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/websockets/WebSocketConnection.scala
+++ b/dex-it-common/src/main/scala/com/wavesplatform/dex/it/api/websockets/WebSocketConnection.scala
@@ -21,7 +21,7 @@ class WebSocketConnection[Output](uri: String, parseOutput: Message => Output, t
     materializer: Materializer)
     extends ScorexLogging {
 
-  log.info(s"Connecting to ws://$uri")
+  log.info(s"Connecting to ws://$uri, apiKey = $apiKey")
 
   private val messagesBuffer: ConcurrentLinkedQueue[Output] = new ConcurrentLinkedQueue[Output]()
 

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/api/MatcherWebSocketsTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/api/MatcherWebSocketsTestSuite.scala
@@ -1,15 +1,19 @@
 package com.wavesplatform.it.sync.api
 
+import java.nio.charset.StandardCharsets
+
 import akka.http.scaladsl.model.StatusCodes
 import cats.syntax.option._
+import com.google.common.primitives.Longs
 import com.softwaremill.diffx.{Derived, Diff}
 import com.typesafe.config.{Config, ConfigFactory}
 import com.wavesplatform.dex.api.websockets._
+import com.wavesplatform.dex.api.websockets.headers.{`X-Error-Code`, `X-Error-Message`}
 import com.wavesplatform.dex.domain.asset.Asset
 import com.wavesplatform.dex.domain.asset.Asset.Waves
 import com.wavesplatform.dex.domain.order.OrderType
 import com.wavesplatform.dex.domain.order.OrderType.{BUY, SELL}
-import com.wavesplatform.dex.error.ErrorFormatterContext
+import com.wavesplatform.dex.error.{ApiKeyIsNotValid, ErrorFormatterContext, RequestInvalidSignature}
 import com.wavesplatform.dex.it.api.responses.dex.{OrderStatus => ApiOrderStatus}
 import com.wavesplatform.dex.it.api.websockets.{HasWebSockets, WebSocketAuthenticatedConnection, WebSocketConnection}
 import com.wavesplatform.dex.model.{LimitOrder, OrderStatus}
@@ -101,28 +105,45 @@ class MatcherWebSocketsTestSuite extends MatcherSuiteBase with HasWebSockets wit
 
       val kp = mkKeyPair("JIo6cTep_u3_6ocToHa")
 
-      val uriWithoutParams = s"${getBaseBalancesStreamUri(dex1)}${kp.publicKey}"
-      val uriWithParams    = s"$uriWithoutParams?t=${System.currentTimeMillis}&s=incorrect"
+      val timestamp     = System.currentTimeMillis
+      val signedMessage = "as".getBytes(StandardCharsets.UTF_8) ++ kp.publicKey.arr ++ Longs.toByteArray(timestamp)
 
-      val incorrectKey = "incorrectXApiKey".some
+      val correctSignature   = com.wavesplatform.dex.domain.crypto.sign(kp, signedMessage).base58
+      val incorrectSignature = "incorrectSignature"
+
+      val incorrectKey = "incorrectKey".some
       val correctKey   = com.wavesplatform.dex.it.docker.apiKey.some
       val withoutKey   = Option.empty[String]
+
+      val uriWithoutParams                    = s"${getBaseBalancesStreamUri(dex1)}${kp.publicKey}"
+      def uriWithSignature(signature: String) = s"$uriWithoutParams?t=$timestamp&s=$signature"
 
       forAll(
         Table(
           // format: off
-          ("uri",            "api-key",    "expectedStatus"),
-          (uriWithParams,    incorrectKey, StatusCodes.Forbidden),
-          (uriWithParams,    withoutKey,   StatusCodes.BadRequest),
-          (uriWithParams,    correctKey,   StatusCodes.SwitchingProtocols),
-          (uriWithoutParams, incorrectKey, StatusCodes.Forbidden),
-          (uriWithoutParams, withoutKey,   StatusCodes.NotFound),
-          (uriWithoutParams, correctKey,   StatusCodes.SwitchingProtocols),
+          ("uri",                                "api-key",    "expected status",             "expected error"),
+          (uriWithSignature(incorrectSignature), incorrectKey, StatusCodes.Forbidden,          ApiKeyIsNotValid.some),
+          (uriWithSignature(incorrectSignature), withoutKey,   StatusCodes.BadRequest,         RequestInvalidSignature.some),
+          (uriWithSignature(incorrectSignature), correctKey,   StatusCodes.SwitchingProtocols, None),
+          (uriWithSignature(correctSignature),   incorrectKey, StatusCodes.Forbidden,          ApiKeyIsNotValid.some),
+          (uriWithSignature(correctSignature),   withoutKey,   StatusCodes.SwitchingProtocols, None),
+          (uriWithSignature(correctSignature),   correctKey,   StatusCodes.SwitchingProtocols, None),
+          (uriWithoutParams,                     incorrectKey, StatusCodes.Forbidden,          ApiKeyIsNotValid.some),
+          (uriWithoutParams,                     withoutKey,   StatusCodes.BadRequest,         RequestInvalidSignature.some),
+          (uriWithoutParams,                     correctKey,   StatusCodes.SwitchingProtocols, None)
           // format: on
         )
-      ) { (uri, apiKey, expectedStatus) =>
+      ) { (uri, apiKey, expectedStatus, expectedError) =>
         val connection = new WebSocketAuthenticatedConnection(uri, apiKey)
-        Await.result(connection.getConnectionResponse, 1.second).response.status shouldBe expectedStatus
+        val response   = Await.result(connection.getConnectionResponse, 1.second).response
+
+        response.status shouldBe expectedStatus
+
+        expectedError.fold() { error =>
+          response.getHeader(`X-Error-Message`.name).get.value shouldBe error.message.text
+          response.getHeader(`X-Error-Code`.name).get.value shouldBe error.code.toString
+        }
+
         connection.close()
       }
     }

--- a/dex/src/main/scala/com/wavesplatform/dex/Matcher.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/Matcher.scala
@@ -231,7 +231,7 @@ class Matcher(settings: MatcherSettings)(implicit val actorSystem: ActorSystem) 
         apiKeyHash,
         settings
       ),
-      MatcherWebSocketRoute(addressActors, matcherActor, pairBuilder)
+      MatcherWebSocketRoute(addressActors, matcherActor, pairBuilder, apiKeyHash)
     )
   }
 

--- a/dex/src/main/scala/com/wavesplatform/dex/api/MatcherWebSocketRoute.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/MatcherWebSocketRoute.scala
@@ -5,6 +5,7 @@ import java.nio.charset.StandardCharsets
 import akka.Done
 import akka.actor.ActorRef
 import akka.http.scaladsl.marshalling.{ToResponseMarshallable, ToResponseMarshaller}
+import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.ws.TextMessage
 import akka.http.scaladsl.server.directives.FutureDirectives
 import akka.http.scaladsl.server.{Directive0, Directive1, Route}
@@ -20,7 +21,7 @@ import com.wavesplatform.dex.domain.asset.AssetPair
 import com.wavesplatform.dex.domain.bytes.codec.Base58
 import com.wavesplatform.dex.domain.crypto
 import com.wavesplatform.dex.domain.utils.ScorexLogging
-import com.wavesplatform.dex.error.MatcherError
+import com.wavesplatform.dex.error.{MatcherError, RequestInvalidSignature}
 import com.wavesplatform.dex.market.MatcherActor
 import com.wavesplatform.dex.{AddressActor, AddressDirectory, AssetPairBuilder}
 import io.swagger.annotations.Api
@@ -78,28 +79,40 @@ case class MatcherWebSocketRoute(addressDirectory: ActorRef, matcher: ActorRef, 
       }
       .watchTermination()(handleTermination)
 
-  private def signedGet(prefix: String, publicKey: PublicKey, incorrectSignatureAction: Directive0 = complete(InvalidSignature)): Directive0 =
-    parameters(('t, 's)).tflatMap {
-      case (timestamp, signature) =>
-        Base58
-          .tryDecodeWithLimit(signature)
-          .map { crypto.verify(_, prefix.getBytes(StandardCharsets.UTF_8) ++ publicKey.arr ++ Longs.toByteArray(timestamp.toLong), publicKey) } match {
-          case Success(true) => pass
-          case _             => incorrectSignatureAction
-        }
-    }
+  private def createStreamFor(source: Source[TextMessage.Strict, Unit]): Route = {
+    handleWebSocketMessages(Flow.fromSinkAndSourceCoupled(Sink.ignore, source))
+  }
+
+  private def signedGet(prefix: String, publicKey: PublicKey): Directive0 = {
+    val invalidSignatureResponse = complete(RequestInvalidSignature toWsHttpResponse StatusCodes.BadRequest)
+
+    val directive: Directive0 =
+      parameters(('t, 's)).tflatMap {
+        case (timestamp, signature) =>
+          Base58
+            .tryDecodeWithLimit(signature)
+            .map {
+              crypto.verify(_, prefix.getBytes(StandardCharsets.UTF_8) ++ publicKey.arr ++ Longs.toByteArray(timestamp.toLong), publicKey)
+            } match {
+            case Success(true) => pass
+            case _             => invalidSignatureResponse
+          }
+      }
+
+    directive.recover(_ => invalidSignatureResponse)
+  }
 
   /** Requires PublicKey, Timestamp and Signature of [prefix `as`, PublicKey, Timestamp] */
   private def accountUpdates: Route = (path("accountUpdates" / PublicKeyPM) & get) { publicKey =>
     val directive = optionalHeaderValueByName(`X-Api-Key`.name).flatMap { maybeKey =>
-      if (maybeKey.isDefined) signedGet(balanceStreamPrefix, publicKey, reject) | withAuth else signedGet(balanceStreamPrefix, publicKey)
+      if (maybeKey.isDefined) withAuth else signedGet(balanceStreamPrefix, publicKey)
     }
-    directive { handleWebSocketMessages(Flow.fromSinkAndSourceCoupled(Sink.ignore, accountUpdatesSource(publicKey))) }
+    directive { createStreamFor(accountUpdatesSource(publicKey)) }
   }
 
   private val orderBook: Route = (path("orderbook" / AssetPairPM) & get) { p =>
     withAssetPair(p) { pair =>
-      handleWebSocketMessages(Flow.fromSinkAndSourceCoupled(Sink.ignore, orderBookUpdatesSource(pair)))
+      createStreamFor(orderBookUpdatesSource(pair))
     }
   }
 

--- a/dex/src/main/scala/com/wavesplatform/dex/api/http/AuthRoute.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/http/AuthRoute.scala
@@ -1,24 +1,30 @@
 package com.wavesplatform.dex.api.http
 
-import akka.http.scaladsl.marshalling.ToResponseMarshaller
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.marshalling.{ToResponseMarshallable, ToResponseMarshaller}
+import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import akka.http.scaladsl.server.Directive0
-import com.wavesplatform.dex.api.{MatcherResponse, SimpleErrorResponse}
+import com.wavesplatform.dex.api.{MatcherResponse, MatcherWebSocketRoute, SimpleErrorResponse}
 import com.wavesplatform.dex.domain.crypto
-import com.wavesplatform.dex.error.{ApiKeyIsNotProvided, ApiKeyIsNotValid}
+import com.wavesplatform.dex.error.{ApiKeyIsNotProvided, ApiKeyIsNotValid, MatcherError}
 
 trait AuthRoute { this: ApiRoute =>
 
   protected val apiKeyHash: Option[Array[Byte]]
 
   def withAuth(implicit trm: ToResponseMarshaller[MatcherResponse]): Directive0 = {
+
+    def correctResponse(statusCode: StatusCode, matcherError: MatcherError): ToResponseMarshallable = this match {
+      case _: MatcherWebSocketRoute => matcherError.toWsHttpResponse(statusCode)
+      case _                        => SimpleErrorResponse(statusCode, matcherError)
+    }
+
     apiKeyHash.fold[Directive0] { complete(SimpleErrorResponse(StatusCodes.InternalServerError, ApiKeyIsNotProvided)) } { hashFromSettings =>
       optionalHeaderValueByType[`X-Api-Key`](()).flatMap {
         case Some(key) if java.util.Arrays.equals(crypto secureHash key.value, hashFromSettings) => pass
         case _ =>
           optionalHeaderValueByType[api_key](()).flatMap {
             case Some(key) if java.util.Arrays.equals(crypto secureHash key.value, hashFromSettings) => pass
-            case _                                                                                   => complete { SimpleErrorResponse(StatusCodes.Forbidden, ApiKeyIsNotValid) }
+            case _                                                                                   => complete { correctResponse(StatusCodes.Forbidden, ApiKeyIsNotValid) }
           }
       }
     }

--- a/dex/src/main/scala/com/wavesplatform/dex/api/websockets/headers/`X-Error-Code`.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/websockets/headers/`X-Error-Code`.scala
@@ -1,0 +1,16 @@
+package com.wavesplatform.dex.api.websockets.headers
+
+import akka.http.scaladsl.model.headers._
+
+import scala.util.Try
+
+object `X-Error-Code` extends ModeledCustomHeaderCompanion[`X-Error-Code`] {
+  override final val name: String                        = "X-Error-Code"
+  override def parse(value: String): Try[`X-Error-Code`] = Try(new `X-Error-Code`(value))
+}
+
+final class `X-Error-Code`(val value: String) extends ModeledCustomHeader[`X-Error-Code`] {
+  override def companion: `X-Error-Code`.type = `X-Error-Code`
+  override def renderInRequests: Boolean      = false
+  override def renderInResponses: Boolean     = true
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/api/websockets/headers/`X-Error-Message`.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/api/websockets/headers/`X-Error-Message`.scala
@@ -1,0 +1,16 @@
+package com.wavesplatform.dex.api.websockets.headers
+
+import akka.http.scaladsl.model.headers._
+
+import scala.util.Try
+
+object `X-Error-Message` extends ModeledCustomHeaderCompanion[`X-Error-Message`] {
+  override final val name: String                           = "X-Error-Message"
+  override def parse(value: String): Try[`X-Error-Message`] = Try(new `X-Error-Message`(value))
+}
+
+final class `X-Error-Message`(val value: String) extends ModeledCustomHeader[`X-Error-Message`] {
+  override def companion: `X-Error-Message`.type = `X-Error-Message`
+  override def renderInRequests: Boolean         = false
+  override def renderInResponses: Boolean        = true
+}


### PR DESCRIPTION
 * Connection to authenticated balance stream can be done via correct timestamp and signature or X-API-Key. X-API-Key has the highest priority, with correct signature and incorrect key stream connection won't be established
 * WS connection responses have X-Error-Message and X-Error-Code headers
 * withAuth creates simple response or response with aforementioned headers for different types of Routes
 * It-test added