### PR TITLE
DEX-677 Wrong order cancel

### DIFF
--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/CancelOrderTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/CancelOrderTestSuite.scala
@@ -242,7 +242,7 @@ class CancelOrderTestSuite extends MatcherSuiteBase {
   }
 
   "Auto cancel" - {
-    "wrong auto cancel when match on all coins" in {
+    "wrong cancel when match on all coins" in {
       val accounts       = (1 to 30).map(i => KeyPair(s"auto-cancel-$i".getBytes(StandardCharsets.UTF_8)))
       val oneOrderAmount = 10000
       val orderPrice     = 3000000000000L
@@ -296,6 +296,22 @@ class CancelOrderTestSuite extends MatcherSuiteBase {
             status shouldBe OrderStatus.Filled
           }
       }
+    }
+
+    "wrong cancel when executing a big order by small amount" in {
+      val trader = KeyPair(ByteStr("trader-auto-cancel-big-order".getBytes(StandardCharsets.UTF_8)))
+
+      val amount     = 835.85722414.waves
+      val matcherFee = 0.003.waves
+      broadcastAndAwait(mkTransfer(alice, trader, amount + matcherFee, Waves))
+
+      // Spending all assets
+      val counterOrder = mkOrder(trader, wavesUsdPair, OrderType.SELL, amount, 903200, matcherFee, version = 3)
+      placeAndAwaitAtDex(counterOrder)
+      dex1.api.place(mkOrder(alice, wavesUsdPair, OrderType.BUY, 0.0001.waves, 909700, matcherFee))
+
+      Thread.sleep(5000) // Is there a better way?
+      dex1.api.orderStatus(counterOrder).status shouldBe OrderStatus.PartiallyFilled
     }
   }
 

--- a/dex-it/src/test/scala/com/wavesplatform/it/sync/MultipleMatchersTestSuite.scala
+++ b/dex-it/src/test/scala/com/wavesplatform/it/sync/MultipleMatchersTestSuite.scala
@@ -5,7 +5,6 @@ import com.typesafe.config.{Config, ConfigFactory}
 import com.wavesplatform.dex.domain.account.KeyPair
 import com.wavesplatform.dex.domain.asset.Asset.Waves
 import com.wavesplatform.dex.domain.asset.AssetPair
-import com.wavesplatform.dex.domain.order.OrderType.BUY
 import com.wavesplatform.dex.domain.order.{Order, OrderType}
 import com.wavesplatform.dex.it.api.dex.DexApi
 import com.wavesplatform.dex.it.api.responses.dex.OrderStatus

--- a/dex/src/main/scala/com/wavesplatform/dex/AddressActor.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/AddressActor.scala
@@ -122,7 +122,8 @@ class AddressActor(owner: Address,
       val allActiveOrderIds = getActiveLimitOrders(None).map(_.order.id()).toSet
       val toCancelIds       = allActiveOrderIds.intersect(command.orderIds)
       val unknownIds        = command.orderIds -- allActiveOrderIds
-      log.debug(s"Got $command, to cancel: ${toCancelIds.mkString(", ")}, unknown ids: ${unknownIds.mkString(", ")}")
+      log.debug(s"Got $command, total orders: ${allActiveOrderIds.size}, to cancel (${toCancelIds.size}): ${toCancelIds
+        .mkString(", ")}, unknown ids (${unknownIds.size}): ${unknownIds.mkString(", ")}")
 
       val initResponse = unknownIds.map(id => id -> api.OrderCancelRejected(error.OrderNotFound(id))).toMap
       if (toCancelIds.isEmpty) sender ! api.BatchCancelCompleted(initResponse)

--- a/dex/src/main/scala/com/wavesplatform/dex/Matcher.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/Matcher.scala
@@ -30,10 +30,12 @@ import com.wavesplatform.dex.grpc.integration.dto.BriefAssetDescription
 import com.wavesplatform.dex.history.HistoryRouter
 import com.wavesplatform.dex.market.OrderBookActor.MarketStatus
 import com.wavesplatform.dex.market._
+import com.wavesplatform.dex.model.AcceptedOrder.partialFee
 import com.wavesplatform.dex.model._
 import com.wavesplatform.dex.queue._
-import com.wavesplatform.dex.settings.MatcherSettings
-import com.wavesplatform.dex.settings.OrderFeeSettings.{DynamicSettings, OrderFeeSettings}
+import com.wavesplatform.dex.settings.AssetType.AssetType
+import com.wavesplatform.dex.settings.OrderFeeSettings.{DynamicSettings, FixedSettings, OrderFeeSettings, PercentSettings}
+import com.wavesplatform.dex.settings.{AssetType, MatcherSettings}
 import com.wavesplatform.dex.time.NTP
 import com.wavesplatform.dex.util._
 import mouse.any.anySyntaxMouse
@@ -82,15 +84,12 @@ class Matcher(settings: MatcherSettings)(implicit val actorSystem: ActorSystem) 
 
   private lazy val assetsCache = AssetsStorage.cache { AssetsStorage.levelDB(db) }
 
-  private lazy val transactionCreator = {
-    new ExchangeTransactionCreator(
-      matcherKeyPair,
-      settings.exchangeTxBaseFee,
-      orderFeeSettingsCache.getSettingsForOffset(lastProcessedOffset),
-      hasMatcherAccountScript,
-      assetsCache.unsafeGetHasScript
-    )
-  }
+  private lazy val transactionCreator = new ExchangeTransactionCreator(
+    matcherKeyPair,
+    settings.exchangeTxBaseFee,
+    hasMatcherAccountScript,
+    assetsCache.unsafeGetHasScript
+  )
 
   private implicit val errorContext: ErrorFormatterContext = {
     case Asset.Waves        => 8
@@ -551,8 +550,57 @@ object Matcher extends ScorexLogging {
     getMakerTakerFee(ofsc getSettingsForOffset offset)(s, c)
   }
 
-  def getMakerTakerFee(ofs: => OrderFeeSettings)(s: AcceptedOrder, c: LimitOrder): (Long, Long) = ofs match {
-    case ds: DynamicSettings => multiplyFeeByDouble(c.matcherFee, ds.makerRatio) -> multiplyFeeByDouble(s.matcherFee, ds.takerRatio)
-    case _                   => c.matcherFee                                     -> s.matcherFee
+  def getMakerTakerFee(ofs: => OrderFeeSettings)(s: AcceptedOrder, c: LimitOrder): (Long, Long) = {
+    val executedPrice  = c.price
+    val executedAmount = AcceptedOrder.executedAmount(s, c)
+    val (buy, sell)    = Order.splitByType(s.order, c.order)
+
+    def getActualBuySellAmounts(assetType: AssetType, buyAmount: Long, buyPrice: Long, sellAmount: Long, sellPrice: Long): (Long, Long) = {
+
+      val (buyAmt, sellAmt) = assetType match {
+        case AssetType.AMOUNT    => buy.getReceiveAmount _ -> sell.getSpendAmount _
+        case AssetType.PRICE     => buy.getSpendAmount _   -> sell.getReceiveAmount _
+        case AssetType.RECEIVING => buy.getReceiveAmount _ -> sell.getReceiveAmount _
+        case AssetType.SPENDING  => buy.getSpendAmount _   -> sell.getSpendAmount _
+      }
+
+      buyAmt(buyAmount, buyPrice).explicitGet() -> sellAmt(sellAmount, sellPrice).explicitGet()
+    }
+
+    def isFirstMatch(ao: AcceptedOrder): Boolean = ao.amount == ao.order.amount
+
+    def absoluteFee(totalCounterFee: Long, totalSubmittedFee: Long): (Long, Long) = {
+      val counterExecutedFee   = partialFee(totalCounterFee, c.order.amount, executedAmount)
+      val submittedExecutedFee = partialFee(totalSubmittedFee, s.order.amount, executedAmount)
+
+      (
+        if (isFirstMatch(c) && c.order.version >= 3) counterExecutedFee max 1L else counterExecutedFee,
+        if (isFirstMatch(s) && s.order.version >= 3) submittedExecutedFee max 1L else submittedExecutedFee
+      )
+    }
+
+    ofs match {
+      case PercentSettings(assetType, _) =>
+        val (buyAmountExecuted, sellAmountExecuted) = getActualBuySellAmounts(assetType, executedAmount, executedPrice, executedAmount, executedPrice)
+        val (buyAmountTotal, sellAmountTotal)       = getActualBuySellAmounts(assetType, buy.amount, buy.price, sell.amount, sell.price)
+
+        val buyExecutedFee  = partialFee(buy.matcherFee, buyAmountTotal, buyAmountExecuted)
+        val sellExecutedFee = partialFee(sell.matcherFee, sellAmountTotal, sellAmountExecuted)
+
+        if (c.isBuyOrder) (buyExecutedFee, sellExecutedFee)
+        else (sellExecutedFee, buyExecutedFee)
+
+      case settings: DynamicSettings =>
+        absoluteFee(
+          totalCounterFee = multiplyFeeByDouble(c.matcherFee, settings.makerRatio),
+          totalSubmittedFee = multiplyFeeByDouble(s.matcherFee, settings.takerRatio)
+        )
+
+      case _: FixedSettings =>
+        absoluteFee(
+          totalCounterFee = c.matcherFee,
+          totalSubmittedFee = s.matcherFee
+        )
+    }
   }
 }

--- a/dex/src/main/scala/com/wavesplatform/dex/model/ExchangeTransactionCreator.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/ExchangeTransactionCreator.scala
@@ -6,75 +6,27 @@ import com.wavesplatform.dex.domain.asset.{Asset, AssetPair}
 import com.wavesplatform.dex.domain.error.ValidationError
 import com.wavesplatform.dex.domain.order.Order
 import com.wavesplatform.dex.domain.transaction.{ExchangeTransaction, ExchangeTransactionV2}
-import com.wavesplatform.dex.domain.utils.EitherExt2
 import com.wavesplatform.dex.model.Events.OrderExecuted
 import com.wavesplatform.dex.model.ExchangeTransactionCreator._
-import com.wavesplatform.dex.settings.AssetType
-import com.wavesplatform.dex.settings.AssetType.AssetType
-import com.wavesplatform.dex.settings.OrderFeeSettings.{OrderFeeSettings, PercentSettings}
 
 import scala.concurrent.ExecutionContext
 
 class ExchangeTransactionCreator(matcherPrivateKey: KeyPair,
                                  exchangeTxBaseFee: Long,
-                                 currentOrderFeeSettings: => OrderFeeSettings,
                                  hasMatcherAccountScript: Boolean,
                                  hasAssetScript: IssuedAsset => Boolean)(implicit ec: ExecutionContext) {
 
   def createTransaction(orderExecutedEvent: OrderExecuted): Either[ValidationError, ExchangeTransaction] = {
-
-    import orderExecutedEvent._
-
-    val price       = counter.price
+    import orderExecutedEvent.{counter, executedAmount, submitted, timestamp}
     val (buy, sell) = Order.splitByType(submitted.order, counter.order)
 
-    // Move this logic to order book
-    def calculateMatcherFee: (Long, Long) = {
-
-      import AcceptedOrder.partialFee
-
-      def isSubmitted[A](order: Order, s: A, c: A): A = if (order.orderType == submitted.order.orderType) s else c
-      def executedFee(order: Order): Long             = isSubmitted(order, submittedExecutedFee, counterExecutedFee)
-      def isFirstMatch(order: Order): Boolean         = isSubmitted(order, submitted.amount == submitted.order.amount, counter.amount == counter.order.amount)
-
-      def getActualBuySellAmounts(assetType: AssetType, buyAmount: Long, buyPrice: Long, sellAmount: Long, sellPrice: Long): (Long, Long) = {
-
-        val (buyAmt, sellAmt) = assetType match {
-          case AssetType.AMOUNT    => buy.getReceiveAmount _ -> sell.getSpendAmount _
-          case AssetType.PRICE     => buy.getSpendAmount _   -> sell.getReceiveAmount _
-          case AssetType.RECEIVING => buy.getReceiveAmount _ -> sell.getReceiveAmount _
-          case AssetType.SPENDING  => buy.getSpendAmount _   -> sell.getSpendAmount _
-        }
-
-        buyAmt(buyAmount, buyPrice).explicitGet() -> sellAmt(sellAmount, sellPrice).explicitGet()
-      }
-
-      currentOrderFeeSettings match {
-        case PercentSettings(assetType, _) =>
-          val (buyAmountExecuted, sellAmountExecuted) = getActualBuySellAmounts(assetType, executedAmount, price, executedAmount, price)
-          val (buyAmountTotal, sellAmountTotal)       = getActualBuySellAmounts(assetType, buy.amount, buy.price, sell.amount, sell.price)
-
-          (
-            partialFee(buy.matcherFee, buyAmountTotal, buyAmountExecuted) min buy.matcherFee,
-            partialFee(sell.matcherFee, sellAmountTotal, sellAmountExecuted) min sell.matcherFee
-          )
-
-        case _ =>
-          val (buyExecutedFee, sellExecutedFee)         = executedFee(buy)  -> executedFee(sell)
-          val (isFirstMatchForBuy, isFirstMatchForSell) = isFirstMatch(buy) -> isFirstMatch(sell)
-
-          (
-            if (isFirstMatchForBuy && buy.version >= 3) buyExecutedFee max 1L else buyExecutedFee,
-            if (isFirstMatchForSell && sell.version >= 3) sellExecutedFee max 1L else sellExecutedFee
-          )
-      }
-    }
-
-    val (buyFee, sellFee) = calculateMatcherFee
+    val (buyFee, sellFee) =
+      if (orderExecutedEvent.submitted.isBuyOrder) (orderExecutedEvent.submittedExecutedFee, orderExecutedEvent.counterExecutedFee)
+      else (orderExecutedEvent.counterExecutedFee, orderExecutedEvent.submittedExecutedFee)
 
     // matcher always pays fee to the miners in Waves
     val txFee = minFee(exchangeTxBaseFee, hasMatcherAccountScript, counter.order.assetPair, hasAssetScript)
-    ExchangeTransactionV2.create(matcherPrivateKey, buy, sell, executedAmount, price, buyFee, sellFee, txFee, timestamp)
+    ExchangeTransactionV2.create(matcherPrivateKey, buy, sell, executedAmount, orderExecutedEvent.executedPrice, buyFee, sellFee, txFee, timestamp)
   }
 }
 

--- a/dex/src/main/scala/com/wavesplatform/dex/model/ExchangeTransactionCreator.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/ExchangeTransactionCreator.scala
@@ -28,6 +28,7 @@ class ExchangeTransactionCreator(matcherPrivateKey: KeyPair,
     val price       = counter.price
     val (buy, sell) = Order.splitByType(submitted.order, counter.order)
 
+    // Move this logic to order book
     def calculateMatcherFee: (Long, Long) = {
 
       import AcceptedOrder.partialFee

--- a/dex/src/main/scala/com/wavesplatform/dex/model/Fee.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/Fee.scala
@@ -1,0 +1,68 @@
+package com.wavesplatform.dex.model
+
+import com.wavesplatform.dex.caches.OrderFeeSettingsCache
+import com.wavesplatform.dex.domain.order.Order
+import com.wavesplatform.dex.domain.utils.EitherExt2
+import com.wavesplatform.dex.model.AcceptedOrder.partialFee
+import com.wavesplatform.dex.model.OrderValidator.multiplyFeeByDouble
+import com.wavesplatform.dex.settings.AssetType
+import com.wavesplatform.dex.settings.AssetType.AssetType
+import com.wavesplatform.dex.settings.OrderFeeSettings.{DynamicSettings, FixedSettings, OrderFeeSettings, PercentSettings}
+
+object Fee {
+  def getMakerTakerFeeByOffset(ofsc: OrderFeeSettingsCache)(offset: Long)(s: AcceptedOrder, c: LimitOrder): (Long, Long) = {
+    getMakerTakerFee(ofsc getSettingsForOffset offset)(s, c)
+  }
+
+  def getMakerTakerFee(ofs: => OrderFeeSettings)(s: AcceptedOrder, c: LimitOrder): (Long, Long) = {
+    val executedPrice  = c.price
+    val executedAmount = AcceptedOrder.executedAmount(s, c)
+    val (buy, sell)    = Order.splitByType(s.order, c.order)
+
+    def getActualBuySellAmounts(assetType: AssetType, buyAmount: Long, buyPrice: Long, sellAmount: Long, sellPrice: Long): (Long, Long) = {
+
+      val (buyAmt, sellAmt) = assetType match {
+        case AssetType.AMOUNT    => buy.getReceiveAmount _ -> sell.getSpendAmount _
+        case AssetType.PRICE     => buy.getSpendAmount _   -> sell.getReceiveAmount _
+        case AssetType.RECEIVING => buy.getReceiveAmount _ -> sell.getReceiveAmount _
+        case AssetType.SPENDING  => buy.getSpendAmount _   -> sell.getSpendAmount _
+      }
+
+      buyAmt(buyAmount, buyPrice).explicitGet() -> sellAmt(sellAmount, sellPrice).explicitGet()
+    }
+
+    def absoluteFee(totalCounterFee: Long, totalSubmittedFee: Long): (Long, Long) = {
+      val counterExecutedFee   = partialFee(totalCounterFee, c.order.amount, executedAmount)
+      val submittedExecutedFee = partialFee(totalSubmittedFee, s.order.amount, executedAmount)
+
+      (
+        if (c.isFirstMatch && c.order.version >= 3) counterExecutedFee max 1L else counterExecutedFee,
+        if (s.isFirstMatch && s.order.version >= 3) submittedExecutedFee max 1L else submittedExecutedFee
+      )
+    }
+
+    ofs match {
+      case PercentSettings(assetType, _) =>
+        val (buyAmountExecuted, sellAmountExecuted) = getActualBuySellAmounts(assetType, executedAmount, executedPrice, executedAmount, executedPrice)
+        val (buyAmountTotal, sellAmountTotal)       = getActualBuySellAmounts(assetType, buy.amount, buy.price, sell.amount, sell.price)
+
+        val buyExecutedFee  = partialFee(buy.matcherFee, buyAmountTotal, buyAmountExecuted)
+        val sellExecutedFee = partialFee(sell.matcherFee, sellAmountTotal, sellAmountExecuted)
+
+        if (c.isBuyOrder) (buyExecutedFee, sellExecutedFee)
+        else (sellExecutedFee, buyExecutedFee)
+
+      case settings: DynamicSettings =>
+        absoluteFee(
+          totalCounterFee = multiplyFeeByDouble(c.matcherFee, settings.makerRatio),
+          totalSubmittedFee = multiplyFeeByDouble(s.matcherFee, settings.takerRatio)
+        )
+
+      case _: FixedSettings =>
+        absoluteFee(
+          totalCounterFee = c.matcherFee,
+          totalSubmittedFee = s.matcherFee
+        )
+    }
+  }
+}

--- a/dex/src/main/scala/com/wavesplatform/dex/model/Fee.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/Fee.scala
@@ -42,7 +42,7 @@ object Fee {
           buyAmt(buyAmount, buyPrice).explicitGet() -> sellAmt(sellAmount, sellPrice).explicitGet()
 
         val (buyAmountExecuted, sellAmountExecuted) = buySellFee(executedAmount, executedPrice, executedAmount, executedPrice)
-        val (buyAmountTotal, sellAmountTotal)       = buySellFee(buy.amount, buy.price, sell.amount, sell.price)
+        val (buyAmountTotal, sellAmountTotal)       = buySellFee(buy.amount, executedPrice, sell.amount, executedPrice)
 
         val buyExecutedFee  = partialFee(buy.matcherFee, buyAmountTotal, buyAmountExecuted)
         val sellExecutedFee = partialFee(sell.matcherFee, sellAmountTotal, sellAmountExecuted)

--- a/dex/src/main/scala/com/wavesplatform/dex/model/MatcherModel.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/MatcherModel.scala
@@ -314,7 +314,7 @@ object Events {
   /**
     * In case of dynamic fee settings the following params can be different from the appropriate `acceptedOrder.order.matcherFee`
     */
-  case class OrderExecuted(submitted: AcceptedOrder, counter: LimitOrder, timestamp: Price, counterExecutedFee: Price, submittedExecutedFee: Price)
+  case class OrderExecuted(submitted: AcceptedOrder, counter: LimitOrder, timestamp: Long, counterExecutedFee: Price, submittedExecutedFee: Price)
       extends Event {
 
     def executedPrice: Long                   = counter.price

--- a/dex/src/main/scala/com/wavesplatform/dex/model/MatcherModel.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/MatcherModel.scala
@@ -49,10 +49,7 @@ sealed trait AcceptedOrder {
 
   val matcherFee: Long = order.matcherFee
 
-  def requiredFee: Price = {
-    if (feeAsset == rcvAsset) (fee - receiveAmount).max(0L) else fee
-  }
-
+  def requiredFee: Price                = if (feeAsset == rcvAsset) (fee - receiveAmount).max(0L) else fee
   def requiredBalance: Map[Asset, Long] = Map(spentAsset -> rawSpentAmount) |+| Map(feeAsset -> requiredFee)
   def reservableBalance: Map[Asset, Long]
 
@@ -317,7 +314,7 @@ object Events {
   /**
     * In case of dynamic fee settings the following params can be different from the appropriate `acceptedOrder.order.matcherFee`
     */
-  case class OrderExecuted(submitted: AcceptedOrder, counter: LimitOrder, timestamp: Long, submittedExecutedFee: Long, counterExecutedFee: Long)
+  case class OrderExecuted(submitted: AcceptedOrder, counter: LimitOrder, timestamp: Price, counterExecutedFee: Price, submittedExecutedFee: Price)
       extends Event {
 
     def executedPrice: Long                   = counter.price

--- a/dex/src/main/scala/com/wavesplatform/dex/model/MatcherModel.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/MatcherModel.scala
@@ -80,6 +80,8 @@ sealed trait AcceptedOrder {
     case lo: LimitOrder  => fl(lo)
     case mo: MarketOrder => fm(mo)
   }
+
+  def isFirstMatch: Boolean = amount == order.amount
 }
 
 object AcceptedOrder {

--- a/dex/src/main/scala/com/wavesplatform/dex/model/MatcherModel.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/MatcherModel.scala
@@ -85,6 +85,8 @@ sealed trait AcceptedOrder {
 object AcceptedOrder {
 
   def partialFee(matcherFee: Long, totalAmount: Long, partialAmount: Long): Long = {
+    if (partialAmount > totalAmount)
+      throw new IllegalArgumentException(s"partialAmount: $partialAmount should be less or equal to totalAmount: $totalAmount")
     // Should not round! It could lead to forks. See ExchangeTransactionDiff
     (BigInt(matcherFee) * partialAmount / totalAmount).toLong
   }
@@ -311,33 +313,22 @@ object Events {
   sealed trait Event
 
   /**
-    *  In case of dynamic fee settings the following params can be different from the appropriate `acceptedOrder.order.matcherFee`
-    * @param maxSubmittedFee limited by base-taker-fee
-    * @param maxCounterFee limited by base-maker-fee
+    * In case of dynamic fee settings the following params can be different from the appropriate `acceptedOrder.order.matcherFee`
     */
-  case class OrderExecuted(submitted: AcceptedOrder, counter: LimitOrder, timestamp: Long, maxSubmittedFee: Long, maxCounterFee: Long) extends Event {
+  case class OrderExecuted(submitted: AcceptedOrder, counter: LimitOrder, timestamp: Long, submittedExecutedFee: Long, counterExecutedFee: Long)
+      extends Event {
 
+    def executedPrice: Long                   = counter.price
     lazy val executedAmount: Long             = AcceptedOrder.executedAmount(submitted, counter)
-    lazy val executedAmountOfPriceAsset: Long = MatcherModel.getCost(executedAmount, counter.price)
+    lazy val executedAmountOfPriceAsset: Long = MatcherModel.getCost(executedAmount, executedPrice)
 
     def counterRemainingAmount: Long = math.max(counter.amount - executedAmount, 0)
-    def counterExecutedFee: Long = {
-      val r = AcceptedOrder.partialFee(maxCounterFee, counter.order.amount, executedAmount)
-      if (r == 0 && counter.amount == 0 && counter.order.version == 3) 1
-      else r
-    }
-
     def counterRemainingFee: Long    = math.max(counter.fee - counterExecutedFee, 0)
     def counterRemaining: LimitOrder = counter.partial(amount = counterRemainingAmount, fee = counterRemainingFee)
 
-    def submittedRemainingAmount: Long = math.max(submitted.amount - executedAmount, 0)
-    def submittedExecutedFee: Long = {
-      val r = AcceptedOrder.partialFee(maxSubmittedFee, submitted.order.amount, executedAmount)
-      if (r == 0 && submitted.amount == 0 && submitted.order.version == 3) 1
-      else r
-    }
-
-    def submittedRemainingFee: Long = math.max(submitted.fee - submittedExecutedFee, 0)
+    def submittedRemainingAmount: Long    = math.max(submitted.amount - executedAmount, 0)
+    def submittedRemainingFee: Long       = math.max(submitted.fee - submittedExecutedFee, 0)
+    def submittedRemaining: AcceptedOrder = submitted.fold[AcceptedOrder] { submittedLimitRemaining } { submittedMarketRemaining }
 
     def submittedMarketRemaining(submittedMarketOrder: MarketOrder): MarketOrder = {
 
@@ -354,8 +345,6 @@ object Events {
     def submittedLimitRemaining(submittedLimitOrder: LimitOrder): LimitOrder = {
       submittedLimitOrder.partial(amount = submittedRemainingAmount, fee = submittedRemainingFee)
     }
-
-    def submittedRemaining: AcceptedOrder = submitted.fold[AcceptedOrder] { submittedLimitRemaining } { submittedMarketRemaining }
   }
 
   case class OrderAdded(order: LimitOrder, timestamp: Long) extends Event

--- a/dex/src/main/scala/com/wavesplatform/dex/model/OrderBook.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/OrderBook.scala
@@ -285,11 +285,11 @@ object OrderBook {
             )
 
           } else {
+            val (counterExecutedFee, submittedExecutedFee) = getMakerTakerFee(submitted, counter)
 
-            val (maxCounterFee, maxSubmittedFee) = getMakerTakerFee(submitted, counter)
-            val orderExecutedEvent               = OrderExecuted(submitted, counter, eventTs, maxSubmittedFee, maxCounterFee)
-            val newEvents                        = orderExecutedEvent +: prevEvents
-            val lt                               = Some(LastTrade(counter.price, orderExecutedEvent.executedAmount, submitted.order.orderType))
+            val orderExecutedEvent = OrderExecuted(submitted, counter, eventTs, submittedExecutedFee, counterExecutedFee)
+            val newEvents          = orderExecutedEvent +: prevEvents
+            val lt                 = Some(LastTrade(counter.price, orderExecutedEvent.executedAmount, submitted.order.orderType))
 
             if (orderExecutedEvent.counterRemaining.isValid) { // counter is not filled
 

--- a/dex/src/main/scala/com/wavesplatform/dex/model/OrderBook.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/OrderBook.scala
@@ -287,9 +287,9 @@ object OrderBook {
           } else {
             val (counterExecutedFee, submittedExecutedFee) = getMakerTakerFee(submitted, counter)
 
-            val orderExecutedEvent = OrderExecuted(submitted, counter, eventTs, submittedExecutedFee, counterExecutedFee)
+            val orderExecutedEvent = OrderExecuted(submitted, counter, eventTs, counterExecutedFee, submittedExecutedFee)
             val newEvents          = orderExecutedEvent +: prevEvents
-            val lt                 = Some(LastTrade(counter.price, orderExecutedEvent.executedAmount, submitted.order.orderType))
+            val lt                 = Some(LastTrade(orderExecutedEvent.executedPrice, orderExecutedEvent.executedAmount, submitted.order.orderType))
 
             if (orderExecutedEvent.counterRemaining.isValid) { // counter is not filled
 

--- a/dex/src/main/scala/com/wavesplatform/dex/model/OrderValidator.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/OrderValidator.scala
@@ -179,7 +179,7 @@ object OrderValidator extends ScorexLogging {
 
       lazy val exchangeTx: Result[ExchangeTransaction] = {
         val fakeOrder: Order  = order.updateType(order.orderType.opposite)
-        val oe: OrderExecuted = OrderExecuted(LimitOrder(fakeOrder), LimitOrder(order), time.correctedTime(), fakeOrder.matcherFee, order.matcherFee)
+        val oe: OrderExecuted = OrderExecuted(LimitOrder(fakeOrder), LimitOrder(order), time.correctedTime(), order.matcherFee, fakeOrder.matcherFee)
         transactionCreator(oe) leftMap (txValidationError => error.CanNotCreateExchangeTransaction(txValidationError.toString))
       }
 

--- a/dex/src/main/scala/com/wavesplatform/dex/model/OrderValidator.scala
+++ b/dex/src/main/scala/com/wavesplatform/dex/model/OrderValidator.scala
@@ -179,7 +179,7 @@ object OrderValidator extends ScorexLogging {
 
       lazy val exchangeTx: Result[ExchangeTransaction] = {
         val fakeOrder: Order  = order.updateType(order.orderType.opposite)
-        val oe: OrderExecuted = OrderExecuted(LimitOrder(fakeOrder), LimitOrder(order), time.correctedTime(), order.matcherFee, fakeOrder.matcherFee)
+        val oe: OrderExecuted = OrderExecuted(LimitOrder(fakeOrder), LimitOrder(order), time.correctedTime(), order.matcherFee, order.matcherFee)
         transactionCreator(oe) leftMap (txValidationError => error.CanNotCreateExchangeTransaction(txValidationError.toString))
       }
 

--- a/dex/src/test/scala/com/wavesplatform/dex/MatcherSpecBase.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/MatcherSpecBase.scala
@@ -432,7 +432,7 @@ trait MatcherSpecBase extends NTPTime with DiffMatcherWithImplicits with DoubleO
     val submittedExecutedFee = AcceptedOrder.partialFee(submittedLo.order.matcherFee, submittedLo.order.amount, executedAmount)
     val counterExecutedFee   = AcceptedOrder.partialFee(counterLo.order.matcherFee, counterLo.order.amount, executedAmount)
 
-    OrderExecuted(submittedLo, counterLo, timestamp, submittedExecutedFee, counterExecutedFee)
+    OrderExecuted(submittedLo, counterLo, timestamp, counterExecutedFee, submittedExecutedFee)
   }
 
   def makerTakerPartialFee(submitted: AcceptedOrder, counter: LimitOrder): (Long, Long) = {

--- a/dex/src/test/scala/com/wavesplatform/dex/MatcherSpecBase.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/MatcherSpecBase.scala
@@ -306,7 +306,7 @@ trait MatcherSpecBase extends NTPTime with DiffMatcherWithImplicits with DoubleO
     }
   }
 
-  protected val orderV3PairGenerator: Gen[((KeyPair, Order), (KeyPair, Order))] =
+  protected val orderV3MirrorPairGenerator: Gen[((KeyPair, Order), (KeyPair, Order))] =
     for {
       senderBuy: KeyPair   <- accountGen
       senderSell: KeyPair  <- accountGen

--- a/dex/src/test/scala/com/wavesplatform/dex/MatcherSpecBase.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/MatcherSpecBase.scala
@@ -418,28 +418,25 @@ trait MatcherSpecBase extends NTPTime with DiffMatcherWithImplicits with DoubleO
     Order.sign(correctedOrder, sender)
   }
 
-  def mkOrderExecutedRaw(submitted: Order, counter: Order): OrderExecuted =
+  protected def mkOrderExecutedRaw(submitted: Order, counter: Order): OrderExecuted =
     mkOrderExecuted(LimitOrder(submitted), LimitOrder(counter), submitted.timestamp)
 
-  def mkOrderExecutedRaw(submitted: Order, counter: Order, timestamp: Long): OrderExecuted =
+  protected def mkOrderExecutedRaw(submitted: Order, counter: Order, timestamp: Long): OrderExecuted =
     mkOrderExecuted(LimitOrder(submitted), LimitOrder(counter), timestamp)
 
-  def mkOrderExecuted(submittedLo: AcceptedOrder, counterLo: LimitOrder): OrderExecuted =
-    mkOrderExecuted(submittedLo, counterLo, submittedLo.order.timestamp)
+  protected def mkOrderExecuted(submittedAo: AcceptedOrder, counterLo: LimitOrder): OrderExecuted =
+    mkOrderExecuted(submittedAo, counterLo, submittedAo.order.timestamp)
 
-  def mkOrderExecuted(submittedLo: AcceptedOrder, counterLo: LimitOrder, timestamp: Long): OrderExecuted = {
-    val executedAmount       = AcceptedOrder.executedAmount(submittedLo, counterLo)
-    val submittedExecutedFee = AcceptedOrder.partialFee(submittedLo.order.matcherFee, submittedLo.order.amount, executedAmount)
-    val counterExecutedFee   = AcceptedOrder.partialFee(counterLo.order.matcherFee, counterLo.order.amount, executedAmount)
-
-    OrderExecuted(submittedLo, counterLo, timestamp, counterExecutedFee, submittedExecutedFee)
+  protected def mkOrderExecuted(submittedAo: AcceptedOrder, counterLo: LimitOrder, timestamp: Long): OrderExecuted = {
+    val (counterExecutedFee, submittedExecutedFee) = makerTakerPartialFee(submittedAo, counterLo)
+    OrderExecuted(submittedAo, counterLo, timestamp, counterExecutedFee, submittedExecutedFee)
   }
 
-  def makerTakerPartialFee(submitted: AcceptedOrder, counter: LimitOrder): (Long, Long) = {
-    val executedAmount = AcceptedOrder.executedAmount(submitted, counter)
+  protected def makerTakerPartialFee(submittedAo: AcceptedOrder, counterLo: LimitOrder): (Long, Long) = {
+    val executedAmount = AcceptedOrder.executedAmount(submittedAo, counterLo)
     (
-      AcceptedOrder.partialFee(counter.matcherFee, counter.order.amount, executedAmount),
-      AcceptedOrder.partialFee(submitted.matcherFee, submitted.order.amount, executedAmount)
+      AcceptedOrder.partialFee(counterLo.matcherFee, counterLo.order.amount, executedAmount),
+      AcceptedOrder.partialFee(submittedAo.matcherFee, submittedAo.order.amount, executedAmount)
     )
   }
 }

--- a/dex/src/test/scala/com/wavesplatform/dex/history/HistoryRouterSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/history/HistoryRouterSpecification.scala
@@ -76,7 +76,7 @@ class HistoryRouterSpecification
   def orderCancelled(submitted: AcceptedOrder): OrderCanceled = OrderCanceled(submitted, isSystemCancel = false, ntpTime.getTimestamp())
 
   def orderExecuted(submitted: AcceptedOrder, counter: LimitOrder): OrderExecuted = {
-    OrderExecuted(submitted, counter, ntpTime.getTimestamp(), submitted.matcherFee, counter.matcherFee)
+    OrderExecuted(submitted, counter, ntpTime.getTimestamp(), counter.matcherFee, submitted.matcherFee)
   }
 
   // don't need to use blockchain in order to find out asset decimals, therefore pair parameter isn't used

--- a/dex/src/test/scala/com/wavesplatform/dex/market/MatcherActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/market/MatcherActorSpecification.scala
@@ -14,7 +14,7 @@ import com.wavesplatform.dex.grpc.integration.dto.BriefAssetDescription
 import com.wavesplatform.dex.market.MatcherActor.{ForceStartOrderBook, GetMarkets, MarketData, SaveSnapshot}
 import com.wavesplatform.dex.market.MatcherActorSpecification.{DeletingActor, FailAtStartActor, NothingDoActor, RecoveringActor, _}
 import com.wavesplatform.dex.market.OrderBookActor.{OrderBookRecovered, OrderBookSnapshotUpdateCompleted}
-import com.wavesplatform.dex.model.{AcceptedOrder, Events, OrderBook}
+import com.wavesplatform.dex.model.{Events, OrderBook}
 import com.wavesplatform.dex.queue.{QueueEvent, QueueEventWithMeta}
 import com.wavesplatform.dex.settings.{DenormalizedMatchingRule, MatchingRule}
 import com.wavesplatform.dex.time.NTPTime
@@ -428,14 +428,7 @@ class MatcherActorSpecification
             NonEmptyList.one(DenormalizedMatchingRule(0, 0.00000001)),
             _ => {},
             _ => MatchingRule.DefaultRule,
-            _ =>
-              (t, m) => {
-                val executedAmount = AcceptedOrder.executedAmount(t, m)
-                (
-                  AcceptedOrder.partialFee(m.matcherFee, m.order.amount, executedAmount),
-                  AcceptedOrder.partialFee(t.matcherFee, t.order.amount, executedAmount)
-                )
-            }
+            _ => makerTakerPartialFee
         ),
         assetDescription
       )

--- a/dex/src/test/scala/com/wavesplatform/dex/market/OrderBookActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/market/OrderBookActorSpecification.scala
@@ -406,9 +406,11 @@ class OrderBookActorSpecification
         tp.expectMsg(OrderBookRecovered(pair, None))
         val now = System.currentTimeMillis()
 
-        val maker1 = sell(wavesUsdPair, 10.waves, 3.00, matcherFee = 0.003.waves.some, ts = now.some) // was placed when order-fee was DynamicSettings(0.003.waves, 0.003.waves)
+        // place when order fee settings is DynamicSettings(0.001.waves, 0.003.waves)
+        val maker1 = sell(wavesUsdPair, 10.waves, 3.00, matcherFee = 0.003.waves.some, ts = now.some)
         orderBook ! wrapLimitOrder(0, maker1)
 
+        // place when order fee settings is DynamicSettings(0.001.waves, 0.005.waves)
         val taker1 = buy(wavesUsdPair, 10.waves, 3.00, matcherFee = 0.005.waves.some, ts = now.some)
         orderBook ! wrapLimitOrder(1, taker1)
         tp.expectMsgType[OrderAdded]

--- a/dex/src/test/scala/com/wavesplatform/dex/market/OrderBookActorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/market/OrderBookActorSpecification.scala
@@ -5,7 +5,9 @@ import java.util.concurrent.ConcurrentHashMap
 import akka.actor.ActorRef
 import akka.testkit.{ImplicitSender, TestActorRef, TestProbe}
 import cats.data.NonEmptyList
+import cats.syntax.option._
 import com.wavesplatform.dex.MatcherSpecBase
+import com.wavesplatform.dex.caches.OrderFeeSettingsCache
 import com.wavesplatform.dex.db.OrderBookSnapshotDB
 import com.wavesplatform.dex.domain.asset.Asset.{IssuedAsset, Waves}
 import com.wavesplatform.dex.domain.asset.{Asset, AssetPair}
@@ -19,6 +21,7 @@ import com.wavesplatform.dex.market.OrderBookActor._
 import com.wavesplatform.dex.model.Events.{OrderAdded, OrderCanceled, OrderExecuted}
 import com.wavesplatform.dex.model._
 import com.wavesplatform.dex.queue.QueueEvent.Canceled
+import com.wavesplatform.dex.settings.OrderFeeSettings.DynamicSettings
 import com.wavesplatform.dex.settings.{DenormalizedMatchingRule, MatchingRule}
 import com.wavesplatform.dex.time.NTPTime
 import org.scalamock.scalatest.PathMockFactory
@@ -62,7 +65,8 @@ class OrderBookActorSpecification
     }
 
   private def obcTestWithPrepare(prepare: (OrderBookSnapshotDB, AssetPair) => Unit,
-                                 matchingRules: NonEmptyList[DenormalizedMatchingRule] = NonEmptyList.one(DenormalizedMatchingRule(0, 0.00000001)))(
+                                 matchingRules: NonEmptyList[DenormalizedMatchingRule] = NonEmptyList.one(DenormalizedMatchingRule(0, 0.00000001)),
+                                 makerTakerFeeAtOffset: Long => (AcceptedOrder, LimitOrder) => (Long, Long) = _ => makerTakerPartialFee)(
       f: (AssetPair, TestActorRef[OrderBookActor with RestartableActor], TestProbe) => Unit): Unit = {
 
     obc.clear()
@@ -86,7 +90,7 @@ class OrderBookActorSpecification
         matchingRules,
         _ => (),
         raw => MatchingRule(raw.startOffset, (raw.tickSize * BigDecimal(10).pow(8)).toLongExact),
-        _ => makerTakerPartialFee
+        makerTakerFeeAtOffset
       ) with RestartableActor)
 
     f(pair, orderBookActor, tp)
@@ -387,6 +391,31 @@ class OrderBookActorSpecification
         val bids = obc.get(pair).bids
         bids.size shouldBe 1
         bids.head.price shouldBe 0.000004 * Order.PriceConstant
+      }
+    }
+
+    "correctly apply new fees when rules are switched" in {
+      val makerTakerFeeAtOffset = Fee.getMakerTakerFeeByOffset(
+        new OrderFeeSettingsCache(
+          Map(
+            0L -> DynamicSettings(0.001.waves, 0.003.waves),
+            1L -> DynamicSettings(0.001.waves, 0.005.waves)
+          ))) _
+
+      obcTestWithPrepare(prepare = (_, _) => (), makerTakerFeeAtOffset = makerTakerFeeAtOffset) { (pair, orderBook, tp) =>
+        tp.expectMsg(OrderBookRecovered(pair, None))
+        val now = System.currentTimeMillis()
+
+        val maker1 = sell(wavesUsdPair, 10.waves, 3.00, matcherFee = 0.003.waves.some, ts = now.some) // was placed when order-fee was DynamicSettings(0.003.waves, 0.003.waves)
+        orderBook ! wrapLimitOrder(0, maker1)
+
+        val taker1 = buy(wavesUsdPair, 10.waves, 3.00, matcherFee = 0.005.waves.some, ts = now.some)
+        orderBook ! wrapLimitOrder(1, taker1)
+        tp.expectMsgType[OrderAdded]
+
+        val oe = tp.expectMsgType[OrderExecuted]
+        oe.counterExecutedFee shouldBe 0.0006.waves
+        oe.submittedExecutedFee shouldBe 0.005.waves
       }
     }
 

--- a/dex/src/test/scala/com/wavesplatform/dex/matching/ReservedBalanceSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/matching/ReservedBalanceSpecification.scala
@@ -93,9 +93,9 @@ class ReservedBalanceSpecification
 
   private val ignoreSpendableBalanceChanges: Subject[SpendableBalanceChanges, SpendableBalanceChanges] = Subject.empty[SpendableBalanceChanges]
 
-  private val pair: AssetPair      = AssetPair(mkAssetId("WAVES"), mkAssetId("USD"))
+  private val pair: AssetPair = AssetPair(mkAssetId("WAVES"), mkAssetId("USD"))
 
-  private def mkOrderHistory = new OrderHistoryStub(system, ntpTime, 100, 70)
+  private def mkOrderHistory       = new OrderHistoryStub(system, ntpTime, 100, 70)
   private var oh: OrderHistoryStub = mkOrderHistory
 
   private val addressDir = system.actorOf(
@@ -522,7 +522,7 @@ class ReservedBalanceSpecification
   }
 
   private def executeMarketOrder(addressDirWithOrderBookCache: ActorRef, marketOrder: MarketOrder, limitOrder: LimitOrder): OrderExecuted = {
-    val executionEvent = OrderExecuted(marketOrder, limitOrder, marketOrder.order.timestamp, marketOrder.matcherFee, limitOrder.matcherFee)
+    val executionEvent = mkOrderExecuted(marketOrder, limitOrder, marketOrder.order.timestamp)
 
     addressDirWithOrderBookCache ! OrderAdded(limitOrder, ntpTime.getTimestamp())
     addressDirWithOrderBookCache ! executionEvent

--- a/dex/src/test/scala/com/wavesplatform/dex/matching/ReservedBalanceSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/matching/ReservedBalanceSpecification.scala
@@ -142,7 +142,7 @@ class ReservedBalanceSpecification
     addressDir ! OrderAdded(LimitOrder(counter), ntpTime.getTimestamp())
 
     oh.process(OrderAdded(LimitOrder(counter), ntpTime.getTimestamp()))
-    val exec = OrderExecuted(LimitOrder(submitted), LimitOrder(counter), submitted.timestamp, submitted.matcherFee, counter.matcherFee)
+    val exec = OrderExecuted(LimitOrder(submitted), LimitOrder(counter), submitted.timestamp, counter.matcherFee, submitted.matcherFee)
     addressDir ! exec
     exec
   }

--- a/dex/src/test/scala/com/wavesplatform/dex/model/EventSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/EventSpecification.scala
@@ -4,7 +4,6 @@ import com.wavesplatform.dex.MatcherSpecBase
 import com.wavesplatform.dex.domain.account.KeyPair
 import com.wavesplatform.dex.domain.asset.Asset.Waves
 import com.wavesplatform.dex.domain.asset.AssetPair
-import com.wavesplatform.dex.model.Events.OrderExecuted
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -14,7 +13,7 @@ class EventSpecification extends AnyFreeSpec with Matchers with MatcherSpecBase 
     val pair      = AssetPair(Waves, mkAssetId("BTC"))
     val counter   = sell(pair, 840340L, 0.00000238, matcherFee = Some(300000L))
     val submitted = buy(pair, 425532L, 0.00000238, matcherFee = Some(300000L))
-    val exec      = OrderExecuted(LimitOrder(submitted), LimitOrder(counter), 0L, submitted.matcherFee, counter.matcherFee)
+    val exec      = mkOrderExecutedRaw(submitted, counter)
     exec.executedAmount shouldBe 420169L
     exec.counterRemainingAmount shouldBe 420171L
     exec.counterRemainingAmount shouldBe counter.amount - exec.executedAmount
@@ -32,7 +31,7 @@ class EventSpecification extends AnyFreeSpec with Matchers with MatcherSpecBase 
     val counter   = sell(pair, 100000000, 0.0008, matcherFee = Some(2000L))
     val submitted = buy(pair, 120000000, 0.00085, matcherFee = Some(1000L))
 
-    val exec = OrderExecuted(LimitOrder(submitted), LimitOrder(counter), 0L, submitted.matcherFee, counter.matcherFee)
+    val exec = mkOrderExecutedRaw(submitted, counter)
     exec.submittedRemainingAmount shouldBe 20000000L
     exec.submittedRemainingFee shouldBe 167L
   }
@@ -45,7 +44,7 @@ class EventSpecification extends AnyFreeSpec with Matchers with MatcherSpecBase 
     val bobPk     = KeyPair("bob".getBytes("utf-8"))
     val submitted = sell(pair, 223345000L, 0.00031887, matcherFee = Some(300000), sender = Some(bobPk))
 
-    val exec = OrderExecuted(LimitOrder(submitted), LimitOrder(counter), 0L, submitted.matcherFee, counter.matcherFee)
+    val exec = mkOrderExecutedRaw(submitted, counter)
     exec.executedAmount shouldBe 223344937L
   }
 }

--- a/dex/src/test/scala/com/wavesplatform/dex/model/ExchangeTransactionCreatorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/ExchangeTransactionCreatorSpecification.scala
@@ -6,11 +6,8 @@ import com.wavesplatform.dex.domain.crypto
 import com.wavesplatform.dex.domain.crypto.Proofs
 import com.wavesplatform.dex.domain.order.Order
 import com.wavesplatform.dex.domain.order.OrderOps._
-import com.wavesplatform.dex.domain.order.OrderType.{BUY, SELL}
 import com.wavesplatform.dex.domain.transaction.ExchangeTransactionV2
 import com.wavesplatform.dex.domain.utils.EitherExt2
-import com.wavesplatform.dex.model.Events.OrderExecuted
-import com.wavesplatform.dex.settings.OrderFeeSettings.DynamicSettings
 import com.wavesplatform.dex.{MatcherSpecBase, NoShrink}
 import org.scalacheck.Gen
 import org.scalamock.scalatest.PathMockFactory
@@ -80,24 +77,6 @@ class ExchangeTransactionCreatorSpecification
           tx.buyMatcherFee shouldBe oe.submittedExecutedFee
           tx.sellMatcherFee shouldBe oe.counterExecutedFee
       }
-    }
-
-    // TODO: to AddressActor
-    "create transactions with correct buy/sell matcher fees when order fee settings changes" in {
-
-      val maker = LimitOrder(createOrder(wavesUsdPair, SELL, 10.waves, 3.00, 0.003.waves)) // was placed when order-fee was DynamicSettings(0.003.waves, 0.003.waves)
-      val taker = LimitOrder(createOrder(wavesUsdPair, BUY, 10.waves, 3.00, 0.005.waves))
-
-      val ofs      = DynamicSettings(0.001.waves, 0.005.waves)
-      val tc       = getExchangeTransactionCreator()
-      val (mf, tf) = Fee.getMakerTakerFee(ofs)(taker, maker)
-      val oe       = OrderExecuted(taker, maker, System.currentTimeMillis(), tf, mf)
-
-      val tx = tc.createTransaction(oe)
-
-      tx shouldBe 'right
-      tx.explicitGet().sellMatcherFee shouldBe 0.0006.waves
-      tx.explicitGet().buyMatcherFee shouldBe 0.005.waves
     }
   }
 }

--- a/dex/src/test/scala/com/wavesplatform/dex/model/ExchangeTransactionCreatorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/ExchangeTransactionCreatorSpecification.scala
@@ -11,7 +11,7 @@ import com.wavesplatform.dex.domain.order.OrderType.{BUY, SELL}
 import com.wavesplatform.dex.domain.transaction.ExchangeTransactionV2
 import com.wavesplatform.dex.domain.utils.EitherExt2
 import com.wavesplatform.dex.model.Events.OrderExecuted
-import com.wavesplatform.dex.settings.OrderFeeSettings.{DynamicSettings, OrderFeeSettings}
+import com.wavesplatform.dex.settings.OrderFeeSettings.DynamicSettings
 import com.wavesplatform.dex.{Matcher, MatcherSpecBase, NoShrink}
 import org.scalamock.scalatest.PathMockFactory
 import org.scalatest.BeforeAndAfterAll
@@ -32,11 +32,9 @@ class ExchangeTransactionCreatorSpecification
     with NoShrink
     with TableDrivenPropertyChecks {
 
-  private def getExchangeTransactionCreator(
-      hasMatcherScript: Boolean = false,
-      hasAssetScripts: Asset => Boolean = _ => false,
-      orderFeeSettings: OrderFeeSettings = DynamicSettings.symmetric(matcherFee)): ExchangeTransactionCreator = {
-    new ExchangeTransactionCreator(MatcherAccount, matcherSettings.exchangeTxBaseFee, orderFeeSettings, hasMatcherScript, hasAssetScripts)
+  private def getExchangeTransactionCreator(hasMatcherScript: Boolean = false,
+                                            hasAssetScripts: Asset => Boolean = _ => false): ExchangeTransactionCreator = {
+    new ExchangeTransactionCreator(MatcherAccount, matcherSettings.exchangeTxBaseFee, hasMatcherScript, hasAssetScripts)
   }
 
   "ExchangeTransactionCreator" should {
@@ -179,7 +177,7 @@ class ExchangeTransactionCreatorSpecification
       val taker = LimitOrder(createOrder(wavesUsdPair, BUY, 10.waves, 3.00, 0.005.waves))
 
       val ofs      = DynamicSettings(0.001.waves, 0.005.waves)
-      val tc       = getExchangeTransactionCreator(orderFeeSettings = ofs)
+      val tc       = getExchangeTransactionCreator()
       val (mf, tf) = Matcher.getMakerTakerFee(ofs)(taker, maker)
       val oe       = OrderExecuted(taker, maker, System.currentTimeMillis(), tf, mf)
 
@@ -196,7 +194,7 @@ class ExchangeTransactionCreatorSpecification
         val submitted = LimitOrder(createOrder(wavesUsdPair, SELL, amount = 50000000L, price = 932500L, matcherFee = 300000L, version = 3.toByte))
 
         val feeSettings          = DynamicSettings.symmetric(300000L)
-        val transactionCreator   = getExchangeTransactionCreator(orderFeeSettings = feeSettings)
+        val transactionCreator   = getExchangeTransactionCreator()
         val (makerFee, takerFee) = Matcher.getMakerTakerFee(feeSettings)(submitted, counter)
         val oe                   = OrderExecuted(submitted, counter, System.currentTimeMillis(), takerFee, makerFee)
 

--- a/dex/src/test/scala/com/wavesplatform/dex/model/ExchangeTransactionCreatorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/ExchangeTransactionCreatorSpecification.scala
@@ -46,7 +46,7 @@ class ExchangeTransactionCreatorSpecification
             val submitted = sell(wavesBtcPair, 100000, 0.0007, matcherFee = Some(1000L), version = submittedVersion.toByte)
 
             val tc = getExchangeTransactionCreator()
-            val oe = OrderExecuted(LimitOrder(submitted), LimitOrder(counter), System.currentTimeMillis, submitted.matcherFee, counter.matcherFee)
+            val oe = mkOrderExecutedRaw(submitted, counter)
 
             tc.createTransaction(oe).explicitGet() shouldBe a[ExchangeTransactionV2]
           }
@@ -61,7 +61,7 @@ class ExchangeTransactionCreatorSpecification
       forAll(preconditions) {
         case (buyOrder, sellOrder) =>
           val tc = getExchangeTransactionCreator()
-          val oe = OrderExecuted(LimitOrder(buyOrder), LimitOrder(sellOrder), System.currentTimeMillis, buyOrder.matcherFee, sellOrder.matcherFee)
+          val oe = mkOrderExecutedRaw(buyOrder, sellOrder)
           val tx = tc.createTransaction(oe).explicitGet()
 
           tx.buyMatcherFee shouldBe buyOrder.matcherFee
@@ -82,7 +82,7 @@ class ExchangeTransactionCreatorSpecification
       forAll(preconditions) {
         case (buyOrder, sellOrder) =>
           val tc = getExchangeTransactionCreator()
-          val oe = OrderExecuted(LimitOrder(buyOrder), LimitOrder(sellOrder), System.currentTimeMillis, buyOrder.matcherFee, sellOrder.matcherFee)
+          val oe = mkOrderExecutedRaw(buyOrder, sellOrder)
           val tx = tc.createTransaction(oe)
 
           tx shouldBe 'right
@@ -123,7 +123,7 @@ class ExchangeTransactionCreatorSpecification
             .zipWithIndex
             .foldLeft[AcceptedOrder](submittedOrder) {
               case (submitted, ((counter, expectedMatcherFee), i)) =>
-                val oe            = OrderExecuted(submitted, counter, System.currentTimeMillis, submitted.matcherFee, counter.matcherFee)
+                val oe            = mkOrderExecuted(submitted, counter)
                 val tx            = tc.createTransaction(oe).explicitGet()
                 val counterAmount = Denormalization.denormalizeAmountAndFee(counter.order.amount, 8)
 

--- a/dex/src/test/scala/com/wavesplatform/dex/model/ExchangeTransactionCreatorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/ExchangeTransactionCreatorSpecification.scala
@@ -12,7 +12,7 @@ import com.wavesplatform.dex.domain.transaction.ExchangeTransactionV2
 import com.wavesplatform.dex.domain.utils.EitherExt2
 import com.wavesplatform.dex.model.Events.OrderExecuted
 import com.wavesplatform.dex.settings.OrderFeeSettings.DynamicSettings
-import com.wavesplatform.dex.{Matcher, MatcherSpecBase, NoShrink}
+import com.wavesplatform.dex.{MatcherSpecBase, NoShrink}
 import org.scalamock.scalatest.PathMockFactory
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
@@ -148,7 +148,7 @@ class ExchangeTransactionCreatorSpecification
         *
         * But only for orders with version >= 3, because there is a proportional checks of spent fee for older versions.
         */
-      (1 to 2).foreach { v =>
+      (1 to 3).foreach { v =>
         s"submitted order version is $v" when {
           test(BUY, 100.waves, submittedFee = 1, orderVersion = v)(100.waves)(1)
           test(BUY, 100.waves, submittedFee = 1, orderVersion = v)(99.99999999.waves)(0)
@@ -159,16 +159,16 @@ class ExchangeTransactionCreatorSpecification
         }
       }
 
-      (3 to 3).foreach { v =>
-        s"submitted order version is $v" when {
-          test(BUY, 100.waves, submittedFee = 1, orderVersion = v)(100.waves)(1)
-          test(BUY, 100.waves, submittedFee = 1, orderVersion = v)(99.99999999.waves)(1)
-          test(BUY, 100.waves, submittedFee = 1, orderVersion = v)(50.waves, 50.waves)(1, 0)
-          test(BUY, 100.waves, submittedFee = 1, orderVersion = v)(1.waves, 120.waves)(1, 0)
-          test(SELL, 100.waves, submittedFee = 5, orderVersion = v)(2.waves, 500.waves)(1, 4)
-          test(SELL, 100.waves, submittedFee = 5, orderVersion = v)(2.waves, 50.waves)(1, 2)
-        }
-      }
+//      (3 to 3).foreach { v =>
+//        s"submitted order version is $v" when {
+//          test(BUY, 100.waves, submittedFee = 1, orderVersion = v)(100.waves)(1)
+//          test(BUY, 100.waves, submittedFee = 1, orderVersion = v)(99.99999999.waves)(1)
+//          test(BUY, 100.waves, submittedFee = 1, orderVersion = v)(50.waves, 50.waves)(1, 0)
+//          test(BUY, 100.waves, submittedFee = 1, orderVersion = v)(1.waves, 120.waves)(1, 0)
+//          test(SELL, 100.waves, submittedFee = 5, orderVersion = v)(2.waves, 500.waves)(1, 4)
+//          test(SELL, 100.waves, submittedFee = 5, orderVersion = v)(2.waves, 50.waves)(1, 2)
+//        }
+//      }
     }
 
     "create transactions with correct buy/sell matcher fees when order fee settings changes" in {
@@ -178,7 +178,7 @@ class ExchangeTransactionCreatorSpecification
 
       val ofs      = DynamicSettings(0.001.waves, 0.005.waves)
       val tc       = getExchangeTransactionCreator()
-      val (mf, tf) = Matcher.getMakerTakerFee(ofs)(taker, maker)
+      val (mf, tf) = Fee.getMakerTakerFee(ofs)(taker, maker)
       val oe       = OrderExecuted(taker, maker, System.currentTimeMillis(), tf, mf)
 
       val tx = tc.createTransaction(oe)
@@ -195,7 +195,7 @@ class ExchangeTransactionCreatorSpecification
 
         val feeSettings          = DynamicSettings.symmetric(300000L)
         val transactionCreator   = getExchangeTransactionCreator()
-        val (makerFee, takerFee) = Matcher.getMakerTakerFee(feeSettings)(submitted, counter)
+        val (makerFee, takerFee) = Fee.getMakerTakerFee(feeSettings)(submitted, counter)
         val oe                   = OrderExecuted(submitted, counter, System.currentTimeMillis(), takerFee, makerFee)
 
         val tx = transactionCreator.createTransaction(oe)

--- a/dex/src/test/scala/com/wavesplatform/dex/model/FeeSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/FeeSpecification.scala
@@ -1,0 +1,124 @@
+package com.wavesplatform.dex.model
+
+import com.wavesplatform.dex.domain.model.Denormalization
+import com.wavesplatform.dex.domain.order.OrderType
+import com.wavesplatform.dex.domain.order.OrderType.{BUY, SELL}
+import com.wavesplatform.dex.model.Events.OrderExecuted
+import com.wavesplatform.dex.settings.OrderFeeSettings
+import com.wavesplatform.dex.settings.OrderFeeSettings.DynamicSettings
+import com.wavesplatform.dex.{MatcherSpecBase, NoShrink}
+import org.scalamock.scalatest.PathMockFactory
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.scalacheck.{ScalaCheckPropertyChecks => PropertyChecks}
+
+class FeeSpecification
+    extends AnyWordSpec
+    with Matchers
+    with MatcherSpecBase
+    with BeforeAndAfterAll
+    with PathMockFactory
+    with PropertyChecks
+    with NoShrink {
+
+  "Fee.getMakerTakerFee" should {
+    "create transactions with correct buyMatcherFee/sellMatcherFee for expensive feeAsset" when {
+
+      def test(submittedType: OrderType, submittedAmount: Long, submittedFee: Long, orderVersion: Int)(countersAmounts: Long*)(
+          expectedSubmittedMatcherFees: Long*): Unit = {
+
+        require(countersAmounts.length == expectedSubmittedMatcherFees.length)
+
+        val submittedOrder = LimitOrder(
+          createOrder(
+            wavesBtcPair,
+            submittedType,
+            submittedAmount,
+            0.00011131,
+            matcherFee = submittedFee,
+            feeAsset = mkAssetId("Very expensive asset"),
+            version = orderVersion.toByte
+          )
+        )
+
+        val counterOrders = countersAmounts.map { amount =>
+          LimitOrder(createOrder(wavesBtcPair, submittedType.opposite, amount, 0.00011131))
+        }
+
+        val submittedDenormalizedAmount = Denormalization.denormalizeAmountAndFee(submittedOrder.amount, 8)
+        val denormalizedCounterAmounts  = countersAmounts.map(Denormalization.denormalizeAmountAndFee(_, 8))
+
+        // taker / maker -> maker / taker
+        val getFee = Fee.getMakerTakerFee(OrderFeeSettings.DynamicSettings(0.003.waves, 0.006.waves)) _
+
+        s"S: $submittedType $submittedDenormalizedAmount, C: ${denormalizedCounterAmounts.mkString("[", ", ", "]")}" in {
+          counterOrders
+            .zip(expectedSubmittedMatcherFees)
+            .zipWithIndex
+            .foldLeft[AcceptedOrder](submittedOrder) {
+              case (submitted, ((counter, expectedMatcherFee), i)) =>
+                val (makerFee, takerFee) = getFee(submitted, counter)
+                val (buyMatcherFee, sellMatcherFee) =
+                  if (counter.isBuyOrder) (makerFee, takerFee)
+                  else (takerFee, makerFee)
+
+                val counterAmount = Denormalization.denormalizeAmountAndFee(counter.order.amount, 8)
+                withClue(s"C($i): ${counter.order.orderType} $counterAmount:\n") {
+                  if (submittedType == BUY) buyMatcherFee shouldBe expectedMatcherFee
+                  else sellMatcherFee shouldBe expectedMatcherFee
+                }
+
+                OrderExecuted(submitted, counter, submitted.order.timestamp, takerFee, makerFee).submittedRemaining
+            }
+        }
+      }
+
+      /**
+        * Consider the situation, when matcherFeeAsset is very expensive, that is 1 the smallest part of it
+        * (like 1 satoshi for BTC) costs at least 0.003 Waves. This means that 1 fraction of this asset
+        * is enough to meet matcher's fee requirements (DynamicSettings mode, base fee = 0.003 Waves)
+        *
+        * In case of partial filling of the submitted order (with fee = 1 fraction of the expensive asset)
+        * Fee.getMakerTakerFee has to correctly calculate buyMatcherFee/sellMatcherFee. They should have non-zero values
+        * after the first execution.
+        *
+        * But only for orders with version >= 3, because there is a proportional checks of spent fee for older versions.
+        */
+      (1 to 2).foreach { v =>
+        s"submitted order version is $v" when {
+          test(BUY, 100.waves, submittedFee = 1, orderVersion = v)(100.waves)(1)
+          test(BUY, 100.waves, submittedFee = 1, orderVersion = v)(99.99999999.waves)(0)
+          test(BUY, 100.waves, submittedFee = 1, orderVersion = v)(50.waves, 50.waves)(0, 0)
+          test(BUY, 100.waves, submittedFee = 1, orderVersion = v)(1.waves, 120.waves)(0, 0)
+          test(SELL, 100.waves, submittedFee = 5, orderVersion = v)(2.waves, 500.waves)(0, 4)
+          test(SELL, 100.waves, submittedFee = 5, orderVersion = v)(2.waves, 50.waves)(0, 2)
+        }
+      }
+
+      (3 to 3).foreach { v =>
+        s"submitted order version is $v" when {
+          test(BUY, 100.waves, submittedFee = 1, orderVersion = v)(100.waves)(1)
+          test(BUY, 100.waves, submittedFee = 1, orderVersion = v)(99.99999999.waves)(1)
+          test(BUY, 100.waves, submittedFee = 1, orderVersion = v)(50.waves, 50.waves)(1, 0)
+          test(BUY, 100.waves, submittedFee = 1, orderVersion = v)(1.waves, 120.waves)(1, 0)
+          test(SELL, 100.waves, submittedFee = 5, orderVersion = v)(2.waves, 500.waves)(1, 4)
+          test(SELL, 100.waves, submittedFee = 5, orderVersion = v)(2.waves, 50.waves)(1, 2)
+        }
+      }
+    }
+
+    "create transactions with correct buy/sell matcher fees for submitted order v3 " when List(1, 2).foreach { counterVersion =>
+      s"counter order v$counterVersion" in {
+        val counter   = LimitOrder(createOrder(wavesUsdPair, BUY, amount = 88947718687647L, price = 934300L, matcherFee = 300000L, version = 2.toByte))
+        val submitted = LimitOrder(createOrder(wavesUsdPair, SELL, amount = 50000000L, price = 932500L, matcherFee = 300000L, version = 3.toByte))
+
+        val feeSettings          = DynamicSettings.symmetric(300000L)
+        val (makerFee, takerFee) = Fee.getMakerTakerFee(feeSettings)(submitted, counter)
+
+        takerFee shouldBe 0.003.waves
+        makerFee shouldBe 0L
+      }
+    }
+  }
+}

--- a/dex/src/test/scala/com/wavesplatform/dex/model/FeeSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/FeeSpecification.scala
@@ -22,8 +22,8 @@ class FeeSpecification
     with PropertyChecks
     with NoShrink {
 
-  "Fee.getMakerTakerFee" should {
-    "create transactions with correct buyMatcherFee/sellMatcherFee for expensive feeAsset" when {
+  "Fee.getMakerTakerFee should calculate correct buy/sell matcher fees" when {
+    "expensive feeAsset" when {
 
       def test(submittedType: OrderType, submittedAmount: Long, submittedFee: Long, orderVersion: Int)(countersAmounts: Long*)(
           expectedSubmittedMatcherFees: Long*): Unit = {
@@ -69,7 +69,7 @@ class FeeSpecification
                   else sellMatcherFee shouldBe expectedMatcherFee
                 }
 
-                OrderExecuted(submitted, counter, submitted.order.timestamp, takerFee, makerFee).submittedRemaining
+                OrderExecuted(submitted, counter, submitted.order.timestamp, makerFee, takerFee).submittedRemaining
             }
         }
       }
@@ -108,7 +108,7 @@ class FeeSpecification
       }
     }
 
-    "create transactions with correct buy/sell matcher fees for submitted order v3 " when List(1, 2).foreach { counterVersion =>
+    "submitted order v3 " when List(1, 2).foreach { counterVersion =>
       s"counter order v$counterVersion" in {
         val counter   = LimitOrder(createOrder(wavesUsdPair, BUY, amount = 88947718687647L, price = 934300L, matcherFee = 300000L, version = 2.toByte))
         val submitted = LimitOrder(createOrder(wavesUsdPair, SELL, amount = 50000000L, price = 932500L, matcherFee = 300000L, version = 3.toByte))

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderBookSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderBookSpec.scala
@@ -13,7 +13,7 @@ import com.wavesplatform.dex.model.OrderBook.{LastTrade, Level, SideSnapshot, Sn
 import com.wavesplatform.dex.settings.MatchingRule
 import com.wavesplatform.dex.settings.OrderFeeSettings.{DynamicSettings, OrderFeeSettings}
 import com.wavesplatform.dex.time.NTPTime
-import com.wavesplatform.dex.{Matcher, MatcherSpecBase, NoShrink}
+import com.wavesplatform.dex.{MatcherSpecBase, NoShrink}
 import org.scalacheck.Gen
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
@@ -458,7 +458,7 @@ class OrderBookSpec
 
       val maker = limit(mAmt, SELL, orderMFee)
       val taker = if (isTMarket) market(tAmt, BUY, normalizedOrderTFee, tFeeAsset) else limit(tAmt, BUY, normalizedOrderTFee, tFeeAsset)
-      val gmtf  = Matcher.getMakerTakerFee(ofs)(_, _)
+      val gmtf  = Fee.getMakerTakerFee(ofs)(_, _)
       val evt   = { ob.add(maker, System.currentTimeMillis, gmtf); ob.add(taker, System.currentTimeMillis, gmtf) }.head
 
       evt shouldBe a[OrderExecuted]

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderBookSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderBookSpec.scala
@@ -161,7 +161,7 @@ class OrderBookSpec
     withClue("matchable orders should be matched without tick size:\n") {
       ob.append(counterSellOrder, counterOrderTime) shouldBe Seq(OrderAdded(counterSellOrder, counterOrderTime))
       ob.append(submittedBuyOrder, submittedOrderTime) shouldBe Seq(
-        OrderExecuted(submittedBuyOrder, counterSellOrder, submittedOrderTime, submittedBuyOrder.matcherFee, counterSellOrder.matcherFee)
+        OrderExecuted(submittedBuyOrder, counterSellOrder, submittedOrderTime, counterSellOrder.matcherFee, submittedBuyOrder.matcherFee)
       )
 
       ob.getAsks shouldBe empty
@@ -198,7 +198,7 @@ class OrderBookSpec
 
       ob.append(counter, counterTs) shouldBe Seq(OrderAdded(counter, counterTs))
       ob.append(submitted, submittedTs, tickSize = normalizedTickSize(0.1)) shouldBe Seq(
-        OrderExecuted(submitted, counter, submittedTs, submitted.matcherFee, counter.matcherFee)
+        OrderExecuted(submitted, counter, submittedTs, counter.matcherFee, submitted.matcherFee)
       )
 
       ob.getAsks shouldBe empty

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderBookSpec.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderBookSpec.scala
@@ -33,7 +33,7 @@ class OrderBookSpec
 
   implicit class OrderBookOps(ob: OrderBook) {
     def append(ao: AcceptedOrder, ts: Long, tickSize: Long = MatchingRule.DefaultRule.tickSize): Seq[Event] =
-      ob.add(ao, ts, (t, m) => m.matcherFee -> t.matcherFee, tickSize)
+      ob.add(ao, ts, makerTakerPartialFee, tickSize)
   }
 
   val pair: AssetPair = AssetPair(Waves, mkAssetId("BTC"))
@@ -284,12 +284,13 @@ class OrderBookSpec
 
     val restAmount = ord1.amount + ord2.amount + ord3.amount - ord4.amount
 
-    ob.allOrders.map(_._2) shouldEqual Seq(
-      SellLimitOrder(
-        restAmount,
-        ord3.matcherFee - AcceptedOrder.partialFee(ord3.matcherFee, ord3.amount, ord3.amount - restAmount),
-        ord3
-      ))
+    ob.allOrders.map(_._2).toList should matchTo(
+      List[LimitOrder](
+        SellLimitOrder(
+          restAmount,
+          ord3.matcherFee - AcceptedOrder.partialFee(ord3.matcherFee, ord3.amount, ord3.amount - restAmount),
+          ord3
+        )))
   }
 
   "partially execute order with small remaining part" in {

--- a/dex/src/test/scala/com/wavesplatform/dex/model/OrderValidatorSpecification.scala
+++ b/dex/src/test/scala/com/wavesplatform/dex/model/OrderValidatorSpecification.scala
@@ -939,13 +939,8 @@ class OrderValidatorSpecification
 
   private def exchangeTransactionCreator(blockchain: AsyncBlockchain,
                                          hasMatcherAccountScript: Boolean = false,
-                                         hasAssetScript: Asset => Boolean = getDefaultAssetDescriptions(_).hasScript) = {
-    new ExchangeTransactionCreator(MatcherAccount,
-                                   matcherSettings.exchangeTxBaseFee,
-                                   DynamicSettings.symmetric(matcherFee),
-                                   hasMatcherAccountScript,
-                                   hasAssetScript)
-  }
+                                         hasAssetScript: Asset => Boolean = getDefaultAssetDescriptions(_).hasScript) =
+    new ExchangeTransactionCreator(MatcherAccount, matcherSettings.exchangeTxBaseFee, hasMatcherAccountScript, hasAssetScript)
 
   private def asa[A](
       p: Portfolio = defaultPortfolio,
@@ -966,7 +961,12 @@ class OrderValidatorSpecification
   }
 
   private def msa(ba: Set[Address], o: Order): Order => Result[Order] = {
-    OrderValidator.matcherSettingsAware(o.matcherPublicKey, ba, matcherSettings, getDefaultAssetDescriptions(_).decimals, rateCache, DynamicSettings.symmetric(matcherFee))
+    OrderValidator.matcherSettingsAware(o.matcherPublicKey,
+                                        ba,
+                                        matcherSettings,
+                                        getDefaultAssetDescriptions(_).decimals,
+                                        rateCache,
+                                        DynamicSettings.symmetric(matcherFee))
   }
 
   private def validateByMatcherSettings(orderFeeSettings: OrderFeeSettings,


### PR DESCRIPTION
Fee: an object with functions to calculate fees;
OrderExecuted: counterExecutedFee and submittedRemainingFee now are static and not calculated;
ExchangeTransactionCreator now uses calculated fees from the OrderExecuted event;

CancelOrderTestSuite:
* A new integration test to check this bug;
* Test stabilization;

ExchangeTransactionCreatorSpecification: some tests migrated to FeeSpecification and OrderBookActorSpecification;